### PR TITLE
Document release-label discipline (post-mortem on accidental minor bumps)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,13 @@ jobs:
             --jq '.[0].number' 2>/dev/null || echo "")
           labels=$(gh pr view "$pr_number" --json labels --jq '.labels[].name' || echo "")
 
+          # Bump labels follow strict semver — see docs/RELEASE_PROCESS.md
+          # "Label cheat sheet" for when each is appropriate. Quick reminder:
+          #   major  = breaking changes (CLI flags removed, config schema rewrite)
+          #   minor  = new user-visible feature (new pack, new command, new flag)
+          #   patch  = bug fix, doc update, internal refactor, dep bump
+          # When in doubt, prefer patch — minor inflates expectations and
+          # burns version numbers fast in 0.x.
           if echo "$labels" | grep -qxF "major"; then
             major=$((major + 1)); minor=0; patch=0
           elif echo "$labels" | grep -qxF "minor"; then

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -35,20 +35,20 @@ We use **semantic versioning**: `vMAJOR.MINOR.PATCH`
 
 ### Label cheat sheet
 
-Apply these labels to a PR **only when you actually want a release on merge**. The pipeline ships when the `release` label is present *and* one of `major` / `minor` / `patch` (default: `patch`).
+Apply these labels to a PR **only when you actually want a release on merge**. The pipeline ships when the `release` label is present. If neither `major` nor `minor` is present, the release defaults to a `patch` bump; use `patch` only when you want to make that default explicit.
 
 | Label | Use it for | Don't use it for |
 |---|---|---|
 | `release` | Mandatory on any PR you want to ship | Doc-only PRs, refactors, internal tweaks |
 | `major` | Breaking CLI flag changes, removed commands, config schema rewrites | Anything that doesn't break existing user setups |
 | `minor` | A new prompt pack, a new command, a new provider in core, a new flag | Bug fixes, polish, internal refactors |
-| `patch` | Bug fixes, doc/config updates, dependency bumps, test additions | New user-visible functionality |
+| `patch` | Bug fixes, doc/config updates, dependency bumps, test additions, or when you want to make the default patch bump explicit | New user-visible functionality |
 
 **Common mistakes to avoid:**
 
 - ❌ **`minor` for "I want to ship this, the change feels notable"** → bumps the published version more than necessary. v0.1.1 → v0.2.0 implies a feature; if the PR is "fix typo in error message," use `patch`.
 - ❌ **`release` on every merged PR** → ships a tag for every doc/CI/refactor PR. Wastes version numbers and inflates release frequency. Only label `release` when you specifically want to publish.
-- ❌ **No bump label, just `release`** → defaults to `patch`. If you wanted a feature release, you'd skip a number. Always pair `release` with the explicit bump label.
+- ❌ **No bump label, just `release`, when you intended a feature or breaking release** → defaults to `patch`. Add `minor` or `major` when you need something other than the default patch bump.
 
 **0.x special case:** while you're pre-1.0, "minor" still doesn't promise stability — anything can break. But the version number is still the public-facing signal of momentum, so bumping it casually inflates expectations. Default to `patch` unless the PR adds new user-visible functionality.
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -33,6 +33,25 @@ We use **semantic versioning**: `vMAJOR.MINOR.PATCH`
 - Automatically from **PR labels** or **conventional commits**
 - Manual override possible via workflow dispatch
 
+### Label cheat sheet
+
+Apply these labels to a PR **only when you actually want a release on merge**. The pipeline ships when the `release` label is present *and* one of `major` / `minor` / `patch` (default: `patch`).
+
+| Label | Use it for | Don't use it for |
+|---|---|---|
+| `release` | Mandatory on any PR you want to ship | Doc-only PRs, refactors, internal tweaks |
+| `major` | Breaking CLI flag changes, removed commands, config schema rewrites | Anything that doesn't break existing user setups |
+| `minor` | A new prompt pack, a new command, a new provider in core, a new flag | Bug fixes, polish, internal refactors |
+| `patch` | Bug fixes, doc/config updates, dependency bumps, test additions | New user-visible functionality |
+
+**Common mistakes to avoid:**
+
+- ❌ **`minor` for "I want to ship this, the change feels notable"** → bumps the published version more than necessary. v0.1.1 → v0.2.0 implies a feature; if the PR is "fix typo in error message," use `patch`.
+- ❌ **`release` on every merged PR** → ships a tag for every doc/CI/refactor PR. Wastes version numbers and inflates release frequency. Only label `release` when you specifically want to publish.
+- ❌ **No bump label, just `release`** → defaults to `patch`. If you wanted a feature release, you'd skip a number. Always pair `release` with the explicit bump label.
+
+**0.x special case:** while you're pre-1.0, "minor" still doesn't promise stability — anything can break. But the version number is still the public-facing signal of momentum, so bumping it casually inflates expectations. Default to `patch` unless the PR adds new user-visible functionality.
+
 ### 2. Release Flow
 
 ```


### PR DESCRIPTION
## Summary
Two minor bumps (v0.2.0, v0.3.0) shipped when patch was intended. Tags are public so we leave them — but write down the discipline so the next maintainer (including future-you) doesn't repeat it.

## Changes
- **`docs/RELEASE_PROCESS.md`**: new "Label cheat sheet" section with:
  - Table of label → use case → anti-use case
  - "Common mistakes to avoid" list naming the exact failure modes that just happened
  - 0.x special-case note (minor doesn't promise stability, but version numbers still signal momentum)
- **`.github/workflows/release.yml`**: inline reminder above the bump-decision block, points to the cheat sheet, summarizes intent, says "when in doubt, prefer patch"

## What didn't change
- Workflow behavior: still defaults to `patch` when no `major`/`minor` label is present (this was already correct — the issue was applying `minor` explicitly)
- Public tags: v0.2.0 and v0.3.0 stay. Reverting them is destructive and the version "waste" is purely cosmetic at 0.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation with label guidelines to clarify semver bump labeling semantics and best practices for PR classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->