### PR TITLE
Fix doctor command: versions, Copilot, OpenAI Plus → ChatGPT Plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Multi-LLM Support**: Run code reviews in parallel with multiple AI models
   - Claude CLI integration (free tier available)
   - Gemini CLI integration (free API key required)
-  - Codex CLI integration (OpenAI Plus required, disabled by default)
+  - Codex CLI integration (ChatGPT Plus required, disabled by default)
 - **Multi-LLM Commands**:
   - `local-review multi staged` - Review staged changes with all enabled LLMs
   - `local-review multi commit [ref]` - Review a specific commit

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ local-review multi staged --merge-with claude
 |-----|-------------|--------------|--------|
 | **Claude** | ✅ Free tier via [claude.ai](https://claude.ai) | `npm install -g @anthropic/claude-cli` | Default enabled |
 | **Gemini** | ✅ Free API key from [Google AI Studio](https://aistudio.google.com/apikey) | `npm install -g @google/gemini-cli` | Default enabled |
-| **Codex** | ⚠️ Requires OpenAI Plus ($20/mo) | `npm install -g @openai/codex` | Disabled by default |
+| **Codex** | ⚠️ Requires ChatGPT Plus ($20/mo) | `npm install -g @openai/codex` | Disabled by default |
 
 **How it works:**
 1. Detects installed LLM CLIs (claude, gemini, codex)
@@ -129,7 +129,7 @@ llms:
     api_key_env: GEMINI_API_KEY  # required for Gemini
 
   codex:
-    enabled: false         # paid only, enable if you have OpenAI Plus
+    enabled: false         # paid only, enable if you have ChatGPT Plus
     mode: cli
 
 merge:

--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -1,13 +1,9 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -24,7 +20,6 @@ It detects:
   - Claude CLI (claude)
   - Gemini CLI (gemini)
   - OpenAI Codex CLI (codex)
-  - GitHub CLI (gh) for Copilot
 
 For each CLI, it shows version and installation status.
 If any are missing, it provides installation instructions.`,
@@ -83,8 +78,6 @@ func getDisplayName(name string) string {
 		return "Gemini CLI"
 	case "codex":
 		return "Codex CLI"
-	case "gh":
-		return "Copilot CLI"
 	default:
 		return name
 	}
@@ -96,13 +89,11 @@ func printInstallInstructions(name string) {
 		fmt.Println("  Install: npm install -g @anthropic/claude-cli")
 		fmt.Println("  Auth:    claude login")
 	case "gemini":
-		fmt.Println("  Install: npm install -g @google/gemini-cli@0.40.0")
+		fmt.Println("  Install: npm install -g @google/gemini-cli")
 		fmt.Println("  Requires: Node.js 20+")
 	case "codex":
-		fmt.Println("  Install: npm install -g @openai/codex@0.128.0")
-	case "gh":
-		fmt.Println("  Install: brew install gh")
-		fmt.Println("  Auth:    gh auth login")
+		fmt.Println("  Install: npm install -g @openai/codex")
+		fmt.Println("  Note: requires a ChatGPT Plus subscription")
 	}
 }
 
@@ -132,35 +123,13 @@ func printAPIFallbackStatus() {
 		{"Claude", "ANTHROPIC_API_KEY"},
 		{"Gemini", "GEMINI_API_KEY"},
 		{"Codex", "OPENAI_API_KEY"},
-		{"Copilot", "GITHUB_TOKEN"},
 	}
 
 	for _, key := range apiKeys {
-		llm, envVar := key.Name, key.EnvVar
-
-		// Special case for Copilot - check gh auth status with timeout
-		if llm == "Copilot" {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			cmd := exec.CommandContext(ctx, "gh", "auth", "status")
-			cmd.Stdout = io.Discard // Suppress gh output
-			cmd.Stderr = io.Discard // Suppress gh output
-			err := cmd.Run()
-			cancel() // Explicitly cancel to avoid leak in loop
-
-			if err == nil {
-				fmt.Printf("✓ %-15s (gh auth configured)\n", llm)
-			} else if os.Getenv(envVar) != "" {
-				fmt.Printf("✓ %-15s (%s set)\n", llm, envVar)
-			} else {
-				fmt.Printf("✗ %-15s (not authenticated - run 'gh auth login')\n", llm)
-			}
-			continue
-		}
-
-		if os.Getenv(envVar) != "" {
-			fmt.Printf("✓ %-15s (%s set)\n", llm, envVar)
+		if os.Getenv(key.EnvVar) != "" {
+			fmt.Printf("✓ %-15s (%s set)\n", key.Name, key.EnvVar)
 		} else {
-			fmt.Printf("✗ %-15s (no API key)\n", llm)
+			fmt.Printf("✗ %-15s (no API key)\n", key.Name)
 		}
 	}
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -564,8 +564,8 @@ export GEMINI_API_KEY=your-key  # Get from https://aistudio.google.com/apikey</c
         </div>
         <div class="llm-card paid">
           <h3>Codex</h3>
-          <p>Requires an OpenAI Plus subscription</p>
-          <span class="badge badge-paid">OpenAI Plus required</span>
+          <p>Requires a ChatGPT Plus subscription</p>
+          <span class="badge badge-paid">ChatGPT Plus required</span>
           <p style="margin-top: 10px; font-size: 0.9em; color: #666;">Disabled by default</p>
         </div>
       </div>

--- a/examples/.local-review-multi.yml
+++ b/examples/.local-review-multi.yml
@@ -27,7 +27,7 @@ llms:
     api_key_env: GEMINI_API_KEY         # required for Gemini CLI
     timeout_seconds: 120
 
-  # Codex - Requires OpenAI Plus ($20/mo), disabled by default
+  # Codex - Requires ChatGPT Plus ($20/mo), disabled by default
   codex:
     enabled: false
     mode: cli

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,7 +120,7 @@ func Defaults() Config {
 				TimeoutSec: 120,
 			},
 			"codex": {
-				Enabled:    boolPtr(false), // Disabled: has usage limits, requires OpenAI Plus subscription
+				Enabled:    boolPtr(false), // Disabled: has usage limits, requires ChatGPT Plus subscription
 				Mode:       "cli",
 				CLIPath:    "codex",
 				Model:      "gpt-4",


### PR DESCRIPTION
## Summary
Fixes user-reported issues with `local-review doctor` output:

1. **Hardcoded version pins** in install hints (`@google/gemini-cli@0.40.0`, `@openai/codex@0.128.0`) — now resolve to latest, matching README/website
2. **Copilot still appearing in API fallback list** even though Copilot CLI support was removed — leftover dead state in `doctor.go`
3. **"OpenAI Plus" is not a real product** — found via dogfood self-review by Claude. Codex CLI requires a **ChatGPT Plus** subscription. Fixed everywhere it appeared:
   - `cmd/local-review/doctor.go`
   - `README.md` (LLM table + config example comment)
   - `docs/index.html` (Codex card description + badge)
   - `CHANGELOG.md` (v0.1.0 entry)

## Code cleanup (doctor.go)
- Drop dead `case "gh"` branches in `getDisplayName` and `printInstallInstructions`
- Drop unused imports (`context`, `io`, `os/exec`, `time`) — they were only used by the deleted `gh auth status` check
- `printAPIFallbackStatus` loop body is now uniform

## Dogfooding
Per the rule in CLAUDE.md, ran `local-review multi branch main` against this branch. First pass caught the "OpenAI Plus" mistake. Second pass: **APPROVE** with two non-blocking consistency notes:
- `CLAUDE.md` still describes Copilot in several places (architecture section) — to be cleaned up in a follow-up sweep
- Removal of version pins is intentional (user-facing docs always-latest, internal CLAUDE.md keeps tested versions)

## Note for v0.1.0 release notes on GitHub
The published v0.1.0 release notes still say "OpenAI Plus" (they were copy-pasted from CHANGELOG.md when it had the bug). Worth editing manually at https://github.com/mshykov/local-review/releases/tag/v0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)