### PR TITLE
Release v0.4.3: doctor + docs consistency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-04
+
 ### Fixed
 - **CLAUDE.md** Codex auth note now includes the OPENAI_API_KEY path (was claiming "ChatGPT Plus subscription" only — contradicted v0.4.2 release notes).
 - **README.md** auth-table column header renamed `API-key alternative` → `Alternative` to match the Gemini row's contents (which point to OAuth, not an API key).


### PR DESCRIPTION
## Summary

Patch release bundling the five post-v0.4.2 polish fixes already merged to main via PR #31. No new code changes here — this PR only promotes the `[Unreleased]` CHANGELOG entries to a versioned `[0.4.3]` heading and triggers the release pipeline.

## What's in v0.4.3

All from PR #31, none user-impacting in the "broken behavior" sense — all consistency / polish:

1. **CLAUDE.md** Codex auth note now includes the `OPENAI_API_KEY` path (was claiming ChatGPT Plus only — contradicted v0.4.2 release notes).
2. **README.md** auth-table column header renamed `API-key alternative` → `Alternative` to match the Gemini row's content (OAuth, not an API key).
3. **`local-review doctor`** Gemini install hints now lead with `GEMINI_API_KEY` (the README's preferred path) and list `gemini /auth` as the alternative — was reversed.
4. **`local-review doctor`** propagates I/O write errors via a small `errWriter` wrapper. Previously `local-review doctor > /dev/full` would silently exit 0 despite failed writes.
5. **CHANGELOG** added the standard `[Unreleased]` section per Keep a Changelog convention.

## Why a separate PR for this

The fixes themselves merged to main without `release` labels (per [the discipline cheat sheet](docs/RELEASE_PROCESS.md) — they were polish, not user-facing functionality at the time). This PR exists only to bundle them under v0.4.3 and trigger the pipeline. Pure CHANGELOG promotion: 2 lines.

## Verification
- `go build`, `go vet`, `go test -race ./...` — all green (pre-merge)
- `local-review doctor` smoke-tested live after PR #31 merged

## Release labels
`release` + `patch` → ships as v0.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guidance in documentation.
  * Improved local-review doctor command guidance for API key configuration.
  * Corrected table and header formatting in documentation.

* **Bug Fixes**
  * Fixed error handling to prevent failed write operations from reporting success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->