### PR TITLE
Add Google Search Console verification + make hero CTA version-independent

### DIFF
--- a/docs/google25c448019dd85114.html
+++ b/docs/google25c448019dd85114.html
@@ -1,0 +1,1 @@
+google-site-verification: google25c448019dd85114.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -468,7 +468,7 @@
       <h1>local-review</h1>
       <p class="tagline">Privacy-first AI code reviews with multi-LLM support</p>
       <div class="cta-buttons">
-        <a href="https://github.com/mshykov/local-review/releases/tag/v0.1.1" class="btn btn-primary">Download v0.1.1</a>
+        <a href="https://github.com/mshykov/local-review/releases/latest" class="btn btn-primary">Download latest release</a>
         <a href="https://github.com/mshykov/local-review" class="btn btn-secondary">View on GitHub</a>
       </div>
       <p class="trust-line">Open-source &middot; MIT Licensed &middot; No telemetry &middot; No SaaS</p>
@@ -667,7 +667,10 @@ export GEMINI_API_KEY=your-key  # Get from https://aistudio.google.com/apikey</c
         <a href="https://github.com/mshykov/local-review/issues">Issues</a> •
         <a href="https://github.com/mshykov/local-review/blob/main/LICENSE">MIT License</a>
       </p>
-      <p style="margin-top: 8px; opacity: 0.5; font-size: 0.82em;">v0.1.1 &mdash; May 2026</p>
+      <p style="margin-top: 8px; opacity: 0.5; font-size: 0.82em;">
+        <a href="https://github.com/mshykov/local-review/releases/latest" style="color: inherit;">Latest release</a>
+        &middot; <a href="https://github.com/mshykov/local-review/blob/main/CHANGELOG.md" style="color: inherit;">Changelog</a>
+      </p>
     </div>
   </footer>
   <div id="copy-live" role="status" aria-live="polite" aria-atomic="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap"></div>


### PR DESCRIPTION
## Summary
Two small SEO/site-maintenance fixes triggered by the v0.1.1 → v0.3.0 release sequence:

### 1. Google Search Console verification
- Adds `docs/google25c448019dd85114.html` — the verification file Google needs to confirm site ownership
- After this merges and Pages rebuilds, **claim the property** at https://search.google.com/search-console (you should already be most of the way through this)
- Then submit `https://mshykov.github.io/local-review/sitemap.xml` for faster indexing

### 2. Version-independent hero CTA
- Was: `Download v0.1.1` linking to `/releases/tag/v0.1.1` — went stale instantly when v0.3.0 shipped
- Now: `Download latest release` linking to `/releases/latest` — GitHub auto-redirects to whatever's current
- Footer updated similarly: replaced the static `v0.1.1 — May 2026` line with two links: "Latest release" + "Changelog", both auto-current

No more manual edits to the website after each release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Download link now directs to the latest GitHub release instead of a fixed version.
  * Footer updated with links to the latest release and changelog.

* **Chores**
  * Added site verification support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->