### PR TITLE
Add DeepSeek and Mistral provider examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ local-review speaks the OpenAI chat-completions API — every major provider sup
 |---|---|---|
 | OpenAI | `https://api.openai.com/v1` | Default |
 | Anthropic | `https://api.anthropic.com/v1` | Use chat-completions, not messages |
+| Mistral | `https://api.mistral.ai/v1` | EU-hosted; Codestral is code-tuned. See [`examples/.local-review.mistral.yml`](examples/.local-review.mistral.yml) |
+| DeepSeek | `https://api.deepseek.com/v1` | Cheapest option; DeepSeek-R1 reasons well. See [`examples/.local-review.deepseek.yml`](examples/.local-review.deepseek.yml) |
 | Groq | `https://api.groq.com/openai/v1` | Fast |
 | Together | `https://api.together.xyz/v1` | Llama, Mixtral, etc. |
 | OpenRouter | `https://openrouter.ai/api/v1` | One key, all models |

--- a/examples/.local-review.deepseek.yml
+++ b/examples/.local-review.deepseek.yml
@@ -41,6 +41,7 @@ review:
   max_findings: 20
   exclude:
     - "**/*.lock"
+    - "**/*.snap"
     - "**/dist/**"
     - "**/build/**"
     - "**/node_modules/**"

--- a/examples/.local-review.deepseek.yml
+++ b/examples/.local-review.deepseek.yml
@@ -1,0 +1,46 @@
+# local-review config — DeepSeek provider example.
+#
+# Drop this at the root of any repo (rename it to `.local-review.yml`,
+# or symlink). DeepSeek's API speaks the OpenAI chat-completions
+# dialect, so it works without any local-review code changes.
+#
+# Setup:
+#   1. Create an API key at https://platform.deepseek.com/api_keys
+#   2. export DEEPSEEK_API_KEY=sk-...   (or whatever env var name you pick)
+#   3. local-review staged
+#
+# Why DeepSeek for code review:
+#   - Very competitive pricing (deepseek-chat is ~$0.27/1M input tokens
+#     as of mid-2026; deepseek-reasoner ~$0.55/1M).
+#   - deepseek-reasoner (DeepSeek-R1 family) is a strong code-reasoning
+#     model — good for security/correctness review where it's worth
+#     paying a bit more for deeper analysis.
+#   - deepseek-chat (DeepSeek-V3) is fine and very cheap for
+#     style/idiom review.
+#
+# Heads-up on data:
+#   DeepSeek is a Chinese company. Their public API processes your
+#   diff on their servers. If your code is sensitive (closed-source,
+#   regulated industry, customer data in fixtures), prefer a self-
+#   hosted DeepSeek model via Ollama or vLLM instead. local-review
+#   doesn't care which OpenAI-compat endpoint it talks to.
+
+provider:
+  base_url: https://api.deepseek.com/v1
+  model: deepseek-chat              # cheap & fast; swap for deepseek-reasoner for harder reviews
+
+  # local-review reads the key from this env var.
+  api_key_env: DEEPSEEK_API_KEY
+
+  # DeepSeek's reasoner model can be slow on long diffs — bump
+  # timeout if you hit "deadline exceeded" errors.
+  timeout_seconds: 120
+
+review:
+  min_severity: warning
+  max_findings: 20
+  exclude:
+    - "**/*.lock"
+    - "**/dist/**"
+    - "**/build/**"
+    - "**/node_modules/**"

