### PR TITLE
Post-v0.4.2 polish: doctor and docs consistency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **CLAUDE.md** Codex auth note now includes the OPENAI_API_KEY path (was claiming "ChatGPT Plus subscription" only — contradicted v0.4.2 release notes).
+- **README.md** auth-table column header renamed `API-key alternative` → `Alternative` to match the Gemini row's contents (which point to OAuth, not an API key).
+- **`local-review doctor`** Gemini install hints now lead with `GEMINI_API_KEY` (the project's preferred path per the README) and list `gemini /auth` as the alternative — was the other way around.
+- **`local-review doctor`** now propagates I/O write errors. Previously `local-review doctor > /dev/full` (or any broken-pipe scenario) would silently exit 0 even though writes had failed.
+- **CHANGELOG** added the `[Unreleased]` section per Keep a Changelog convention.
+
 ## [0.4.2] - 2026-05-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Key constraints:
 **Supported LLM CLIs**
 1. **Claude CLI** — `npm install -g @anthropic-ai/claude-code` (auth: `claude login`)
 2. **Gemini CLI** — `npm install -g @google/gemini-cli` (requires Node.js 20+)
-3. **OpenAI Codex CLI** — `npm install -g @openai/codex` (requires ChatGPT Plus subscription)
+3. **OpenAI Codex CLI** — `npm install -g @openai/codex` (auth via `codex login` with ChatGPT Plus, or `OPENAI_API_KEY` env var pay-per-token — usually cheaper for occasional use)
 
 **CLI Invocation Patterns**
 - Codex: `codex review --commit <sha>`

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ local-review multi staged
 
 **Authentication — what each LLM needs:**
 
-| LLM | Default (preferred) | API-key alternative |
+| LLM | Default (preferred) | Alternative |
 |---|---|---|
 | **Claude** | `claude login` — Anthropic OAuth, works with the free tier on a claude.ai account | `export ANTHROPIC_API_KEY=...` (paid API access) |
-| **Gemini** | `export GEMINI_API_KEY=...` — free key from [Google AI Studio](https://aistudio.google.com/apikey) | (Gemini CLI also supports `gemini /auth` for Google OAuth) |
+| **Gemini** | `export GEMINI_API_KEY=...` — free key from [Google AI Studio](https://aistudio.google.com/apikey) | `gemini /auth` for Google OAuth |
 | **Codex** | `codex login` — uses your ChatGPT Plus subscription ($20/mo) | `export OPENAI_API_KEY=...` — pay-per-token; usually **cheaper** for occasional review use |
 
 Run `local-review doctor` to see which CLIs you have installed and authenticated. The output tells you exactly what to fix for each row that isn't ✓ ready.

--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -28,7 +28,7 @@ func doctorCmd() *cobra.Command {
 
 It detects:
   - Claude CLI (claude) — auth via 'claude login' or ANTHROPIC_API_KEY
-  - Gemini CLI (gemini) — auth via 'gemini /auth' (Google OAuth) or GEMINI_API_KEY
+  - Gemini CLI (gemini) — auth via GEMINI_API_KEY (preferred) or 'gemini /auth' (Google OAuth)
   - OpenAI Codex CLI (codex) — auth via 'codex login' (ChatGPT Plus) or OPENAI_API_KEY
 
 For each CLI, doctor prints one of:
@@ -47,9 +47,15 @@ Exit code is always 0; this is a diagnostic command, not a gate.`,
 // runDoctor prints a diagnostic table of each LLM CLI's state. Output
 // is structured so a user reading it knows exactly what's needed for
 // each CLI: install it, log in, set an env var, or nothing.
+//
+// All writes go through an errWriter so the first I/O error (broken
+// pipe, disk full, etc.) is preserved and returned at the end —
+// otherwise `local-review doctor > /dev/full` would silently exit 0.
 func runDoctor(out io.Writer) error {
-	fmt.Fprintln(out, "Checking LLM installations and authentication...")
-	fmt.Fprintln(out)
+	w := &errWriter{w: out}
+
+	fmt.Fprintln(w, "Checking LLM installations and authentication...")
+	fmt.Fprintln(w)
 
 	llms := cli.DetectAll()
 
@@ -59,12 +65,32 @@ func runDoctor(out io.Writer) error {
 		if status == statusReady {
 			readyCount++
 		}
-		printLLMRow(out, llm, status, auth)
+		printLLMRow(w, llm, status, auth)
 	}
 
-	fmt.Fprintln(out)
-	fmt.Fprintf(out, "%d/%d LLMs ready for multi-review.\n", readyCount, len(llms))
-	return nil
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "%d/%d LLMs ready for multi-review.\n", readyCount, len(llms))
+	return w.err
+}
+
+// errWriter is an io.Writer that captures the first error from the
+// underlying writer and short-circuits subsequent writes. Lets the
+// caller string together many fmt.Fprintln calls and then check one
+// error at the end.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) Write(p []byte) (int, error) {
+	if ew.err != nil {
+		return 0, ew.err
+	}
+	n, err := ew.w.Write(p)
+	if err != nil {
+		ew.err = err
+	}
+	return n, err
 }
 
 // llmStatus is the consolidated state of an LLM CLI as we want to
@@ -143,8 +169,8 @@ func printInstallInstructions(out io.Writer, name string) {
 		fmt.Fprintln(out, "    then:      claude login   (free tier — uses your claude.ai account)")
 	case "gemini":
 		fmt.Fprintln(out, "    install:   npm install -g @google/gemini-cli  (requires Node.js 20+)")
-		fmt.Fprintln(out, "    then:      gemini /auth   (Google OAuth, free tier)")
-		fmt.Fprintln(out, "    or:        export GEMINI_API_KEY=...   (free at https://aistudio.google.com/apikey)")
+		fmt.Fprintln(out, "    then:      export GEMINI_API_KEY=...   (free at https://aistudio.google.com/apikey)")
+		fmt.Fprintln(out, "    or:        gemini /auth   (Google OAuth, free tier)")
 	case "codex":
 		fmt.Fprintln(out, "    install:   npm install -g @openai/codex")
 		fmt.Fprintln(out, "    then:      codex login   (ChatGPT Plus subscription, $20/mo)")


### PR DESCRIPTION
## Summary

Five small fixes flagged by Copilot and CodeRabbit on PR #30 after it merged. None are blockers — all are consistency / polish issues that should be cleaned up before announcement so the docs and tool output don't contradict each other.

**No `release` label** — these ride along with whatever ships next, not a separate version bump.

## Findings addressed

| # | Source | What | Fix |
|---|---|---|---|
| 1 | CodeRabbit | `CLAUDE.md:32` still said Codex "requires ChatGPT Plus subscription" — contradicts the v0.4.2 release notes that added the OPENAI_API_KEY path | Now mentions both paths with the same cost framing as the rest of the project |
| 2 | Copilot | `README.md:128` auth-table header was "API-key alternative" but Gemini's 3rd column is OAuth (`gemini /auth`), not an API key | Header renamed to "Alternative" |
| 3 | Copilot | `doctor.go:147` Gemini install hint led with `gemini /auth`; README treats `GEMINI_API_KEY` as preferred | Reordered hints + updated long help text to match: API key first, OAuth as "or:" |
| 4 | CodeRabbit (Major) | `runDoctor` discarded every `fmt.Fprintln` error → `local-review doctor > /dev/full` silently exits 0 | Added small `errWriter` wrapper; first underlying error short-circuits subsequent writes and is returned at the end |
| 5 | Copilot | `CHANGELOG.md` had no `[Unreleased]` section despite claiming to follow Keep a Changelog | Added; this PR's entries land there |

## Verification
- `go build ./...`, `go vet ./...`, `go test -race ./...` — all green
- Smoke-tested `local-review doctor` on a real machine — output unchanged for the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAI Codex CLI authentication documentation to include OPENAI_API_KEY environment variable option alongside ChatGPT Plus
  * Clarified Gemini authentication guidance in documentation and CLI help text

* **Bug Fixes**
  * Fixed `local-review doctor` command to properly report I/O write errors instead of always reporting success

<!-- end of auto-generated comment: release notes by coderabbit.ai -->