### PR TITLE
Release v0.4.4: clearer 'no API key' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-05-05
+
+### Fixed
+- **Misleading "no API key" error.** Single-LLM commands (`local-review staged|commit|branch`) used to error with `set LOCAL_REVIEW_API_KEY or provider.api_key` regardless of what the user's actual config expected. Setting `OPENAI_API_KEY` (or whatever your `provider.api_key_env` names) and getting the same error anyway was a real first-run trap. The error now names the env var the resolved config is actually reading from, suggests `local-review init` to scaffold a config, and points at `local-review multi <cmd>` as an alternative for users who only have CLI auth (e.g., `claude login`) and no provider API key.
+
 ## [0.4.3] - 2026-05-04
 
 ### Fixed

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -19,20 +19,26 @@ import (
 type Client struct {
 	BaseURL string
 	APIKey  string
-	Model   string
-	HTTP    *http.Client
+	// APIKeyEnv is the name of the env var the key was sourced from.
+	// Surfaced in the empty-key error so users see the right knob to set
+	// (their config may point at OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.,
+	// not the legacy LOCAL_REVIEW_API_KEY default).
+	APIKeyEnv string
+	Model     string
+	HTTP      *http.Client
 }
 
 // New returns a Client with a sensible default timeout.
-func New(baseURL, apiKey, model string, timeoutSec int) *Client {
+func New(baseURL, apiKey, apiKeyEnv, model string, timeoutSec int) *Client {
 	if timeoutSec <= 0 {
 		timeoutSec = 60
 	}
 	return &Client{
-		BaseURL: strings.TrimRight(baseURL, "/"),
-		APIKey:  apiKey,
-		Model:   model,
-		HTTP:    &http.Client{Timeout: time.Duration(timeoutSec) * time.Second},
+		BaseURL:   strings.TrimRight(baseURL, "/"),
+		APIKey:    apiKey,
+		APIKeyEnv: apiKeyEnv,
+		Model:     model,
+		HTTP:      &http.Client{Timeout: time.Duration(timeoutSec) * time.Second},
 	}
 }
 
@@ -71,7 +77,11 @@ type response struct {
 // should still steer the model to JSON.
 func (c *Client) Complete(ctx context.Context, msgs []Message, jsonMode bool) (string, error) {
 	if c.APIKey == "" {
-		return "", fmt.Errorf("no API key configured (set LOCAL_REVIEW_API_KEY or provider.api_key)")
+		envName := c.APIKeyEnv
+		if envName == "" {
+			envName = "LOCAL_REVIEW_API_KEY"
+		}
+		return "", fmt.Errorf("no API key: $%s is empty\n         run `local-review init` to set up a provider, or `export %s=...`\n         or use `local-review multi <cmd>` if you have LLM CLIs installed (see `local-review doctor`)", envName, envName)
 	}
 
 	req := request{

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -19,10 +19,7 @@ import (
 type Client struct {
 	BaseURL string
 	APIKey  string
-	// APIKeyEnv is the name of the env var the key was sourced from.
-	// Surfaced in the empty-key error so users see the right knob to set
-	// (their config may point at OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.,
-	// not the legacy LOCAL_REVIEW_API_KEY default).
+	// APIKeyEnv is the env var the key was sourced from; used in the empty-key error.
 	APIKeyEnv string
 	Model     string
 	HTTP      *http.Client
@@ -81,7 +78,7 @@ func (c *Client) Complete(ctx context.Context, msgs []Message, jsonMode bool) (s
 		if envName == "" {
 			envName = "LOCAL_REVIEW_API_KEY"
 		}
-		return "", fmt.Errorf("no API key: $%s is empty\n         run `local-review init` to set up a provider, or `export %s=...`\n         or use `local-review multi <cmd>` if you have LLM CLIs installed (see `local-review doctor`)", envName, envName)
+		return "", fmt.Errorf("no API key: $%s is unset or empty\n         run `local-review init` to set up a provider, or `export %s=...`\n         or use `local-review multi <cmd>` if you have LLM CLIs installed (see `local-review doctor`)", envName, envName)
 	}
 
 	req := request{

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -15,43 +15,70 @@ import (
 )
 
 func TestNew_DefaultTimeout(t *testing.T) {
-	c := New("https://api.example.com", "sk-x", "gpt-4", 0)
+	c := New("https://api.example.com", "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 0)
 	if c.HTTP.Timeout != 60*time.Second {
 		t.Errorf("default timeout: want 60s, got %v", c.HTTP.Timeout)
 	}
 
-	c = New("https://api.example.com", "sk-x", "gpt-4", -5)
+	c = New("https://api.example.com", "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", -5)
 	if c.HTTP.Timeout != 60*time.Second {
 		t.Errorf("negative timeout should fall back to 60s, got %v", c.HTTP.Timeout)
 	}
 }
 
 func TestNew_CustomTimeout(t *testing.T) {
-	c := New("https://api.example.com", "sk-x", "gpt-4", 30)
+	c := New("https://api.example.com", "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 30)
 	if c.HTTP.Timeout != 30*time.Second {
 		t.Errorf("custom timeout: want 30s, got %v", c.HTTP.Timeout)
 	}
 }
 
 func TestNew_StripsTrailingSlashFromBaseURL(t *testing.T) {
-	c := New("https://api.example.com/v1/", "sk-x", "gpt-4", 0)
+	c := New("https://api.example.com/v1/", "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 0)
 	if c.BaseURL != "https://api.example.com/v1" {
 		t.Errorf("trailing slash not stripped: got %q", c.BaseURL)
 	}
-	c = New("https://api.example.com/v1", "sk-x", "gpt-4", 0)
+	c = New("https://api.example.com/v1", "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 0)
 	if c.BaseURL != "https://api.example.com/v1" {
 		t.Errorf("clean URL altered: got %q", c.BaseURL)
 	}
 }
 
 func TestComplete_NoAPIKeyReturnsError(t *testing.T) {
-	c := New("https://api.example.com", "", "gpt-4", 0)
+	// The error must (a) name the configured env var so users see the
+	// right knob to set, and (b) point at `multi` mode as an alternative
+	// for users who only have CLI auth.
+	c := New("https://api.example.com", "", "OPENAI_API_KEY", "gpt-4", 0)
 	_, err := c.Complete(context.Background(), nil, false)
 	if err == nil {
 		t.Fatal("expected error for missing API key, got nil")
 	}
-	if !strings.Contains(err.Error(), "no API key") {
-		t.Errorf("unexpected error: %v", err)
+	msg := err.Error()
+	if !strings.Contains(msg, "no API key") {
+		t.Errorf("missing 'no API key' phrase: %v", err)
+	}
+	if !strings.Contains(msg, "OPENAI_API_KEY") {
+		t.Errorf("error should name the configured env var, got: %v", err)
+	}
+	if !strings.Contains(msg, "local-review init") {
+		t.Errorf("error should suggest `local-review init`, got: %v", err)
+	}
+	if !strings.Contains(msg, "local-review multi") {
+		t.Errorf("error should suggest `local-review multi` as alternative, got: %v", err)
+	}
+}
+
+func TestComplete_NoAPIKeyFallsBackToLegacyEnvName(t *testing.T) {
+	// When APIKeyEnv is empty (e.g., older callers or buggy config),
+	// the error should fall back to the legacy default rather than
+	// printing "$" with no name.
+	c := New("https://api.example.com", "", "", "gpt-4", 0)
+	_, err := c.Complete(context.Background(), nil, false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "LOCAL_REVIEW_API_KEY") {
+		t.Errorf("empty APIKeyEnv should fall back to LOCAL_REVIEW_API_KEY, got: %v", err)
 	}
 }
 
@@ -92,7 +119,7 @@ func okResponse(content string) http.HandlerFunc {
 
 func TestComplete_SendsExpectedRequestShape(t *testing.T) {
 	m := newMockServer(t, okResponse("hello"))
-	c := New(m.server.URL, "sk-test", "gpt-4o-mini", 5)
+	c := New(m.server.URL, "sk-test", "LOCAL_REVIEW_API_KEY", "gpt-4o-mini", 5)
 
 	got, err := c.Complete(context.Background(), []Message{
 		{Role: "system", Content: "you are a reviewer"},
@@ -142,7 +169,7 @@ func TestComplete_SendsExpectedRequestShape(t *testing.T) {
 
 func TestComplete_JSONModeIncludesResponseFormat(t *testing.T) {
 	m := newMockServer(t, okResponse("{}"))
-	c := New(m.server.URL, "sk-test", "gpt-4o-mini", 5)
+	c := New(m.server.URL, "sk-test", "LOCAL_REVIEW_API_KEY", "gpt-4o-mini", 5)
 
 	_, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, true)
 	if err != nil {
@@ -168,7 +195,7 @@ func TestComplete_4xxWithJSONErrorEnvelope(t *testing.T) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key","type":"auth_error"}}`))
 	})
-	c := New(m.server.URL, "sk-bad", "gpt-4", 5)
+	c := New(m.server.URL, "sk-bad", "LOCAL_REVIEW_API_KEY", "gpt-4", 5)
 
 	_, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false)
 	if err == nil {
@@ -187,7 +214,7 @@ func TestComplete_4xxWithNonJSONBody(t *testing.T) {
 		w.WriteHeader(http.StatusBadGateway)
 		_, _ = w.Write([]byte("upstream timeout"))
 	})
-	c := New(m.server.URL, "sk-x", "gpt-4", 5)
+	c := New(m.server.URL, "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 5)
 
 	_, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false)
 	if err == nil {
@@ -204,7 +231,7 @@ func TestComplete_EmptyChoicesReturnsError(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"choices":[]}`))
 	})
-	c := New(m.server.URL, "sk-x", "gpt-4", 5)
+	c := New(m.server.URL, "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 5)
 
 	_, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false)
 	if err == nil {
@@ -220,7 +247,7 @@ func TestComplete_MalformedJSONResponse(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`not-json`))
 	})
-	c := New(m.server.URL, "sk-x", "gpt-4", 5)
+	c := New(m.server.URL, "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 5)
 
 	_, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false)
 	if err == nil {
@@ -240,7 +267,7 @@ func TestComplete_RespectsContextCancellation(t *testing.T) {
 			_, _ = w.Write([]byte(`{}`))
 		}
 	})
-	c := New(m.server.URL, "sk-x", "gpt-4", 30)
+	c := New(m.server.URL, "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 30)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -269,7 +296,7 @@ func (e *errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 }
 
 func TestComplete_NetworkErrorIncludesURL(t *testing.T) {
-	c := New("http://127.0.0.1:9999", "sk-x", "gpt-4", 5)
+	c := New("http://127.0.0.1:9999", "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 5)
 	// Inject a stub transport so the failure is deterministic and does not
 	// depend on whether port 9999 happens to be unbound in the test environment.
 	c.HTTP.Transport = &errRoundTripper{err: errors.New("connection refused")}
@@ -285,7 +312,7 @@ func TestComplete_NetworkErrorIncludesURL(t *testing.T) {
 
 func TestComplete_BodyContainsMessages(t *testing.T) {
 	m := newMockServer(t, okResponse("ok"))
-	c := New(m.server.URL, "sk-x", "gpt-4", 5)
+	c := New(m.server.URL, "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 5)
 
 	msgs := []Message{
 		{Role: "system", Content: "be terse"},

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -24,7 +24,7 @@ type Reviewer struct {
 func New(cfg config.Config) *Reviewer {
 	return &Reviewer{
 		cfg:    cfg,
-		client: llm.New(cfg.Provider.BaseURL, cfg.Provider.APIKey, cfg.Provider.Model, cfg.Provider.TimeoutSec),
+		client: llm.New(cfg.Provider.BaseURL, cfg.Provider.APIKey, cfg.Provider.APIKeyEnv, cfg.Provider.Model, cfg.Provider.TimeoutSec),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Single-LLM commands (`staged|commit|branch`) now report the env var your **resolved config** is reading from instead of the hardcoded legacy `LOCAL_REVIEW_API_KEY`.
- Error suggests `local-review init` and points at `local-review multi <cmd>` as an alternative for users who only have CLI auth.

## Why

A user who set `OPENAI_API_KEY` (matching the init wizard's OpenAI preset) and ran `local-review branch` saw `set LOCAL_REVIEW_API_KEY or provider.api_key` and had no clue why. The error was hardcoded; it didn't reflect their config. Real first-run trap, hit during dogfooding.

## Before

```
Error: llm: no API key configured (set LOCAL_REVIEW_API_KEY or provider.api_key)
```

## After

```
Error: llm: no API key: $OPENAI_API_KEY is unset or empty
         run `local-review init` to set up a provider, or `export OPENAI_API_KEY=...`
         or use `local-review multi <cmd>` if you have LLM CLIs installed (see `local-review doctor`)
```

## Test plan

- [x] `go test -race ./...` (all green)
- [x] `go vet ./...` (clean)
- [x] Built binary, verified the rendered error end-to-end with `LOCAL_REVIEW_API_KEY="" local-review commit HEAD`
- [x] New tests assert: configured env var name surfaces, `init` and `multi` hints present, fallback to `LOCAL_REVIEW_API_KEY` when `APIKeyEnv` is empty
- [x] Self-reviewed via `local-review multi branch main` — APPROVE, info-level cosmetic notes addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved misleading error messages for missing API keys in single-LLM commands. Error messages now clearly reference the actual configured environment variable and provide helpful guidance, including suggestions to run `local-review init` for setup or use `local-review multi` for CLI-only authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->