--- a/examples/.local-review.mistral.yml
+++ b/examples/.local-review.mistral.yml
@@ -1,0 +1,42 @@
+# local-review config — Mistral provider example.
+#
+# Drop this at the root of any repo (rename it to `.local-review.yml`,
+# or symlink). Mistral La Plateforme exposes an OpenAI-compatible
+# chat-completions endpoint, so it works without any local-review
+# code changes.
+#
+# Setup:
+#   1. Create an API key at https://console.mistral.ai/api-keys/
+#   2. export MISTRAL_API_KEY=...
+#   3. local-review staged
+#
+# Why Mistral for code review:
+#   - Strong on code: Codestral and Mistral Large are both code-aware
+#     and well-priced. Codestral is purpose-built for coding tasks.
+#   - EU-hosted (France) — meaningful if your data residency rules
+#     prefer EU jurisdiction over US providers.
+#   - Free tier on La Plateforme is generous enough for small teams
+#     to evaluate before committing.
+#
+# Open-weights alternative:
+#   Mistral also publishes open-weight models (Mistral 7B, Mixtral
+#   8x7B, Codestral Mamba). If you'd rather not send code over the
+#   wire, run them locally via Ollama or vLLM and point local-review
+#   at that endpoint instead.
+
+provider:
+  base_url: https://api.mistral.ai/v1
+  model: codestral-latest           # purpose-built for code; swap for mistral-large-latest if you want a generalist
+
+  api_key_env: MISTRAL_API_KEY
+
+  timeout_seconds: 60
+
+review:
+  min_severity: warning
+  max_findings: 20
+  exclude:
+    - "**/*.lock"
+    - "**/dist/**"
+    - "**/build/**"
+    - "**/node_modules/**"

--- a/examples/.local-review.mistral.yml
+++ b/examples/.local-review.mistral.yml
@@ -37,6 +37,7 @@ review:
   max_findings: 20
   exclude:
     - "**/*.lock"
+    - "**/*.snap"
     - "**/dist/**"
     - "**/build/**"
     - "**/node_modules/**"

--- a/examples/.local-review.yml
+++ b/examples/.local-review.yml
@@ -10,8 +10,8 @@ provider:
   # Any OpenAI-compatible endpoint. Examples:
   #   OpenAI       https://api.openai.com/v1
   #   Anthropic    https://api.anthropic.com/v1   (chat-completions endpoint)
-  #   Mistral      https://api.mistral.ai/v1      (EU-hosted; see .local-review.mistral.yml)
-  #   DeepSeek     https://api.deepseek.com/v1    (cheapest; see .local-review.deepseek.yml)
+  #   Mistral      https://api.mistral.ai/v1      (EU-hosted; see examples/.local-review.mistral.yml)
+  #   DeepSeek     https://api.deepseek.com/v1    (cheapest; see examples/.local-review.deepseek.yml)
   #   Together     https://api.together.xyz/v1
   #   Groq         https://api.groq.com/openai/v1
   #   OpenRouter   https://openrouter.ai/api/v1

--- a/examples/.local-review.yml
+++ b/examples/.local-review.yml
@@ -10,6 +10,8 @@ provider:
   # Any OpenAI-compatible endpoint. Examples:
   #   OpenAI       https://api.openai.com/v1
   #   Anthropic    https://api.anthropic.com/v1   (chat-completions endpoint)
+  #   Mistral      https://api.mistral.ai/v1      (EU-hosted; see .local-review.mistral.yml)
+  #   DeepSeek     https://api.deepseek.com/v1    (cheapest; see .local-review.deepseek.yml)
   #   Together     https://api.together.xyz/v1
   #   Groq         https://api.groq.com/openai/v1
   #   OpenRouter   https://openrouter.ai/api/v1


### PR DESCRIPTION
## Summary
Two new provider config examples — copy-paste, set the env var, you're reviewing.

### `examples/.local-review.deepseek.yml`
- `base_url: https://api.deepseek.com/v1`
- Default model: `deepseek-chat` (cheap & fast); note swap to `deepseek-reasoner` for harder reviews
- 120s timeout because R1-style reasoning models can be slow on long diffs
- Includes a data-residency note (DeepSeek hosted in China; suggests Ollama/vLLM with self-hosted weights for sensitive code)

### `examples/.local-review.mistral.yml`
- `base_url: https://api.mistral.ai/v1`
- Default model: `codestral-latest` (purpose-built for code)
- Notes EU-hosting positioning and the open-weights alternative

## Other touches
- README provider table: Mistral and DeepSeek added with links to the new example files
- `examples/.local-review.yml`: Mistral and DeepSeek added to the comment list of OpenAI-compat endpoints

## No code changes
Both providers speak the standard chat-completions API — `internal/llm/client.go` doesn't care which endpoint it talks to. This PR is purely examples + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README "Switching providers" table to add Mistral and fix row numbering/positioning.
  * Added example configuration files to simplify setup for DeepSeek and Mistral providers.
  * Extended example comments to include provider endpoint references for Mistral and DeepSeek.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->