### PR TITLE
Add Rust prompt pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ local-review is a local, BYOK (Bring Your Own Key) AI code reviewer. It's a sing
 - **v0.1+**: Supports multi-LLM parallel reviews (Claude, Gemini, Codex)
 - **v0**: Single-LLM via OpenAI-compatible API endpoints
 - Saves reviews to local storage and merges findings intelligently
-- Ships with language-aware prompt packs for TypeScript, Go, Python, and more
+- Ships with language-aware prompt packs for TypeScript, Go, Python, Rust, and more
 
 Key constraints:
 - **No vendor SDK dependencies** — keeps the binary small and portable
@@ -299,7 +299,7 @@ Exit codes:
 ### Prompt Packs (internal/prompts/)
 Embedded markdown files (packs/*.md) define language-specific review rules:
 - `default.md` — fallback for unknown languages
-- `typescript.md`, `go.md`, `python.md` — language-specific packs
+- `typescript.md`, `go.md`, `python.md`, `rust.md` — language-specific packs
 
 Each pack is a system prompt with:
 1. Priority-ordered review criteria (correctness > security > perf > style)

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Exit codes:
 
 ## Prompt packs
 
-local-review ships with packs for `default`, `typescript`, `go`, `python`, with more coming. The CLI auto-picks based on the dominant language in your diff. Force a specific pack with `review.prompt_pack: <id>` in your YAML config.
+local-review ships with packs for `default`, `typescript`, `go`, `python`, `rust`, with more coming. The CLI auto-picks based on the dominant language in your diff. Force a specific pack with `review.prompt_pack: <id>` in your YAML config.
 
 Each pack is a markdown file (in [`internal/prompts/packs/`](internal/prompts/packs/)) that defines:
 - What to look for (priority-ordered)

--- a/internal/prompts/packs/rust.md
+++ b/internal/prompts/packs/rust.md
@@ -58,7 +58,7 @@ Apply the default review rules. Plus: Rust-specific patterns to look for.
 
 ### Match & pattern matching
 - **`_ =>` arms hiding new variants** — adding an enum variant won't trigger a compile error at the match site; prefer explicit patterns when the enum is owned by the project.
-- **`match x { Some(_) => ..., None => panic!() }`** — that's `.unwrap()` with extra steps; prefer the latter or `.expect("reason")`.
+- **`match x { Some(_) => ..., None => panic!() }`** — verbose panic-on-None; prefer handling the `None` case explicitly (return an error, use a default, or `?`). If a panic is truly acceptable and the invariant is documented, use `.expect("reason")` for clarity — but do not introduce `.unwrap()` here, as that is flagged as a production code issue.
 - **`if let` binding then never used** — `if let Some(v) = expr { … }` where `v` isn't read inside the block; either consume `v` or drop it (`if let Some(_)`/`if expr.is_some()`).
 
 ### API design
@@ -76,7 +76,7 @@ Apply the default review rules. Plus: Rust-specific patterns to look for.
 - **`cargo-deny` / `cargo-audit` flags ignored** — yanked or vulnerable deps.
 
 ### Testing
-- **`#[test]` without `#[cfg(test)]`-gated helpers** — test-only code shipped in the binary.
+- **Test helper code outside `#[cfg(test)]`** — `#[test]` items themselves are excluded from non-test builds, but helper functions, structs, and `use` statements defined *outside* `#[cfg(test)]` are compiled into production code. This can trigger `unused_*` warnings (or be a ship-blocker if `#![deny(warnings)]` is set). All test-only helpers, `use` imports, and utility code should live inside `#[cfg(test)] mod tests { … }`.
 - **`unwrap()` in tests** — fine for setup, but use `expect("...")` to make failures readable.
 - **Async tests without an async test attribute** — `#[test] async fn …` is a compile error on stable Rust; require `#[tokio::test]`, `#[async_std::test]`, or the runtime-specific equivalent.
 - **Doctest examples that don't run** — `/// ```ignore` is a smell; either fix the example or document why it can't compile.

--- a/internal/prompts/packs/rust.md
+++ b/internal/prompts/packs/rust.md
@@ -89,7 +89,7 @@ Apply the default review rules. Plus: Rust-specific patterns to look for.
 - **`as` casts for numeric narrowing** — silent truncation; prefer `try_into()` and handle the error.
 - **`.into()` chains hiding type confusion** — when the target type isn't obvious from the line, name it.
 - **`Default::default()`** — `T::default()` is clearer.
-- **Trait imports forgotten** — methods invisible without `use SomeTrait;` (especially `IteratorExt`, `FutureExt`, etc.).
+- **Trait imports forgotten** — extension methods invisible without `use SomeTrait;` (e.g. `itertools::Itertools`, `futures::StreamExt`, `tokio::io::AsyncReadExt`).
 
 ## Output
 

--- a/internal/prompts/packs/rust.md
+++ b/internal/prompts/packs/rust.md
@@ -30,9 +30,9 @@ Apply the default review rules. Plus: Rust-specific patterns to look for.
 - **`Arc<Mutex<T>>` for read-heavy data** — prefer `Arc<RwLock<T>>` when reads dominate.
 - **Lock held across `await`** — deadlock risk if any task awaiting on the same lock runs on the same thread; either drop the guard before `.await` or use `tokio::sync::Mutex`.
 - **`std::sync::Mutex` in async code** — blocks the executor thread. Use `tokio::sync::Mutex` (or hold briefly and drop before await).
-- **Channels without bounded capacity** — unbounded `mpsc` can OOM under backpressure. Default to `mpsc::channel(N)` for any input from the network/disk.
-- **`thread::spawn` without join handle** — silent panic; spawn returns `JoinHandle`, drop it with care or `.join()` to surface failures.
-- **`Send`/`Sync` impls hand-rolled with `unsafe`** — extremely high bar; demand a written invariant proof.
+- **Channels without bounded capacity** — unbounded channels can OOM under backpressure. Use `tokio::sync::mpsc::channel(N)` or `std::sync::mpsc::sync_channel(N)` (note: `std::sync::mpsc::channel()` is always unbounded — that's the issue, not a missing arg).
+- **Spawned panics swallowed** — `thread::spawn` and `tokio::spawn` capture panics into the returned handle. Dropping the handle (or never `.join()`/`.await`-ing it) means a task can panic silently with no observable failure.
+- **Hand-rolled `Send`/`Sync` impls** — high bar; require a `// SAFETY:` comment justifying the thread-safety invariant.
 
 ### Async & futures
 - **Blocking I/O inside an async fn** — `std::fs`, `std::net`, `Mutex::lock` block the executor. Use the `tokio::` / async equivalents, or `spawn_blocking`.
@@ -57,15 +57,14 @@ Apply the default review rules. Plus: Rust-specific patterns to look for.
 - **Dropping FFI-allocated memory with Rust's allocator** — must use the matching `free` from the foreign side.
 
 ### Match & pattern matching
-- **`_ =>` arms hiding new variants** — adding an enum variant won't trigger a compile error; prefer explicit patterns or `#[non_exhaustive]` thinking.
+- **`_ =>` arms hiding new variants** — adding an enum variant won't trigger a compile error at the match site; prefer explicit patterns when the enum is owned by the project.
 - **`match x { Some(_) => ..., None => panic!() }`** — that's `.unwrap()` with extra steps; prefer the latter or `.expect("reason")`.
-- **`if let Some(v) = ... else` with `_ = v`** — likely a bug; the binding is unused.
+- **`if let` binding then never used** — `if let Some(v) = expr { … }` where `v` isn't read inside the block; either consume `v` or drop it (`if let Some(_)`/`if expr.is_some()`).
 
 ### API design
 - **Returning `&str` vs `String`** — prefer `&str` for slices into existing data; return owned `String` only when allocating is unavoidable.
 - **Generic over too much** — `fn foo<T: AsRef<str>>(x: T)` is fine for ergonomics, but `fn foo<T: Trait>(...)` for one-call sites adds API surface for no reason.
 - **`pub` on internal helpers** — restricts future refactors; default to `pub(crate)` and only widen when actually consumed externally.
-- **`impl Trait` in trait return types pre-Rust 1.75** — only stable since 1.75; if the project's MSRV is older, this won't compile.
 - **Builder methods that take `self`** — fine, but breaks chaining if any branch returns a `Result`. Consider `&mut self` for fallible builders.
 
 ### Cargo, modules, and dependencies
@@ -85,7 +84,7 @@ Apply the default review rules. Plus: Rust-specific patterns to look for.
 
 ## Idioms & style
 
-- **`if let` chains nested deeply** — Rust 1.65+ has `let-else`; pre-1.65 use early returns. Either way, flatten.
+- **`if let` chains nested deeply** — flatten with early returns or `let-else` (Rust 1.65+).
 - **`match` arms returning `()` with side effects** — fine, but ensure no missing `;` ate a value silently.
 - **`as` casts for numeric narrowing** — silent truncation; prefer `try_into()` and handle the error.
 - **`.into()` chains hiding type confusion** — when the target type isn't obvious from the line, name it.

--- a/internal/prompts/packs/rust.md
+++ b/internal/prompts/packs/rust.md
@@ -1,0 +1,97 @@
+# Rust review pack
+
+Apply the default review rules. Plus: Rust-specific patterns to look for.
+
+## High-signal Rust pitfalls
+
+### Error handling
+- **`.unwrap()` / `.expect()` in production code** — every panic on `None`/`Err` is a runtime crash. Flag in non-test, non-`main`, non-prototype code; require `?`, `match`, or a documented invariant explaining why panic is acceptable.
+- **`?` swallowing context** — propagating `?` without wrapping (`.context("loading config")?`) loses the error trail. Flag for I/O, parse, and external-call errors.
+- **`Result<T, Box<dyn Error>>` in libraries** — opaque error type prevents callers from matching specific failures; prefer a typed error enum (`thiserror`) for libs.
+- **Catching everything with `let _ = result`** — silently discarding errors. Always intentional? Add a comment, or handle/log.
+- **Panicking in `Drop`** — aborts the program if drop runs during another panic. Never panic in `Drop::drop`.
+- **`assert!` / `panic!` for caller errors** — should usually be `Result::Err`. Reserve panic for true invariant violations (state the code itself broke).
+
+### Ownership & borrowing
+- **Unnecessary `.clone()`** — cheap on `Arc`/`Rc`/small types, expensive on `String`/`Vec`/large structs. If a borrow would work, prefer `&T`.
+- **`.to_string()` / `.to_owned()` in hot paths** — flag allocation in tight loops; consider `&str` or `Cow<str>`.
+- **Returning references to local data** — caught by the borrow checker, but easy to "fix" by cloning unnecessarily; the right fix is often a different ownership shape.
+- **`RefCell` / `Cell` borrows held across `await` points or function calls** — runtime panic if a re-borrow happens. Tighten the scope.
+- **`.iter().collect::<Vec<_>>()` then iterate again** — wasted allocation if the original iterator could be consumed directly.
+- **Mutable aliasing through `unsafe`** — UB if more than one `&mut` exists at a time. Demand justification.
+
+### Lifetimes
+- **`'static` bounds where they aren't needed** — tightens the API surface; often added to silence the compiler instead of fixing the underlying issue.
+- **Anonymous lifetime `'_` in returned references** — fine, but verify the implicit elision is what the author intended (especially with multiple input lifetimes).
+- **Self-referential structs** — usually a smell; pin/`Pin` only justifies it for futures/generators. Otherwise refactor.
+
+### Concurrency
+- **`Mutex` poisoning ignored** — `.lock().unwrap()` panics on poison; consider `.lock().unwrap_or_else(|e| e.into_inner())` or surface poisoning explicitly.
+- **`Arc<Mutex<T>>` for read-heavy data** — prefer `Arc<RwLock<T>>` when reads dominate.
+- **Lock held across `await`** — deadlock risk if any task awaiting on the same lock runs on the same thread; either drop the guard before `.await` or use `tokio::sync::Mutex`.
+- **`std::sync::Mutex` in async code** — blocks the executor thread. Use `tokio::sync::Mutex` (or hold briefly and drop before await).
+- **Channels without bounded capacity** — unbounded `mpsc` can OOM under backpressure. Default to `mpsc::channel(N)` for any input from the network/disk.
+- **`thread::spawn` without join handle** — silent panic; spawn returns `JoinHandle`, drop it with care or `.join()` to surface failures.
+- **`Send`/`Sync` impls hand-rolled with `unsafe`** — extremely high bar; demand a written invariant proof.
+
+### Async & futures
+- **Blocking I/O inside an async fn** — `std::fs`, `std::net`, `Mutex::lock` block the executor. Use the `tokio::` / async equivalents, or `spawn_blocking`.
+- **`.await` inside `Mutex` guard scope** — see above (lock-across-await).
+- **Forgotten `.await`** — calling an async fn without `.await` returns a future that does nothing. Compiler usually catches via `must_use`, but flag any `let _ = some_async_call()`.
+- **`tokio::spawn` with `'static` capture surprises** — passes ownership; if the task panics and isn't `.await`ed, the panic is silently swallowed.
+- **`select!` without cancellation safety check** — branches can drop a partially-completed future. Flag complex `select!` blocks for review.
+
+### Memory & performance
+- **`Box::leak` outside of init code** — leaks memory; only acceptable for one-time globals.
+- **`Rc<RefCell<T>>` cycles** — strong cycles never drop; use `Weak` for back-references.
+- **`Vec::push` in a loop without `Vec::with_capacity`** — repeated reallocation when size is knowable.
+- **`format!` for simple concatenation** — `String::push_str` is cheaper for known suffixes.
+- **`String::from_utf8_lossy` silently dropping bytes** — flag if input is supposed to be valid UTF-8 elsewhere.
+- **`.collect::<Vec<_>>()` then `.iter()`** — wasted allocation; chain iterators directly.
+
+### Unsafe & FFI
+- **`unsafe` block without a `// SAFETY:` comment** — undocumented invariants. Always require justification for every unsafe block.
+- **`mem::transmute`** — almost always wrong outside of FFI/serialization corners. Demand a strong reason.
+- **Raw pointer dereferencing in safe-looking APIs** — the unsafe contract crosses the API boundary; safe wrappers must enforce all invariants.
+- **`extern "C"` types not `repr(C)`** — UB across the FFI boundary.
+- **Dropping FFI-allocated memory with Rust's allocator** — must use the matching `free` from the foreign side.
+
+### Match & pattern matching
+- **`_ =>` arms hiding new variants** — adding an enum variant won't trigger a compile error; prefer explicit patterns or `#[non_exhaustive]` thinking.
+- **`match x { Some(_) => ..., None => panic!() }`** — that's `.unwrap()` with extra steps; prefer the latter or `.expect("reason")`.
+- **`if let Some(v) = ... else` with `_ = v`** — likely a bug; the binding is unused.
+
+### API design
+- **Returning `&str` vs `String`** — prefer `&str` for slices into existing data; return owned `String` only when allocating is unavoidable.
+- **Generic over too much** — `fn foo<T: AsRef<str>>(x: T)` is fine for ergonomics, but `fn foo<T: Trait>(...)` for one-call sites adds API surface for no reason.
+- **`pub` on internal helpers** — restricts future refactors; default to `pub(crate)` and only widen when actually consumed externally.
+- **`impl Trait` in trait return types pre-Rust 1.75** — only stable since 1.75; if the project's MSRV is older, this won't compile.
+- **Builder methods that take `self`** — fine, but breaks chaining if any branch returns a `Result`. Consider `&mut self` for fallible builders.
+
+### Cargo, modules, and dependencies
+- **`unused_imports` / `dead_code`** — ship-blocker if the project enforces `#![deny(warnings)]`; otherwise still cleanup-worthy.
+- **Wildcard `use` in non-test code** — pollutes namespace, hides shadowing.
+- **`features = ["full"]` on `tokio`** — pulls everything; pin to the actual features needed (`rt-multi-thread`, `macros`, `net`, ...) for compile time and binary size.
+- **Version specifiers `"*"` or `">=X"`** in `Cargo.toml` — non-reproducible builds; use `^X.Y` (the default).
+- **Dependencies on `git = "..."` without `rev = "..."`** — non-reproducible.
+- **`cargo-deny` / `cargo-audit` flags ignored** — yanked or vulnerable deps.
+
+### Testing
+- **`#[test]` without `#[cfg(test)]`-gated helpers** — test-only code shipped in the binary.
+- **`unwrap()` in tests** — fine for setup, but use `expect("...")` to make failures readable.
+- **Async tests without `#[tokio::test]`** — runs but panics; or runs synchronously and skips the future.
+- **Doctest examples that don't run** — `/// ```ignore` is a smell; either fix the example or document why it can't compile.
+- **Flaky tests with `thread::sleep`** — replace with explicit synchronization (channel, `Notify`).
+
+## Idioms & style
+
+- **`if let` chains nested deeply** — Rust 1.65+ has `let-else`; pre-1.65 use early returns. Either way, flatten.
+- **`match` arms returning `()` with side effects** — fine, but ensure no missing `;` ate a value silently.
+- **`as` casts for numeric narrowing** — silent truncation; prefer `try_into()` and handle the error.
+- **`.into()` chains hiding type confusion** — when the target type isn't obvious from the line, name it.
+- **`Default::default()`** — `T::default()` is clearer.
+- **Trait imports forgotten** — methods invisible without `use SomeTrait;` (especially `IteratorExt`, `FutureExt`, etc.).
+
+## Output
+
+Same JSON shape as the default pack.

--- a/internal/prompts/packs/rust.md
+++ b/internal/prompts/packs/rust.md
@@ -78,7 +78,7 @@ Apply the default review rules. Plus: Rust-specific patterns to look for.
 ### Testing
 - **`#[test]` without `#[cfg(test)]`-gated helpers** — test-only code shipped in the binary.
 - **`unwrap()` in tests** — fine for setup, but use `expect("...")` to make failures readable.
-- **Async tests without `#[tokio::test]`** — runs but panics; or runs synchronously and skips the future.
+- **Async tests without an async test attribute** — `#[test] async fn …` is a compile error on stable Rust; require `#[tokio::test]`, `#[async_std::test]`, or the runtime-specific equivalent.
 - **Doctest examples that don't run** — `/// ```ignore` is a smell; either fix the example or document why it can't compile.
 - **Flaky tests with `thread::sleep`** — replace with explicit synchronization (channel, `Notify`).
 

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetKnown(t *testing.T) {
-	cases := []string{"default", "typescript", "go", "python"}
+	cases := []string{"default", "typescript", "go", "python", "rust"}
 	for _, lang := range cases {
 		body, err := Get(lang)
 		if err != nil {
@@ -35,7 +35,7 @@ func TestAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ids) < 4 {
-		t.Errorf("expected ≥4 packs (default + 3 langs), got %d: %v", len(ids), ids)
+	if len(ids) < 5 {
+		t.Errorf("expected ≥5 packs (default + 4 langs), got %d: %v", len(ids), ids)
 	}
 }

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -35,7 +35,7 @@ func TestAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ids) < 5 {
-		t.Errorf("expected ≥5 packs (default + 4 langs), got %d: %v", len(ids), ids)
+	if len(ids) < 2 {
+		t.Errorf("expected at least default + one language pack, got %d: %v", len(ids), ids)
 	}
 }

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -35,7 +35,10 @@ func TestAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ids) < 2 {
-		t.Errorf("expected at least default + one language pack, got %d: %v", len(ids), ids)
+	// Floor matches the current pack count (default + typescript + go +
+	// python + rust). Bump this when adding a pack so a regression that
+	// silently drops one is caught.
+	if len(ids) < 5 {
+		t.Errorf("expected ≥5 packs, got %d: %v", len(ids), ids)
 	}
 }


### PR DESCRIPTION
## Summary
Adds a Rust language prompt pack (`internal/prompts/packs/rust.md`) so `local-review` produces high-signal findings on `.rs` diffs instead of falling back to the generic default pack.

The pack covers 12 categories of Rust-specific pitfalls, modeled on the existing `go.md`/`python.md` style:

- Error handling (`unwrap()` in prod, `?` swallowing context, `panic` in `Drop`)
- Ownership & borrowing (`clone()` overuse, `RefCell` borrows across `.await`)
- Lifetimes (`'static` over-constraint, self-referential structs)
- Concurrency (lock across `await`, unbounded channels, `std::sync::Mutex` in async)
- Async & futures (blocking I/O in async fn, forgotten `.await`, `select!` cancellation safety)
- Memory & performance (`Box::leak`, `Rc` cycles, missing `Vec::with_capacity`)
- Unsafe & FFI (`// SAFETY:` comments, `transmute`, `repr(C)`)
- Match & pattern matching (`_ =>` hiding new variants)
- API design (`&str` vs `String`, generic blast radius, `pub` vs `pub(crate)`)
- Cargo & dependencies (feature bloat, `git` deps without `rev` pin)
- Testing (`#[cfg(test)]` gating, `#[tokio::test]` requirement)
- Idioms (`let-else`, `as` casts, trait imports)

## Wiring
- `internal/lang/detect.go` already maps `.rs` → `"rust"` (was added earlier; pack file was the missing piece)
- `internal/prompts/prompts_test.go`: include `"rust"` in known-pack list, raise floor to 5 packs
- `README.md` / `CLAUDE.md`: list `rust` alongside the other packs

## Dogfooding
Per CLAUDE.md's pre-push rule, ran `local-review multi branch main` three times against this branch:

1. **First pass: REQUEST CHANGES** — Claude caught two real factual bugs in the prompt:
   - Channel guidance ambiguous between `std::sync::mpsc::channel()` (always unbounded) and `tokio::sync::mpsc::channel(N)` (bounded)
   - Malformed `if let ... else` syntax example
2. **Second pass: REQUEST CHANGES** — caught test floor weakened in same diff that added a pack, plus async-test wording (`#[test] async fn` is a compile error, not a runtime panic)
3. **Third pass: APPROVE** with one info-only nit (`IteratorExt` not a real trait — fixed, replaced with real `itertools::Itertools` / `futures::StreamExt` / `tokio::io::AsyncReadExt`)

Net effect: the pack is more accurate before reaching users than it would have been without dogfooding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rust support to prompt packs

* **Documentation**
  * Updated docs to list Rust among supported prompt packs and clarified prompt-pack behavior

* **Tests**
  * Expanded tests to include Rust and adjusted pack count expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->