### PR TITLE
Update --help text: lead with 'init', add Mistral/DeepSeek, link site

### DIFF
--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -49,7 +49,7 @@ Ollama (fully offline), vLLM, etc.
 First-time setup:
 
   local-review init             # interactive — picks a provider, writes .local-review.yml
-  export OPENAI_API_KEY=...     # init prints which env var to set
+  export <API_KEY_ENV>=...      # init prints which env var to set
   local-review staged           # review staged changes
 
 Multi-LLM mode (runs installed LLM CLIs in parallel, merges findings):

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -42,14 +42,23 @@ func main() {
 		Long: `local-review reviews a git diff with an LLM of your choice and reports findings.
 
 It runs entirely on your machine. The only network call is to whichever
-chat-completions endpoint you configure (OpenAI by default; Anthropic,
-Together, Groq, OpenRouter, Ollama, vLLM all work via the same API shape).
+chat-completions endpoint you configure. Works with any OpenAI-compatible
+provider: OpenAI, Anthropic, Mistral, DeepSeek, Together, Groq, OpenRouter,
+Ollama (fully offline), vLLM, etc.
 
-Set your API key:
+First-time setup:
 
-  export LOCAL_REVIEW_API_KEY=sk-...
+  local-review init             # interactive — picks a provider, writes .local-review.yml
+  export OPENAI_API_KEY=...     # init prints which env var to set
+  local-review staged           # review staged changes
 
-Configure provider/model in ~/.local-review.yml or ./.local-review.yml. See README.`,
+Multi-LLM mode (runs installed LLM CLIs in parallel, merges findings):
+
+  local-review doctor           # check which LLM CLIs are installed/authenticated
+  local-review multi staged
+
+Configure manually in ~/.local-review.yml or ./.local-review.yml.
+See README and https://mshykov.github.io/local-review/ for details.`,
 		SilenceUsage: true,
 	}
 


### PR DESCRIPTION
## Summary

Reworks the root-command `Long` help text to match the v0.4 onboarding story.

**Before** (what users saw on `local-review --help`):

```
... OpenAI by default; Anthropic, Together, Groq, OpenRouter, Ollama, vLLM ...

Set your API key:

  export LOCAL_REVIEW_API_KEY=sk-...

Configure provider/model in ~/.local-review.yml or ./.local-review.yml. See README.
```

That's the v0 manual-setup ritual. v0.4 added `local-review init` precisely to skip that ritual.

**After**:

```
... Works with any OpenAI-compatible provider: OpenAI, Anthropic, Mistral,
DeepSeek, Together, Groq, OpenRouter, Ollama (fully offline), vLLM, etc.

First-time setup:

  local-review init             # interactive — picks a provider, writes .local-review.yml
  export OPENAI_API_KEY=...     # init prints which env var to set
  local-review staged           # review staged changes

Multi-LLM mode (runs installed LLM CLIs in parallel, merges findings):

  local-review doctor           # check which LLM CLIs are installed/authenticated
  local-review multi staged

Configure manually in ~/.local-review.yml or ./.local-review.yml.
See README and https://mshykov.github.io/local-review/ for details.
```

Lead is now `init`. Provider list matches the wizard + README. Multi-LLM mode is mentioned but as a second path, not the primary.

## Release

This is user-visible (every `--help` invocation), so I'd label it `release` + `patch` to ship as v0.4.1. Tell me if you'd rather hold it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved help text with clearer first-time setup steps, including initialization and environment API key configuration.
  * Added concise usage guidance for multi-LLM workflows and listed key commands (e.g., doctor, multi staged).
  * Expanded overall usage/configuration descriptions for easier onboarding and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->