### PR TITLE
Replace emoji with Heroicons SVG on feature cards

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,30 @@
+# Third-Party Notices
+
+## Heroicons
+
+The inline SVG icons used in `docs/index.html` are from
+[Heroicons](https://heroicons.com) by Tailwind Labs, Inc.
+
+```
+MIT License
+
+Copyright (c) 2020 Refactoring UI Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,8 +138,15 @@
     }
 
     .feature-icon {
-      font-size: 2.5em;
-      margin-bottom: 15px;
+      margin-bottom: 18px;
+    }
+
+    .feature-icon svg {
+      width: 48px;
+      height: 48px;
+      stroke: #667eea;
+      stroke-width: 1.5;
+      fill: none;
     }
 
     .quickstart {
@@ -273,32 +280,56 @@
       <h2>Why local-review?</h2>
       <div class="features">
         <div class="feature">
-          <div class="feature-icon">🔒</div>
+          <div class="feature-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"/>
+            </svg>
+          </div>
           <h3>Privacy First</h3>
           <p>Your code stays local. No SaaS signup, no telemetry, no data leaving your machine.</p>
         </div>
         <div class="feature">
-          <div class="feature-icon">🤖</div>
+          <div class="feature-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Zm.75-12h9v9h-9v-9Z"/>
+            </svg>
+          </div>
           <h3>Multi-LLM</h3>
           <p>Run reviews with Claude, Gemini, or Codex in parallel. Get consolidated findings with deduplication.</p>
         </div>
         <div class="feature">
-          <div class="feature-icon">💰</div>
+          <div class="feature-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z"/>
+            </svg>
+          </div>
           <h3>Free Options</h3>
           <p>Works with free tiers from Claude and Gemini. No credit card required.</p>
         </div>
         <div class="feature">
-          <div class="feature-icon">⚡</div>
+          <div class="feature-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"/>
+            </svg>
+          </div>
           <h3>Fast Setup</h3>
           <p>Single binary, no Docker/Node required. Works on macOS, Linux, and Windows.</p>
         </div>
         <div class="feature">
-          <div class="feature-icon">🔓</div>
+          <div class="feature-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
+            </svg>
+          </div>
           <h3>No Lock-In</h3>
           <p>Switch between LLM providers freely. Works with any OpenAI-compatible API.</p>
         </div>
         <div class="feature">
-          <div class="feature-icon">🎯</div>
+          <div class="feature-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"/>
+            </svg>
+          </div>
           <h3>Pre-Commit Hooks</h3>
           <p>Catch issues before they're committed. Perfect for team workflows.</p>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,14 +139,16 @@
 
     .feature-icon {
       margin-bottom: 18px;
+      color: #667eea;
     }
 
     .feature-icon svg {
       width: 48px;
       height: 48px;
-      stroke: #667eea;
+      stroke: currentColor;
       stroke-width: 1.5;
       fill: none;
+      display: block;
     }
 
     .quickstart {
@@ -278,6 +280,7 @@
   <section>
     <div class="container">
       <h2>Why local-review?</h2>
+      <!-- Icons from Heroicons (https://heroicons.com) by Tailwind Labs, Inc. — MIT License -->
       <div class="features">
         <div class="feature">
           <div class="feature-icon">


### PR DESCRIPTION
## Summary
- Replace 6 emoji icons in the "Why local-review?" section with inline Heroicons SVG (MIT license)
- Icons: shield-check, cpu-chip, gift, bolt, lock-open, command-line
- No external CDN requests — all paths inlined
- Styled with brand color `#667eea`, 48×48px, stroke-based

## Test plan
- [ ] Check feature cards render correctly at mshykov.github.io/local-review
- [ ] Verify icons display consistently across browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)