### PR TITLE
Improve install.sh PATH hint with copy-paste-ready one-liner

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,9 +83,9 @@ case ":$PATH:" in
     echo "Run this one-liner to fix it now:"
     echo
     if [ "${shell_rc##*/}" = "config.fish" ]; then
-      echo "    fish_add_path ${INSTALL_DIR}"
+      echo "    fish_add_path \"${INSTALL_DIR}\""
     elif [ -n "$shell_rc" ]; then
-      echo "    echo 'export PATH=\"\$PATH:${INSTALL_DIR}\"' >> ${shell_rc} && source ${shell_rc}"
+      echo "    echo 'export PATH=\"\$PATH:${INSTALL_DIR}\"' >> \"${shell_rc}\" && source \"${shell_rc}\""
     else
       echo "    export PATH=\"\$PATH:${INSTALL_DIR}\"   # then add this line to your shell rc"
     fi

--- a/install.sh
+++ b/install.sh
@@ -64,9 +64,32 @@ echo
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) ;;
   *)
-    echo "Note: ${INSTALL_DIR} is not on your PATH."
-    echo "Add to your shell rc:"
-    echo "    export PATH=\"\$PATH:${INSTALL_DIR}\""
+    shell_rc=""
+    case "${SHELL:-}" in
+      */zsh)  shell_rc="$HOME/.zshrc" ;;
+      */bash)
+        # macOS bash uses ~/.bash_profile by convention; Linux uses ~/.bashrc
+        if [ "$(uname -s)" = "Darwin" ]; then
+          shell_rc="$HOME/.bash_profile"
+        else
+          shell_rc="$HOME/.bashrc"
+        fi
+        ;;
+      */fish) shell_rc="$HOME/.config/fish/config.fish" ;;
+    esac
+
+    echo "⚠️  ${INSTALL_DIR} is not on your PATH — local-review won't be found until you fix that."
+    echo
+    echo "Run this one-liner to fix it now:"
+    echo
+    if [ "${shell_rc##*/}" = "config.fish" ]; then
+      echo "    fish_add_path ${INSTALL_DIR}"
+    elif [ -n "$shell_rc" ]; then
+      echo "    echo 'export PATH=\"\$PATH:${INSTALL_DIR}\"' >> ${shell_rc} && source ${shell_rc}"
+    else
+      echo "    export PATH=\"\$PATH:${INSTALL_DIR}\"   # then add this line to your shell rc"
+    fi
+    echo
     ;;
 esac
 


### PR DESCRIPTION
## Summary
After running the installer, new users got a Note saying their PATH didn't include `~/.local/bin` and were told to "add to your shell rc" — but without specifying which rc file or providing a one-liner. So they'd immediately run `local-review` and hit `command not found`.

This PR detects `$SHELL` and prints an exact command for the right rc file:

```
⚠️  /Users/foo/.local/bin is not on your PATH — local-review won't be found until you fix that.

Run this one-liner to fix it now:

    echo 'export PATH="$PATH:/Users/foo/.local/bin"' >> /Users/foo/.zshrc && source /Users/foo/.zshrc
```

Falls back gracefully if `$SHELL` is unset.

## Why not auto-modify dotfiles?
Considered, but: invasive, causes duplicate entries on re-runs, breaks for users with custom PATH managers (chezmoi/dotbot/mise). A copy-paste-ready hint is the safer middle ground for a small CLI installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)