### PR TITLE
Update website and CHANGELOG for v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-05-04
+
+### Added
+- **Homebrew distribution**: `brew install mshykov/tap/local-review` (macOS/Linux)
+
+### Fixed
+- `install.sh` now prints a copy-paste-ready one-liner for adding `~/.local/bin` to PATH, detecting the user's shell (zsh/bash/fish) instead of an abstract `export` line that left users with `command not found` after install.
+- `local-review doctor` no longer prints hardcoded version pins (`@google/gemini-cli@0.40.0`, `@openai/codex@0.128.0`) in install hints.
+- `local-review doctor` no longer probes for "Copilot" in the API fallback section (Copilot CLI support was removed earlier; this was leftover dead state).
+- "OpenAI Plus" → "ChatGPT Plus" everywhere user-facing (`OpenAI Plus` is not an actual product).
+
+### Removed
+- Outdated planning docs: `docs/implementation-plan-v0.1.md`, `docs/multi-llm-architecture.md`. Both described the original 4-LLM design (including Copilot) and were superseded by `CLAUDE.md`.
+- All remaining Copilot references from user-facing docs and code comments (CLAUDE.md, multi.go, CONTRIBUTING.md, OPEN_SOURCE_CHECKLIST.md).
+
 ## [0.1.0] - 2026-05-03
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -414,7 +414,7 @@
       <h1>local-review</h1>
       <p class="tagline">Privacy-first AI code reviews with multi-LLM support</p>
       <div class="cta-buttons">
-        <a href="https://github.com/mshykov/local-review/releases/latest" class="btn btn-primary">Download v0.1.1</a>
+        <a href="https://github.com/mshykov/local-review/releases/tag/v0.1.1" class="btn btn-primary">Download v0.1.1</a>
         <a href="https://github.com/mshykov/local-review" class="btn btn-secondary">View on GitHub</a>
       </div>
       <p class="trust-line">Open-source &middot; MIT Licensed &middot; No telemetry &middot; No SaaS</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -414,7 +414,7 @@
       <h1>local-review</h1>
       <p class="tagline">Privacy-first AI code reviews with multi-LLM support</p>
       <div class="cta-buttons">
-        <a href="https://github.com/mshykov/local-review/releases/latest" class="btn btn-primary">Download v0.1.0</a>
+        <a href="https://github.com/mshykov/local-review/releases/latest" class="btn btn-primary">Download v0.1.1</a>
         <a href="https://github.com/mshykov/local-review" class="btn btn-secondary">View on GitHub</a>
       </div>
       <p class="trust-line">Open-source &middot; MIT Licensed &middot; No telemetry &middot; No SaaS</p>
@@ -577,7 +577,17 @@ export GEMINI_API_KEY=your-key  # Get from https://aistudio.google.com/apikey</c
       <h2>Installation</h2>
       <div class="install-options">
         <div class="install-card recommended">
-          <h3>📦 Download Binary <span class="recommended-badge">RECOMMENDED</span></h3>
+          <h3>🍺 Homebrew (macOS/Linux) <span class="recommended-badge">RECOMMENDED</span></h3>
+          <div class="code-wrapper">
+            <button type="button" class="copy-btn" aria-label="Copy to clipboard">
+              <svg class="icon-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+              <svg class="icon-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg>
+            </button>
+            <pre><code>brew install mshykov/tap/local-review</code></pre>
+          </div>
+        </div>
+        <div class="install-card">
+          <h3>📦 Download Binary</h3>
           <p><a href="https://github.com/mshykov/local-review/releases/latest">Download from GitHub Releases</a></p>
           <p><small>Available for macOS, Linux, Windows &mdash; no dependencies required</small></p>
         </div>
@@ -591,17 +601,6 @@ export GEMINI_API_KEY=your-key  # Get from https://aistudio.google.com/apikey</c
             <pre><code>go install github.com/mshykov/local-review/cmd/local-review@latest</code></pre>
           </div>
         </div>
-        <div class="install-card coming-soon">
-          <h3>🍺 Homebrew (macOS/Linux)</h3>
-          <div class="code-wrapper">
-            <button type="button" class="copy-btn" aria-label="Copy to clipboard">
-              <svg class="icon-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-              <svg class="icon-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg>
-            </button>
-            <pre><code>brew install mshykov/tap/local-review</code></pre>
-          </div>
-          <p><small>Coming in v0.1.1</small></p>
-        </div>
       </div>
     </div>
   </section>
@@ -614,7 +613,7 @@ export GEMINI_API_KEY=your-key  # Get from https://aistudio.google.com/apikey</c
         <a href="https://github.com/mshykov/local-review/issues">Issues</a> •
         <a href="https://github.com/mshykov/local-review/blob/main/LICENSE">MIT License</a>
       </p>
-      <p style="margin-top: 8px; opacity: 0.5; font-size: 0.82em;">v0.1.0 &mdash; May 2026</p>
+      <p style="margin-top: 8px; opacity: 0.5; font-size: 0.82em;">v0.1.1 &mdash; May 2026</p>
     </div>
   </footer>
   <script>


### PR DESCRIPTION
## Summary
v0.1.1 is released and Homebrew tap is working (`brew install mshykov/tap/local-review` tested end-to-end ✓). Update the landing page and CHANGELOG to reflect.

### Website (docs/index.html)
- Promote Homebrew to first / recommended install option
- Reorder install cards: Homebrew → Binary → Go Install
- Drop "Coming in v0.1.1" muted state from Homebrew card
- Update CTA + footer version: 0.1.0 → 0.1.1

### CHANGELOG
- Add [0.1.1] - 2026-05-04 entry covering Homebrew distribution, install.sh PATH hint, doctor cleanup, ChatGPT Plus terminology, Copilot residue cleanup

## Note
Apply the `release` label or no label — this PR ships the v0.1.1 announcement, the actual v0.1.1 binaries are already published. The auto-release workflow is in line for an improvement (separate PR coming) so this merge does NOT need to bump version again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)