### PR TITLE
Release v0.6.0: multi-LLM prompt packs, api_key_env wiring, perf, privacy honesty + Copilot release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,17 @@ jobs:
                   }
                 }
               }')
-          reviews_count=$(echo "$reviews_resp" | jq '[.data.repository.pullRequest.reviews.nodes[] | select(((.author.login // "") | test("copilot"; "i")))] | length')
+          # State filter: a "Copilot reviewed this" claim only counts
+          # for reviews that actually shipped a verdict. Drop:
+          #   - PENDING  : draft, never submitted (doesn't represent any opinion)
+          #   - DISMISSED: was a review, then explicitly invalidated (stale)
+          # Keep:
+          #   - APPROVED, CHANGES_REQUESTED, COMMENTED — all real submissions
+          #     that produced thread state and/or verdicts the maintainer can
+          #     act on. The unresolved-thread check downstream still catches
+          #     the case where Copilot raised concerns and they weren't
+          #     addressed.
+          reviews_count=$(echo "$reviews_resp" | jq '[.data.repository.pullRequest.reviews.nodes[] | select(((.author.login // "") | test("copilot"; "i"))) | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED")] | length')
 
           if [ "$total" = "0" ] && [ "$reviews_count" = "0" ]; then
             echo "::error::Release blocked — no Copilot review or review thread found on PR #${pr_number}."
@@ -338,6 +348,21 @@ jobs:
           path: dist/
           merge-multiple: true
 
+      - name: Generate sha256 checksums manifest
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # Manifest format: `<sha256>  <filename>`, one per line.
+          # That's what `sha256sum -c` and `shasum -a 256 -c` both
+          # consume natively, so install.sh doesn't need to do any
+          # parsing — it just feeds the manifest line to the verifier.
+          # File names match what install.sh expects:
+          # local-review_<version>_checksums.txt
+          cd dist
+          sha256sum local-review_*.tar.gz local-review_*.zip > "local-review_${VERSION}_checksums.txt"
+          echo "--- generated checksums ---"
+          cat "local-review_${VERSION}_checksums.txt"
+
       - name: Create and push tag
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -361,6 +386,7 @@ jobs:
           files: |
             dist/*.tar.gz
             dist/*.zip
+            dist/local-review_*_checksums.txt
 
   update-homebrew:
     needs: [prepare, publish]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,8 +191,32 @@ jobs:
             cursor=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
           done
 
-          if [ "$total" = "0" ]; then
-            echo "::error::Release blocked — no Copilot review found on PR #${pr_number}."
+          # A submitted PR review can exist without any reviewThreads
+          # (Copilot left only a body comment, no inline file comments).
+          # If we keyed "did Copilot review?" off threads alone, that
+          # case would falsely block the release. Cross-check against
+          # the PullRequest.reviews connection — any review object
+          # authored by a *copilot bot is evidence enough that Copilot
+          # ran, even when threads is 0.
+          reviews_resp=$(gh api graphql \
+            -F owner="$owner" -F name="$name" -F num="$pr_number" \
+            -f query='
+              query($owner: String!, $name: String!, $num: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $num) {
+                    reviews(first: 100) {
+                      nodes {
+                        author { login }
+                        state
+                      }
+                    }
+                  }
+                }
+              }')
+          reviews_count=$(echo "$reviews_resp" | jq '[.data.repository.pullRequest.reviews.nodes[] | select(((.author.login // "") | test("copilot"; "i")))] | length')
+
+          if [ "$total" = "0" ] && [ "$reviews_count" = "0" ]; then
+            echo "::error::Release blocked — no Copilot review or review thread found on PR #${pr_number}."
             echo "Either wait for Copilot to complete its review and re-tag, or trigger this"
             echo "workflow manually via workflow_dispatch with an explicit version."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,32 +115,49 @@ jobs:
           # expose isResolved. Each reviewThread groups one or more
           # comments under a resolution state — the conversation as
           # a whole is what gets "resolved" in the UI.
-          threads=$(gh api graphql \
-            -F owner="$owner" -F name="$name" -F num="$pr_number" \
-            -f query='
-              query($owner: String!, $name: String!, $num: Int!) {
-                repository(owner: $owner, name: $name) {
-                  pullRequest(number: $num) {
-                    reviewThreads(first: 100) {
-                      nodes {
-                        isResolved
-                        comments(first: 1) {
-                          nodes { author { login } }
+          #
+          # Pagination matters: a single page returns up to 100 threads.
+          # If hasNextPage is true we'd silently miss unresolved Copilot
+          # threads beyond the first page. Loop until exhausted; only
+          # then trust the totals. Match any bot login containing
+          # "copilot" (case-insensitive) — GitHub has shipped Copilot
+          # review under several bot identities (copilot-pull-request-
+          # reviewer[bot], github-copilot[bot], plain Copilot), and we'd
+          # rather match too broadly than refuse to release because of
+          # a bot rename.
+          total=0
+          unresolved=0
+          cursor=""
+          while :; do
+            page=$(gh api graphql \
+              -F owner="$owner" -F name="$name" -F num="$pr_number" -F cursor="$cursor" \
+              -f query='
+                query($owner: String!, $name: String!, $num: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $num) {
+                      reviewThreads(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          isResolved
+                          comments(first: 1) {
+                            nodes { author { login } }
+                          }
                         }
                       }
                     }
                   }
-                }
-              }')
-
-          # Match any bot login containing "copilot" (case-insensitive).
-          # GitHub has shipped Copilot review under several bot identities
-          # over time — copilot-pull-request-reviewer[bot], github-copilot[bot],
-          # plain Copilot — and we'd rather match too broadly than refuse
-          # to release because of a bot rename.
-          copilot_filter='[.data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].author.login | test("copilot"; "i"))]'
-          total=$(echo "$threads" | jq "$copilot_filter | length")
-          unresolved=$(echo "$threads" | jq "$copilot_filter | map(select(.isResolved == false)) | length")
+                }')
+            copilot_filter='[.data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].author.login | test("copilot"; "i"))]'
+            page_total=$(echo "$page" | jq "$copilot_filter | length")
+            page_unresolved=$(echo "$page" | jq "$copilot_filter | map(select(.isResolved == false)) | length")
+            total=$((total + page_total))
+            unresolved=$((unresolved + page_unresolved))
+            has_next=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+            if [ "$has_next" != "true" ]; then
+              break
+            fi
+            cursor=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+          done
 
           if [ "$total" = "0" ]; then
             echo "::error::Release blocked — no Copilot review found on PR #${pr_number}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,25 +129,57 @@ jobs:
           unresolved=0
           cursor=""
           while :; do
-            page=$(gh api graphql \
-              -F owner="$owner" -F name="$name" -F num="$pr_number" -F cursor="$cursor" \
-              -f query='
-                query($owner: String!, $name: String!, $num: Int!, $cursor: String) {
-                  repository(owner: $owner, name: $name) {
-                    pullRequest(number: $num) {
-                      reviewThreads(first: 100, after: $cursor) {
-                        pageInfo { hasNextPage endCursor }
-                        nodes {
-                          isResolved
-                          comments(first: 1) {
-                            nodes { author { login } }
+            # Build the gh-api invocation. The first iteration must NOT
+            # send a cursor at all — passing `cursor=""` makes the
+            # graphql variable an empty string instead of null, which
+            # GitHub's API rejects (it expects either a real cursor or
+            # the variable absent / null). Build the args slice
+            # accordingly.
+            if [ -z "$cursor" ]; then
+              page=$(gh api graphql \
+                -F owner="$owner" -F name="$name" -F num="$pr_number" \
+                -f query='
+                  query($owner: String!, $name: String!, $num: Int!) {
+                    repository(owner: $owner, name: $name) {
+                      pullRequest(number: $num) {
+                        reviewThreads(first: 100) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            isResolved
+                            comments(first: 1) {
+                              nodes { author { login } }
+                            }
                           }
                         }
                       }
                     }
-                  }
-                }')
-            copilot_filter='[.data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].author.login | test("copilot"; "i"))]'
+                  }')
+            else
+              page=$(gh api graphql \
+                -F owner="$owner" -F name="$name" -F num="$pr_number" -F cursor="$cursor" \
+                -f query='
+                  query($owner: String!, $name: String!, $num: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $name) {
+                      pullRequest(number: $num) {
+                        reviewThreads(first: 100, after: $cursor) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            isResolved
+                            comments(first: 1) {
+                              nodes { author { login } }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }')
+            fi
+            # Null-safe author check: a thread whose first comment has
+            # no author (deleted bot account, or a comment-less thread
+            # GitHub returned for some reason) makes `.login | test()`
+            # crash the entire release job. Coalesce to "" first so the
+            # filter just doesn't match those threads.
+            copilot_filter='[.data.repository.pullRequest.reviewThreads.nodes[] | select(((.comments.nodes[0].author.login // "") | test("copilot"; "i")))]'
             page_total=$(echo "$page" | jq "$copilot_filter | length")
             page_unresolved=$(echo "$page" | jq "$copilot_filter | map(select(.isResolved == false)) | length")
             total=$((total + page_total))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ name: Release
 # Triggered by:
 #   - Push to main, only when the merged PR has a `release` label.
 #     The bump type is read from `major`/`minor`/`patch` labels (default: patch).
+#     ALSO requires a complete Copilot review on the PR with every
+#     Copilot conversation resolved — see the "Verify Copilot review"
+#     step below.
 #   - Manual workflow_dispatch with an explicit version (e.g. v0.1.5).
+#     Bypasses the Copilot gate; the maintainer is taking responsibility.
 #
 # Why combined: GitHub doesn't let GITHUB_TOKEN-pushed events trigger other
 # workflows. Splitting tag/build/publish across multiple workflows broke that
@@ -85,6 +89,73 @@ jobs:
             echo "PR #$pr_number has no 'release' label — skipping"
             echo "should_release=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Verify Copilot review (release-labeled PRs only)
+        # Manual workflow_dispatch is the maintainer's escape hatch — they
+        # set the version explicitly and bypass this gate. Push-triggered
+        # releases (the 99% path) MUST have a complete Copilot review with
+        # every Copilot thread resolved.
+        if: steps.gate.outputs.should_release == 'true' && inputs.version == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          pr_number=$(gh api "/repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
+            --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
+            echo "ERROR: 'release' label set but no PR found for commit ${COMMIT_SHA}"
+            exit 1
+          fi
+
+          owner="${REPO%%/*}"
+          name="${REPO##*/}"
+
+          # GraphQL because the REST review-comments endpoint doesn't
+          # expose isResolved. Each reviewThread groups one or more
+          # comments under a resolution state — the conversation as
+          # a whole is what gets "resolved" in the UI.
+          threads=$(gh api graphql \
+            -F owner="$owner" -F name="$name" -F num="$pr_number" \
+            -f query='
+              query($owner: String!, $name: String!, $num: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $num) {
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                        comments(first: 1) {
+                          nodes { author { login } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }')
+
+          # Match any bot login containing "copilot" (case-insensitive).
+          # GitHub has shipped Copilot review under several bot identities
+          # over time — copilot-pull-request-reviewer[bot], github-copilot[bot],
+          # plain Copilot — and we'd rather match too broadly than refuse
+          # to release because of a bot rename.
+          copilot_filter='[.data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].author.login | test("copilot"; "i"))]'
+          total=$(echo "$threads" | jq "$copilot_filter | length")
+          unresolved=$(echo "$threads" | jq "$copilot_filter | map(select(.isResolved == false)) | length")
+
+          if [ "$total" = "0" ]; then
+            echo "::error::Release blocked — no Copilot review found on PR #${pr_number}."
+            echo "Either wait for Copilot to complete its review and re-tag, or trigger this"
+            echo "workflow manually via workflow_dispatch with an explicit version."
+            exit 1
+          fi
+          if [ "$unresolved" -gt 0 ]; then
+            echo "::error::Release blocked — Copilot has ${unresolved} unresolved review thread(s) on PR #${pr_number}."
+            echo "Resolve each Copilot conversation in the GitHub UI before this release can ship,"
+            echo "or trigger the release manually via workflow_dispatch (after fixing the underlying issues)."
+            exit 1
+          fi
+
+          echo "Copilot review on PR #${pr_number}: ${total} thread(s), all resolved — proceeding"
 
       - name: Determine version
         id: bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-05
+
+### Added
+- **Multi-LLM honors language-specific prompt packs.** Pre-fix, every agent ran with a generic 4-bullet prompt while README claimed pack-aware reviews. Now `lang.Dominant` + `prompts.Get` feed each agent the same Go/TS/Python/Rust pack the single-LLM path uses, with a markdown-output override appended so the merger can consolidate prose across reviewers.
+- **`api_key_env` works end-to-end.** Doctor now reads the configured env var (not the hardcoded canonical default), and invokers inject the resolved key into the subprocess as the canonical name each CLI expects. A user with `api_key_env: MY_GEMINI_KEY` sees ✓ ready and gemini actually authenticates from `$MY_GEMINI_KEY`.
+- **Per-agent model overrides actually take effect** — `--claude-model`, `--gemini-model`, `--codex-model` (plus the matching config fields) are now threaded through to the CLI command line. Pre-v0.6 they were displayed in the roster but never passed to the invoker.
+- **`cli_path` honored** — corporate / nix-store installs at non-standard paths now work (was hardcoded to PATH lookup).
+- **`local-review config` applies CLI flag overrides** as the docs claim (was previously claimed in --help but ignored).
+- **Multi-LLM honors `review.include` / `review.exclude` globs.** Previously the multi path bypassed the filter entirely and reviewed files the user had told it to skip.
+- **`local-review review` (already in v0.5) gains `--only` strictness**: when `--only` matches no ready agents (typo, unauthed agent), the run errors out instead of silently falling back to the configured `provider:` — that fallback would have sent the diff to a different vendor than the one named, a privacy / cost footgun.
+- **Multi-LLM blocking gate has two independent signals**: the merged report AND each per-LLM Output (full, before merger truncation). Defends against a verbose reviewer pushing a Critical finding past the 8 KB merger-input cap.
+- **`install.sh` verifies SHA-256 checksums** of release tarballs. Each release now ships a `checksums.txt` manifest; the installer downloads it alongside the tarball and verifies before extracting. Defends against accidental corruption and basic CDN/MITM tampering. Cosign signing is on the v0.7 roadmap for compromised-release-key defense.
+
+### Changed
+- **`ParseSeverity` defaults to `major` for unknown values** (was `warning`). LLM typos (`"criticl"`, `"sev-high"`, `"BLOCKER"`) used to silently demote out of the blocking range, hiding real findings from the pre-commit hook. Now: unknown → fail-closed at major. **Heads-up:** previously-passing reviews where the LLM emitted a typo'd severity may now block; rerun with the typo corrected, or treat the new failure as the gate working correctly.
+- **JavaScript routes to the TypeScript pack.** No separate `javascript.md` ships — the TS pack covers React/Next.js/Node patterns that apply equally to plain JS.
+- **CodexInvoker uses `codex exec --output-last-message`** instead of bare `codex` (which was launching the interactive TUI in v0.5.0 and aborting every codex review with `exit status 1`).
+- **`--help` banner switched to figlet small font** (~70 cols) so it doesn't garble narrow terminals.
+- **Privacy posture documented honestly.** README's "Privacy" section was overclaiming for default multi-LLM (which fans the diff out to Claude/Gemini/Codex cloud backends). Replaced with a per-mode matrix.
+
+### Fixed
+- **Diff parser preserves deleted-file paths.** `+++ /dev/null` is the standard `git diff` shape for a deleted file; the old parser took the path from `+++` and attributed every deletion to "/dev/null", silently breaking glob filtering and finding attribution.
+- **Diff parser doesn't mistake hunk content for headers.** A deleted SQL comment `-- a/users` rendered inside a hunk as `--- a/users` (with the diff's leading `-`); the old parser matched that as a file header.
+- **Diff parser uses `bufio.Reader` (no per-line cap)** instead of `bufio.Scanner` (4 MB cap → `ErrTooLong` on a single minified-bundle line, aborting the entire review even if globs would have excluded that file).
+- **`parseUnifiedDiff` fails closed on scanner / I/O errors** — a partial-read diff can't satisfy the gate. The earlier "best-effort, swallow" comment was the wrong call.
+- **`parseFindings` brace-counting JSON extractor** instead of first/last-`{` heuristic. The old approach concatenated example + answer when an LLM emitted both, failing to unmarshal.
+- **LLM client caps response at 10 MB.** Defends against runaway providers / spoofed endpoints — the old `io.ReadAll` was unbounded.
+- **LLM client only sets `Authorization: Bearer ...` when a key exists.** Empty-token header used to break local OpenAI-compat servers (Ollama, vLLM) that expect the header absent in unauthenticated mode.
+- **Ollama "no API key" path works.** When `base_url` points at localhost / 127.x / ::1, the empty-key check is skipped — required for the documented fully-offline workflow.
+- **Globs compile once, not per file.** Pre-fix `matchGlob` re-compiled the regex inside the per-file loop; a 500-file diff with 5 globs cost 2,500 compiles. Plus: `**/dist/**` now correctly anchors to a path-segment boundary (was matching `src/mydist/file`), and bracket character classes (`[0-9]`, `[!a-z]`) actually work.
+- **Fail-closed on all-invalid include globs.** Previously `include: ["[!]"]` (and other compile-error patterns) silently *expanded* the review to every file because the empty `includeRE` was treated as "no include filter".
+- **`Authorization` / `--json` / `--min-severity` / `--max-findings` ignored in multi-LLM** — README now states this explicitly instead of "passes them through with a warning". Multi-LLM emits a stderr warning when those flags are set but otherwise drops them; the structured-JSON multi-LLM mode is on the v0.7 roadmap.
+- **`mergeAndPrint` truncates per-review output to 8 KB** before feeding the merger, defending against verbose reviewers blowing the merger's context window. Independent gate signal scans the full per-LLM Output to catch findings past the cutoff.
+- **Git refs are validated** — `--`-prefixed refs (e.g. `local-review commit -c`) and refs with NUL/newline are rejected to defend against `git` flag-injection.
+- **Output write errors propagate** — `WriteText` and `configCmd` no longer silently exit 0 on broken pipe / disk full.
+- **GeminiInvoker / ClaudeInvoker preserve subprocess output on failure** — auth/rate-limit/quota errors no longer collapse to a bare "exit status 1".
+- **Storage SHA normalized** — full and short SHAs hit the same storage key, so re-running with `local-review commit <full-sha>` doesn't create a duplicate artifact.
+- **Detached HEAD review writes to `detached-<short-sha>/`** instead of colliding under `HEAD/`.
+
+### Removed
+- **`LLMConfig.Mode` field**: never wired through to the runtime. yaml.v3 silently ignores stray `mode:` lines, so existing configs keep loading.
+- **JavaScript constant in `internal/lang`** — unused after the JS-→-TypeScript routing.
+
+### CI / release pipeline
+- **Release workflow gates on Copilot review.** Release-labeled PRs that haven't received a Copilot review (or that have unresolved Copilot threads) fail the prepare job loudly instead of tagging silently. Both `PullRequest.reviews` and `reviewThreads` are queried; `PENDING` and `DISMISSED` review states are excluded from the "Copilot reviewed" check.
+- Workflow `paths-ignore` updated to skip docs-only changes.
+- Release workflow generates `local-review_<version>_checksums.txt` and uploads alongside binaries; `install.sh` consumes it.
+
 ## [0.5.1] - 2026-05-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,12 @@ Key constraints:
 3. **OpenAI Codex CLI** — `npm install -g @openai/codex` (auth via `codex login` with ChatGPT Plus, or `OPENAI_API_KEY` env var pay-per-token — usually cheaper for occasional use)
 
 **CLI Invocation Patterns**
-- Codex: `codex review --commit <sha>`
-- Gemini: stdin diff piped to `gemini -p "<prompt>"`
 - Claude: stdin diff piped to `claude` with the review prompt
+- Gemini: short instruction prompt via `-p`, prompt body / diff via stdin (gemini's `-p` content is appended to stdin in headless mode, sidestepping argv-size limits)
+- Codex: `codex exec --output-last-message <tempfile>` with the prompt on stdin. We deliberately do NOT use `codex review --commit <sha>` (the dedicated subcommand) because it re-extracts the diff itself with codex's own settings, conflicting with the orchestrator's "extract once, fan out the same diff string to all agents" contract — that would mean codex sees a different diff than the others and consensus tags become apples-to-oranges.
+
+**Version-probe failures**
+`internal/cli/detector.go` reports an LLM as `Available=false` when the `--version` probe fails (e.g., a CLI changes its banner format and our regex misses). `local-review doctor` surfaces this as the "install broken" state with the resolved binary path, but the runner currently filters silently — an upstream banner change can shrink the active agent set without an error message. Loosen the regex if a real CLI breaks this; for now the doctor row is the diagnostic.
 
 **Storage Structure**
 Reviews saved to `.local-review/reviews/<sanitized-branch>/<commit>_<llm>_<version>.md`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,19 @@ Key constraints:
 - **Git CLI integration only** — no go-git to avoid binary bloat
 - **Hybrid CLI + API mode** — prefer free CLI tools, fallback to API if configured
 
-## v0.1 Multi-LLM Architecture
+## Multi-LLM Architecture (v0.5+)
 
-### Design Decisions (Clarified 2026-05-02)
+### Design Decisions
 
-**Dual Mode: CLI-first with API Fallback**
-- Primary: Use free LLM CLIs (claude, gemini, codex)
-- Fallback: Use API endpoints if CLI unavailable/fails
-- Per-provider configuration allows mixing (e.g., Claude via CLI, GPT via API)
+**Multi-LLM is the default, single-LLM is the fallback**
+- Default: every authenticated LLM CLI (claude, gemini, codex) runs in
+  parallel; findings are merged into one consolidated report.
+- Fallback: when *no* LLM CLI is authenticated, hit the configured
+  `provider:` (any OpenAI-compat endpoint, including local Ollama).
+- The v0.1 plan included an "API fallback when CLI auth fails" inside
+  the multi-LLM path; that idea was abandoned with v0.5.x — `mode:
+  cli|api` was removed from the schema, see do-not-merge/v06-fully-
+  local-ollama-preset.md for the shape it would take if revived.
 
 **Supported LLM CLIs**
 1. **Claude CLI** — `npm install -g @anthropic-ai/claude-code` (auth: `claude login`)
@@ -66,28 +71,27 @@ Reviews saved to `.local-review/reviews/<sanitized-branch>/<commit>_<llm>_<versi
 - Include failure notes in merged.md
 - Skip not-installed LLMs silently (only log installed ones)
 
-**Configuration Schema (v0.1)**
+**Configuration Schema (v0.5+)**
 ```yaml
-# .local-review.yml
+# .local-review.yml — every field is optional; defaults are sensible.
 llms:
   claude:
-    enabled: true
-    mode: cli                    # 'cli' or 'api'
-    cli_path: claude             # auto-detect if empty
-    model: claude-3.5-sonnet
-    api_key_env: ANTHROPIC_API_KEY
+    # enabled: true              # default; omit to use auto-detect
+    cli_path: claude             # path override; defaults to PATH lookup
+    model: claude-opus-4-7       # passed via --model
+    api_key_env: ANTHROPIC_API_KEY  # custom env var for the key
 
   gemini:
-    enabled: true
-    mode: cli
     cli_path: gemini
-    model: gemini-1.5-pro
+    model: gemini-2.0-flash
+    api_key_env: GEMINI_API_KEY
 
   codex:
-    enabled: false               # paid; opt in if you have ChatGPT Plus
-    mode: cli
+    # codex runs by default when authenticated. Set enabled: false to
+    # opt out (e.g., to keep paid-tier billing predictable).
     cli_path: codex
     model: gpt-4
+    api_key_env: OPENAI_API_KEY
 
 merge:
   preferred_llm: auto            # 'auto' or specific LLM name
@@ -96,6 +100,11 @@ merge:
 storage:
   base_path: .local-review/reviews
 ```
+
+The v0.1 schema had a `mode: cli|api` field per LLM. It was never
+wired through to the runtime — the orchestrator always invoked CLIs —
+and was removed in v0.5.x. Existing configs with stray `mode:` lines
+still load (yaml.v3 silently ignores unknown fields).
 
 **Command Structure (v0.5+)**
 ```sh
@@ -165,17 +174,16 @@ npm install -g @anthropic-ai/claude-code
 ### Required Environment
 - Go 1.23+
 - Git CLI available in PATH
-- **v0**: API key set: `export LOCAL_REVIEW_API_KEY=sk-...` (for testing with real providers)
-- **v0.1**: Node.js 20+ and npm (for LLM CLI installations)
+- For single-LLM-fallback testing: `export LOCAL_REVIEW_API_KEY=sk-...`
+- For multi-LLM (default) testing: Node.js 20+ and npm to install at least one of the LLM CLIs
 
-## v0.1 Architecture
+## Multi-LLM Architecture (v0.5+)
 
-### New Packages for Multi-LLM Support
+### Packages
 
 **internal/cli/** — LLM CLI wrapper and detection
-- `detector.go` — Check which LLM CLIs are installed (claude, gemini, codex)
-- `installer.go` — Guide users to install missing CLIs via npm/brew
-- `invoker.go` — Execute CLI commands with proper patterns per LLM
+- `detector.go` — Check which LLM CLIs are installed (claude, gemini, codex); `LLM` struct + `CanonicalAPIKeyEnv` map
+- `invoker.go` — Execute CLI commands with proper patterns per LLM; thread Model + APIKey + systemPrompt
 - `version.go` — Extract CLI version numbers for metadata
 
 **internal/multi/** — Multi-LLM orchestration
@@ -185,9 +193,9 @@ npm install -g @anthropic-ai/claude-code
 - `metadata.go` — Track run details (timestamps, exit codes, versions)
 
 **internal/config/** — Extended configuration
-- Add `LLMs` map with per-provider settings (mode, cli_path, model)
-- Add `Merge` config (preferred_llm, deduplicate)
-- Add `Storage` config (base_path)
+- `LLMs` map with per-agent settings (cli_path, model, api_key_env, timeout)
+- `Merge` config (preferred_llm, deduplicate, consensus_threshold)
+- `Storage` config (base_path)
 
 **cmd/local-review/** — New commands
 - `runner.go` — Unified review dispatcher (multi-LLM with single-LLM fallback)
@@ -255,7 +263,11 @@ npm install -g @anthropic-ai/claude-code
 }
 ```
 
-## v0 Architecture (Current Stable)
+## Single-LLM Fallback Path
+
+Used when no LLM CLI is authenticated. Same code path as the original
+v0 single-LLM design — kept verbatim because it's the simplest way to
+get a review running with just an API key.
 
 ### Configuration Cascade (internal/config/)
 Config is loaded in order of precedence (lowest to highest):

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Distributing to a few hundred engineers? Two patterns work:
 | Single-LLM, `provider.base_url: http://localhost:11434/v1` (Ollama) | **Stays on your machine.** Fully offline. |
 | Single-LLM, any cloud provider (OpenAI, Anthropic, Mistral, etc.) | The provider you configured, over TLS. Their privacy policy applies. |
 | Multi-LLM (default) — Claude / Gemini / Codex CLIs | **Each authenticated CLI calls its own backend** (Anthropic, Google AI, OpenAI). One review fans out to multiple cloud vendors. Your `provider.base_url` is irrelevant in this mode. |
-| Multi-LLM with `--only` restricted to a fully-local agent | (Possible in v0.6+ once the [Ollama multi-agent preset](https://github.com/mshykov/local-review/issues) lands.) |
+| Multi-LLM with `--only` restricted to a fully-local agent | Roadmap. Will be possible once a fully-local-agent preset lands; today every multi-LLM agent (claude / gemini / codex) calls its own cloud backend. |
 
 If you need air-gapped review today, use single-LLM mode against a local Ollama and stay off `local-review review` (which fans out to authenticated cloud CLIs by default).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Reviewer tools today are mostly:
 - **Tied to a vendor** — single-provider lock-in (OpenAI-only or Anthropic-only).
 - **Runtime-heavy** — Node/Python/Java install required just to run the reviewer.
 
-local-review is the opposite: a single static binary, runs locally on a diff, talks to whatever endpoint you configure (OpenAI, Anthropic, Together, Groq, OpenRouter, **Ollama for fully-offline review**), and ships language-aware prompt packs that you can override per-repo.
+local-review is the opposite: a single static binary that runs locally on a diff, sends that diff to whatever LLM(s) you've authenticated, and prints findings. Privacy posture depends on which LLM(s) you point it at — see the [Privacy](#privacy) section for the matrix. **Run with Ollama for fully-offline review.**
 
 ## Install
 
@@ -254,7 +254,16 @@ Distributing to a few hundred engineers? Two patterns work:
 
 ## Privacy
 
-The only network call local-review makes is to the chat-completions endpoint **you configure**. Nothing else — no telemetry, no analytics, no auto-update calls. Run against Ollama and your code never leaves the machine.
+**local-review itself is telemetry-free**: no analytics, no auto-update calls, no signup, no SaaS. The binary makes no network calls of its own. All network traffic is from the LLM(s) *you* authenticate — so what "private" means depends on which LLM(s) you point it at:
+
+| Mode | Where your diff goes |
+|---|---|
+| Single-LLM, `provider.base_url: http://localhost:11434/v1` (Ollama) | **Stays on your machine.** Fully offline. |
+| Single-LLM, any cloud provider (OpenAI, Anthropic, Mistral, etc.) | The provider you configured, over TLS. Their privacy policy applies. |
+| Multi-LLM (default) — Claude / Gemini / Codex CLIs | **Each authenticated CLI calls its own backend** (Anthropic, Google AI, OpenAI). One review fans out to multiple cloud vendors. Your `provider.base_url` is irrelevant in this mode. |
+| Multi-LLM with `--only` restricted to a fully-local agent | (Possible in v0.6+ once the [Ollama multi-agent preset](https://github.com/mshykov/local-review/issues) lands.) |
+
+If you need air-gapped review today, use single-LLM mode against a local Ollama and stay off `local-review review` (which fans out to authenticated cloud CLIs by default).
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,11 @@ Common flags:
 | `--merge-with <agent>` | Pick which agent merges findings (default: auto) |
 | `--model <id>` | Override `provider.model` (single-LLM fallback only) |
 | `--base-url <url>` | Override `provider.base_url` (single-LLM fallback only) |
-| `--min-severity <tier>` | `nit` / `info` / `warning` / `major` / `critical` |
-| `--max-findings <n>` | Cap output |
-| `--json` | Emit JSON (for CI integration) |
+| `--min-severity <tier>` | `nit` / `info` / `warning` / `major` / `critical` (single-LLM fallback only) |
+| `--max-findings <n>` | Cap output (single-LLM fallback only) |
+| `--json` | Emit JSON (single-LLM fallback only — see below) |
+
+In multi-LLM mode the merger returns markdown, not structured findings, so `--json`, `--min-severity`, and `--max-findings` are honored only when no LLM CLI is active and we fall back to the single-LLM `provider:` path. Multi-LLM passes them through with a stderr warning. A structured-JSON multi-LLM mode is parked for v0.6 (see `do-not-merge/v06-json-multi-llm-output.md`).
 
 Config wins by default; flags override config at runtime (e.g., `--only codex` runs codex even if your config sets `codex.enabled: false`).
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Common flags:
 | `--max-findings <n>` | Cap output (single-LLM fallback only) |
 | `--json` | Emit JSON (single-LLM fallback only — see below) |
 
-In multi-LLM mode the merger returns markdown, not structured findings, so `--json`, `--min-severity`, and `--max-findings` are honored only when no LLM CLI is active and we fall back to the single-LLM `provider:` path. Multi-LLM passes them through with a stderr warning. A structured-JSON multi-LLM mode is parked for v0.6 (see `do-not-merge/v06-json-multi-llm-output.md`).
+In multi-LLM mode the merger returns markdown, not structured findings, so `--json`, `--min-severity`, and `--max-findings` are honored only when no LLM CLI is active and we fall back to the single-LLM `provider:` path. Multi-LLM passes them through with a stderr warning. A structured-JSON multi-LLM output mode (where the merger emits both markdown and a JSON envelope) is on the v0.6 roadmap.
 
 Config wins by default; flags override config at runtime (e.g., `--only codex` runs codex even if your config sets `codex.enabled: false`).
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Common flags:
 | `--max-findings <n>` | Cap output (single-LLM fallback only) |
 | `--json` | Emit JSON (single-LLM fallback only — see below) |
 
-In multi-LLM mode the merger returns markdown, not structured findings, so `--json`, `--min-severity`, and `--max-findings` are honored only when no LLM CLI is active and we fall back to the single-LLM `provider:` path. Multi-LLM passes them through with a stderr warning. A structured-JSON multi-LLM output mode (where the merger emits both markdown and a JSON envelope) is on the v0.6 roadmap.
+In multi-LLM mode the merger returns markdown, not structured findings, so `--json`, `--min-severity`, and `--max-findings` are **ignored**: they only take effect in the single-LLM fallback path (when no LLM CLI is authenticated and we hit the configured `provider:` directly). Multi-LLM emits a stderr warning when those flags are passed so you know they had no effect. A structured-JSON multi-LLM output mode (where the merger emits both markdown and a JSON envelope) is on the v0.7 roadmap.
 
 Config wins by default; flags override config at runtime (e.g., `--only codex` runs codex even if your config sets `codex.enabled: false`).
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Distributing to a few hundred engineers? Two patterns work:
 
 ## Privacy
 
-**local-review itself is telemetry-free**: no analytics, no auto-update calls, no signup, no SaaS. The binary makes no network calls of its own. All network traffic is from the LLM(s) *you* authenticate — so what "private" means depends on which LLM(s) you point it at:
+**local-review is telemetry-free**: no analytics, no auto-update calls, no signup, no SaaS. The only network traffic is to the LLM endpoint(s) *you* configure — either an HTTP call from local-review's built-in client (single-LLM mode) or the authenticated CLI subprocesses (multi-LLM mode). What "private" means therefore depends on which LLM(s) you point it at:
 
 | Mode | Where your diff goes |
 |---|---|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ severe and the patch is small.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.x   | :white_check_mark: |
-| 0.4.x   | :grey_question: (severe issues only) |
-| < 0.4   | :x:                |
+| 0.6.x   | :white_check_mark: |
+| 0.5.x   | :grey_question: (severe issues only) |
+| < 0.5   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,14 @@
 
 ## Supported Versions
 
+Only the current release line gets security fixes. Older lines may
+still receive a fix at the maintainer's discretion if the impact is
+severe and the patch is small.
+
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.4.x   | :white_check_mark: |
+| 0.5.x   | :white_check_mark: |
+| 0.4.x   | :grey_question: (severe issues only) |
 | < 0.4   | :x:                |
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,22 @@
 
 ## Supported Versions
 
-Only the current release line gets security fixes. Older lines may
-still receive a fix at the maintainer's discretion if the impact is
-severe and the patch is small.
+| Version | Supported                            |
+| ------- | ------------------------------------ |
+| 0.6.x   | ✅ active line — fixes shipped        |
+| 0.5.x   | ⚠️ exception-only — see policy below |
+| < 0.5   | ❌ unsupported                        |
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.6.x   | :white_check_mark: |
-| 0.5.x   | :grey_question: (severe issues only) |
-| < 0.5   | :x:                |
+**Active line (0.6.x):** every reported vulnerability gets a fix in a
+patch release; the "Security Update Process" below applies as written.
+
+**Exception-only (0.5.x):** a fix is *not* guaranteed. The maintainer
+may backport at their discretion when the impact is severe (remote
+code execution, credential disclosure, supply-chain compromise) AND
+the patch is small. Anything else: upgrade to 0.6.x.
+
+**Unsupported:** report against the last active line. We won't
+investigate or patch.
 
 ## Reporting a Vulnerability
 

--- a/cmd/local-review/config.go
+++ b/cmd/local-review/config.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func configCmd() *cobra.Command {
+func configCmd(sf *sharedFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "config",
 		Short: "Show resolved configuration",
@@ -25,6 +25,11 @@ which settings are being used.`,
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
 			}
+			// Doc claims CLI flags are part of the cascade — apply them
+			// before printing so what the user sees here matches what
+			// `local-review review` would actually use. Pre-fix the
+			// command silently dropped flag overrides on the floor.
+			applyFlagsToConfig(&cfg, sf)
 
 			// Mask API keys before printing (config dumps should be shareable)
 			if cfg.Provider.APIKey != "" {

--- a/cmd/local-review/config.go
+++ b/cmd/local-review/config.go
@@ -44,9 +44,16 @@ which settings are being used.`,
 
 			enc := yaml.NewEncoder(cmd.OutOrStdout())
 			enc.SetIndent(2)
-			defer enc.Close()
 			if err := enc.Encode(cfg); err != nil {
+				_ = enc.Close()
 				return fmt.Errorf("encode config: %w", err)
+			}
+			// Close (not deferred) so a flush failure on a buffered
+			// stdout (broken pipe, disk full, network FS write error)
+			// surfaces as a non-zero exit instead of silently truncating
+			// the YAML output and exiting 0.
+			if err := enc.Close(); err != nil {
+				return fmt.Errorf("flush config output: %w", err)
 			}
 			return nil
 		},

--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -57,7 +57,19 @@ func runDoctor(out io.Writer) error {
 	fmt.Fprintln(w, "Checking LLM installations and authentication...")
 	fmt.Fprintln(w)
 
-	llms := cli.DetectAll()
+	// Mirror the runner: honor cfg.LLMs[*].CLIPath overrides so doctor
+	// and runtime see the same binaries. Without this a user with a
+	// custom cli_path would see ✗ in doctor but a successful run, or
+	// vice versa.
+	overrides := map[string]string{}
+	if cfg, err := loadConfig(); err == nil {
+		for name, c := range cfg.LLMs {
+			if c.CLIPath != "" {
+				overrides[name] = c.CLIPath
+			}
+		}
+	}
+	llms := cli.DetectAllWithOverrides(overrides)
 
 	readyCount := 0
 	for _, llm := range llms {

--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -63,7 +63,17 @@ func runDoctor(out io.Writer) error {
 	// vice versa.
 	overrides := map[string]string{}
 	customEnvVars := map[string]string{}
-	if cfg, err := loadConfig(); err == nil {
+	cfg, cfgErr := loadConfig()
+	if cfgErr != nil {
+		// Surface the failure inline. doctor's whole job is "tell me
+		// what state the user's setup is in"; silently falling back to
+		// defaults here would print cli_path / api_key_env diagnostics
+		// based on built-ins exactly when the user is debugging why
+		// their config isn't taking effect.
+		fmt.Fprintf(w, "WARNING: failed to load config: %v\n", cfgErr)
+		fmt.Fprintln(w, "         Falling back to compiled-in defaults; cli_path / api_key_env shown below may not reflect your config.")
+		fmt.Fprintln(w)
+	} else {
 		for name, c := range cfg.LLMs {
 			if c.CLIPath != "" {
 				overrides[name] = c.CLIPath

--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -62,10 +62,17 @@ func runDoctor(out io.Writer) error {
 	// custom cli_path would see ✗ in doctor but a successful run, or
 	// vice versa.
 	overrides := map[string]string{}
+	customEnvVars := map[string]string{}
 	if cfg, err := loadConfig(); err == nil {
 		for name, c := range cfg.LLMs {
 			if c.CLIPath != "" {
 				overrides[name] = c.CLIPath
+			}
+			// Honor cfg.LLMs[*].APIKeyEnv so a user with a key under,
+			// say, MY_GEMINI_KEY sees ✓ ready instead of "not authed".
+			// Empty falls through to the canonical default per LLM.
+			if c.APIKeyEnv != "" {
+				customEnvVars[name] = c.APIKeyEnv
 			}
 		}
 	}
@@ -73,7 +80,7 @@ func runDoctor(out io.Writer) error {
 
 	readyCount := 0
 	for _, llm := range llms {
-		status, auth := classify(llm)
+		status, auth := classify(llm, customEnvVars[llm.Name])
 		if status == statusReady {
 			readyCount++
 		}
@@ -119,14 +126,19 @@ const (
 
 // classify returns both the bucket and the underlying authStatus so
 // the caller can render either without re-running auth checks.
-func classify(llm cli.LLM) (llmStatus, authStatus) {
+//
+// customEnvVar — when non-empty — replaces the canonical env var name
+// in the auth check (e.g., a config with `api_key_env: MY_GEMINI_KEY`
+// makes us look at $MY_GEMINI_KEY instead of $GEMINI_API_KEY). Empty
+// keeps the canonical default.
+func classify(llm cli.LLM, customEnvVar string) (llmStatus, authStatus) {
 	if !llm.Available {
 		if llm.Path != "" {
 			return statusBrokenInstall, authStatus{}
 		}
 		return statusNotInstalled, authStatus{}
 	}
-	auth := checkAuth(llm.Name)
+	auth := checkAuth(llm.Name, customEnvVar)
 	if !auth.authenticated {
 		return statusNotAuthed, auth
 	}
@@ -208,17 +220,27 @@ type authStatus struct {
 //   - Most CLIs themselves apply the same rule when picking credentials.
 //   - Without this, doctor would lie when a user with a stale OAuth
 //     login exports a fresh API key for testing.
-func checkAuth(name string) authStatus {
+func checkAuth(name, customEnvVar string) authStatus {
 	switch name {
 	case "claude":
-		return checkClaudeAuth()
+		return checkClaudeAuth(customEnvVar)
 	case "gemini":
-		return checkGeminiAuth()
+		return checkGeminiAuth(customEnvVar)
 	case "codex":
-		return checkCodexAuth()
+		return checkCodexAuth(customEnvVar)
 	default:
 		return authStatus{}
 	}
+}
+
+// resolveEnvVar returns customEnvVar when non-empty, otherwise the
+// canonical default for the named LLM. Centralised so the three
+// per-LLM check functions don't each repeat the fallback logic.
+func resolveEnvVar(name, customEnvVar string) string {
+	if customEnvVar != "" {
+		return customEnvVar
+	}
+	return cli.CanonicalAPIKeyEnv[name]
 }
 
 // authHomeDir returns the directory where each CLI stores its auth.
@@ -235,11 +257,12 @@ func authHomeDir() string {
 	return ""
 }
 
-func checkClaudeAuth() authStatus {
-	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+func checkClaudeAuth(customEnvVar string) authStatus {
+	envVar := resolveEnvVar("claude", customEnvVar)
+	if os.Getenv(envVar) != "" {
 		return authStatus{
 			authenticated: true,
-			detail:        "ANTHROPIC_API_KEY env var set",
+			detail:        envVar + " env var set",
 		}
 	}
 	// Claude Code stores tokens in macOS Keychain (or equivalent on
@@ -258,7 +281,7 @@ func checkClaudeAuth() authStatus {
 	}
 	return authStatus{
 		authenticated: false,
-		hint:          "run 'claude login' (free, uses your claude.ai account) — or export ANTHROPIC_API_KEY=...",
+		hint:          fmt.Sprintf("run 'claude login' (free, uses your claude.ai account) — or export %s=...", envVar),
 	}
 }
 
@@ -284,11 +307,12 @@ func hasRecentClaudeSession(sessionsDir string) bool {
 	return false
 }
 
-func checkGeminiAuth() authStatus {
-	if os.Getenv("GEMINI_API_KEY") != "" {
+func checkGeminiAuth(customEnvVar string) authStatus {
+	envVar := resolveEnvVar("gemini", customEnvVar)
+	if os.Getenv(envVar) != "" {
 		return authStatus{
 			authenticated: true,
-			detail:        "GEMINI_API_KEY env var set",
+			detail:        envVar + " env var set",
 		}
 	}
 	// Gemini CLI stores OAuth state in ~/.gemini/google_accounts.json
@@ -309,15 +333,16 @@ func checkGeminiAuth() authStatus {
 	}
 	return authStatus{
 		authenticated: false,
-		hint:          "export GEMINI_API_KEY=... (free at https://aistudio.google.com/apikey) — or run 'gemini /auth' for Google OAuth",
+		hint:          fmt.Sprintf("export %s=... (free at https://aistudio.google.com/apikey) — or run 'gemini /auth' for Google OAuth", envVar),
 	}
 }
 
-func checkCodexAuth() authStatus {
-	if os.Getenv("OPENAI_API_KEY") != "" {
+func checkCodexAuth(customEnvVar string) authStatus {
+	envVar := resolveEnvVar("codex", customEnvVar)
+	if os.Getenv(envVar) != "" {
 		return authStatus{
 			authenticated: true,
-			detail:        "OPENAI_API_KEY env var set",
+			detail:        envVar + " env var set",
 		}
 	}
 	// Codex stores an explicit auth_mode field in ~/.codex/auth.json.
@@ -364,6 +389,6 @@ func checkCodexAuth() authStatus {
 	}
 	return authStatus{
 		authenticated: false,
-		hint:          "run 'codex login' (ChatGPT Plus, $20/mo) — or export OPENAI_API_KEY=... (pay-per-token, usually cheaper)",
+		hint:          fmt.Sprintf("run 'codex login' (ChatGPT Plus, $20/mo) — or export %s=... (pay-per-token, usually cheaper)", envVar),
 	}
 }

--- a/cmd/local-review/doctor_test.go
+++ b/cmd/local-review/doctor_test.go
@@ -38,7 +38,7 @@ func writeFile(t *testing.T, path, content string) {
 
 func TestCheckClaudeAuth_NotAuthenticated(t *testing.T) {
 	withFakeHome(t)
-	got := checkClaudeAuth()
+	got := checkClaudeAuth("")
 	if got.authenticated {
 		t.Errorf("clean home + no env var: expected unauth, got %+v", got)
 	}
@@ -50,7 +50,7 @@ func TestCheckClaudeAuth_NotAuthenticated(t *testing.T) {
 func TestCheckClaudeAuth_RecentSession(t *testing.T) {
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".claude", "sessions", "12345.json"), `{}`)
-	got := checkClaudeAuth()
+	got := checkClaudeAuth("")
 	if !got.authenticated {
 		t.Fatalf("expected authenticated=true, got %+v", got)
 	}
@@ -70,7 +70,7 @@ func TestCheckClaudeAuth_StaleSessionDoesNotCount(t *testing.T) {
 	if err := os.Chtimes(stalePath, old, old); err != nil {
 		t.Fatal(err)
 	}
-	got := checkClaudeAuth()
+	got := checkClaudeAuth("")
 	if got.authenticated {
 		t.Errorf("stale session should not authenticate, got %+v", got)
 	}
@@ -79,7 +79,7 @@ func TestCheckClaudeAuth_StaleSessionDoesNotCount(t *testing.T) {
 func TestCheckClaudeAuth_APIKey(t *testing.T) {
 	withFakeHome(t)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
-	got := checkClaudeAuth()
+	got := checkClaudeAuth("")
 	if !got.authenticated {
 		t.Fatalf("expected authenticated, got %+v", got)
 	}
@@ -94,7 +94,7 @@ func TestCheckClaudeAuth_EnvVarWinsOverSession(t *testing.T) {
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".claude", "sessions", "12345.json"), `{}`)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-fresh")
-	got := checkClaudeAuth()
+	got := checkClaudeAuth("")
 	if !strings.Contains(got.detail, "ANTHROPIC_API_KEY") {
 		t.Errorf("env var should win over session, got %q", got.detail)
 	}
@@ -104,7 +104,7 @@ func TestCheckClaudeAuth_EnvVarWinsOverSession(t *testing.T) {
 
 func TestCheckGeminiAuth_NotAuthenticated(t *testing.T) {
 	withFakeHome(t)
-	got := checkGeminiAuth()
+	got := checkGeminiAuth("")
 	if got.authenticated {
 		t.Errorf("expected unauth, got %+v", got)
 	}
@@ -115,7 +115,7 @@ func TestCheckGeminiAuth_NotAuthenticatedWithEmptyAccountsFile(t *testing.T) {
 	// pre-login state. Must not be reported as authenticated.
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".gemini", "google_accounts.json"), `{"active": null, "old": []}`)
-	got := checkGeminiAuth()
+	got := checkGeminiAuth("")
 	if got.authenticated {
 		t.Errorf("active=null should not count as authenticated, got %+v", got)
 	}
@@ -125,7 +125,7 @@ func TestCheckGeminiAuth_OAuthAccount(t *testing.T) {
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".gemini", "google_accounts.json"),
 		`{"active": "user@example.com", "old": []}`)
-	got := checkGeminiAuth()
+	got := checkGeminiAuth("")
 	if !got.authenticated {
 		t.Fatalf("expected authenticated, got %+v", got)
 	}
@@ -139,9 +139,42 @@ func TestCheckGeminiAuth_APIKeyWinsOverOAuth(t *testing.T) {
 	writeFile(t, filepath.Join(home, ".gemini", "google_accounts.json"),
 		`{"active": "user@example.com", "old": []}`)
 	t.Setenv("GEMINI_API_KEY", "test-key")
-	got := checkGeminiAuth()
+	got := checkGeminiAuth("")
 	if !strings.Contains(got.detail, "GEMINI_API_KEY") {
 		t.Errorf("env var should win, got %q", got.detail)
+	}
+}
+
+func TestCheckGeminiAuth_HonorsCustomEnvVar(t *testing.T) {
+	// A user with `api_key_env: MY_GEMINI_KEY` in config and only that
+	// var exported should see ✓ ready, not "not authenticated". Pre-fix
+	// the auth check hardcoded GEMINI_API_KEY so the configured var was
+	// silently ignored.
+	withFakeHome(t)
+	t.Setenv("MY_GEMINI_KEY", "secret-from-custom-env")
+	got := checkGeminiAuth("MY_GEMINI_KEY")
+	if !got.authenticated {
+		t.Fatalf("expected authenticated via custom env var, got %+v", got)
+	}
+	if !strings.Contains(got.detail, "MY_GEMINI_KEY") {
+		t.Errorf("detail should mention the configured env var, got %q", got.detail)
+	}
+}
+
+func TestCheckGeminiAuth_HintMentionsCustomEnvVar(t *testing.T) {
+	// When the user is unauthed AND has a custom api_key_env configured,
+	// the "fix" hint must point at THEIR env var, not the canonical one
+	// — otherwise the user fixes the wrong knob.
+	withFakeHome(t)
+	got := checkGeminiAuth("MY_GEMINI_KEY")
+	if got.authenticated {
+		t.Fatal("expected unauth, got authenticated")
+	}
+	if !strings.Contains(got.hint, "MY_GEMINI_KEY") {
+		t.Errorf("hint should reference the configured env var, got %q", got.hint)
+	}
+	if strings.Contains(got.hint, "GEMINI_API_KEY") {
+		t.Errorf("hint should NOT reference the canonical default when a custom env is set, got %q", got.hint)
 	}
 }
 
@@ -149,7 +182,7 @@ func TestCheckGeminiAuth_APIKeyWinsOverOAuth(t *testing.T) {
 
 func TestCheckCodexAuth_NotAuthenticated(t *testing.T) {
 	withFakeHome(t)
-	got := checkCodexAuth()
+	got := checkCodexAuth("")
 	if got.authenticated {
 		t.Errorf("expected unauth, got %+v", got)
 	}
@@ -162,7 +195,7 @@ func TestCheckCodexAuth_ChatGPTSubscription(t *testing.T) {
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".codex", "auth.json"),
 		`{"auth_mode": "chatgpt", "OPENAI_API_KEY": null, "tokens": {"id_token": "x"}}`)
-	got := checkCodexAuth()
+	got := checkCodexAuth("")
 	if !got.authenticated {
 		t.Fatalf("expected authenticated, got %+v", got)
 	}
@@ -175,7 +208,7 @@ func TestCheckCodexAuth_ExplicitAPIKeyMode(t *testing.T) {
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".codex", "auth.json"),
 		`{"auth_mode": "api_key", "OPENAI_API_KEY": "sk-stored"}`)
-	got := checkCodexAuth()
+	got := checkCodexAuth("")
 	if !got.authenticated {
 		t.Fatalf("expected authenticated, got %+v", got)
 	}
@@ -191,7 +224,7 @@ func TestCheckCodexAuth_APIKeyModeWithoutStoredKey(t *testing.T) {
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".codex", "auth.json"),
 		`{"auth_mode": "api_key", "OPENAI_API_KEY": null}`)
-	got := checkCodexAuth()
+	got := checkCodexAuth("")
 	if got.authenticated {
 		t.Errorf("api_key mode with null key should not authenticate, got %+v", got)
 	}
@@ -203,7 +236,7 @@ func TestCheckCodexAuth_LegacyAuthFile(t *testing.T) {
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".codex", "auth.json"),
 		`{"OPENAI_API_KEY": "sk-stored"}`)
-	got := checkCodexAuth()
+	got := checkCodexAuth("")
 	if !got.authenticated {
 		t.Errorf("legacy auth file with stored key should authenticate, got %+v", got)
 	}
@@ -214,7 +247,7 @@ func TestCheckCodexAuth_APIKeyEnvWinsOverFile(t *testing.T) {
 	writeFile(t, filepath.Join(home, ".codex", "auth.json"),
 		`{"auth_mode": "chatgpt", "OPENAI_API_KEY": null}`)
 	t.Setenv("OPENAI_API_KEY", "sk-from-env")
-	got := checkCodexAuth()
+	got := checkCodexAuth("")
 	if !strings.Contains(got.detail, "OPENAI_API_KEY") {
 		t.Errorf("env var should win, got %q", got.detail)
 	}
@@ -225,7 +258,7 @@ func TestCheckCodexAuth_GarbageAuthFile(t *testing.T) {
 	// false-positive auth.
 	home := withFakeHome(t)
 	writeFile(t, filepath.Join(home, ".codex", "auth.json"), `not json`)
-	got := checkCodexAuth()
+	got := checkCodexAuth("")
 	if got.authenticated {
 		t.Errorf("garbage auth file should not count as authenticated, got %+v", got)
 	}
@@ -270,7 +303,7 @@ func TestClassify(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setup(t)
-			gotStatus, gotAuth := classify(tc.llm)
+			gotStatus, gotAuth := classify(tc.llm, "")
 			if gotStatus != tc.want {
 				t.Errorf("status: got %v, want %v", gotStatus, tc.want)
 			}

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -132,7 +132,7 @@ See README and https://mshykov.github.io/local-review/ for details.`,
 	root.AddCommand(commitCmd(&sf))
 	root.AddCommand(branchCmd(&sf))
 	root.AddCommand(versionCmd())
-	root.AddCommand(configCmd())
+	root.AddCommand(configCmd(&sf))
 	root.AddCommand(doctorCmd())
 	root.AddCommand(initCmd())
 

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -239,6 +239,15 @@ func runUnifiedReview(ctx context.Context, sf *sharedFlags, mode git.Mode, ref s
 
 	active, configDisabled := pickAgents(cfg, sf)
 	if len(active) == 0 {
+		// `--only` is an explicit allow-list. If the user typed
+		// `--only clude` (typo) or named an unauthenticated agent, the
+		// safe behavior is to error rather than silently fall back to
+		// the configured single-LLM provider — that would send the
+		// diff to a different vendor than the one explicitly named,
+		// which is a privacy / cost / surprise footgun.
+		if sf.only != "" {
+			return fmt.Errorf("--only %q matched no ready LLMs (run `local-review doctor` to see what's authenticated; refusing to fall back to single-LLM since --only is an explicit allow-list)", sf.only)
+		}
 		if len(configDisabled) > 0 {
 			fmt.Fprintf(os.Stderr, "All authenticated LLM CLIs are disabled in config: %v\n", configDisabled)
 			fmt.Fprintln(os.Stderr, "Pass --only <agent> to override config, or run `local-review doctor` for status.")

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -25,22 +25,23 @@ import (
 	"github.com/mshykov/local-review/internal/git"
 )
 
-// banner is the figlet Block-font "LOCAL-REVIEW" art shown atop --help.
-// It's ~120 columns wide and only renders in helpHeader() when stdout
-// is a real TTY ≥ 100 cols; CI logs and narrow tmux panes get a clean
-// text-only header instead.
+// banner is the figlet small-font "LOCAL-REVIEW" art shown atop --help.
+// Small font fits in ~70 columns vs the original block font's ~120, so
+// it stays readable on narrow tmux panes, the `git commit` editor, and
+// most CI logs without wrapping. helpHeader() still suppresses it for
+// non-TTY stdout (pipes/files) so machine-readable callers get clean
+// text.
 const banner = `
-  _|          _|_|      _|_|_|    _|_|    _|              _|_|_|    _|_|_|_|  _|      _|  _|_|_|  _|_|_|_|  _|          _|
-  _|        _|    _|  _|        _|    _|  _|              _|    _|  _|        _|      _|    _|    _|        _|          _|
-  _|        _|    _|  _|        _|_|_|_|  _|  _|_|_|_|_|  _|_|_|    _|_|_|    _|      _|    _|    _|_|_|    _|    _|    _|
-  _|        _|    _|  _|        _|    _|  _|              _|    _|  _|          _|  _|      _|    _|          _|  _|  _|
-  _|_|_|_|    _|_|      _|_|_|  _|    _|  _|_|_|_|        _|    _|  _|_|_|_|      _|      _|_|_|  _|_|_|_|      _|  _|
+   _    ___   ___   _   _       ___ _____   _____ _____      __
+  | |  / _ \ / __| /_\ | |  ___| _ \ __\ \ / /_ _| __\ \    / /
+  | |_| (_) | (__ / _ \| |_|___|   / _| \ V / | || _| \ \/\/ /
+  |____\___/ \___/_/ \_\____|  |_|_\___| \_/ |___|___| \_/\_/
 `
 
 // helpHeader returns the banner when stdout is a wide-enough terminal,
-// or an empty string otherwise. Cobra hard-wraps Long descriptions, so
-// the ~120-col banner becomes unreadable noise on narrower terminals
-// (CI logs, the editor that opens for `git commit`, narrow tmux panes).
+// or an empty string otherwise. The new small-font banner is ~70 cols
+// (was ~120 with block font), so the gate relaxes from 100 → 70 — most
+// terminals comfortably fit it.
 //
 // We use term.GetSize on the stdout fd. $COLUMNS isn't reliable here —
 // shells don't export it to child processes by default, so falling
@@ -51,7 +52,7 @@ func helpHeader() string {
 		return ""
 	}
 	w, _, err := term.GetSize(fd)
-	if err != nil || w < 100 {
+	if err != nil || w < 70 {
 		return ""
 	}
 	return banner + "\n"

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -286,6 +286,14 @@ func applyFlagsToConfig(cfg *config.Config, sf *sharedFlags) {
 	if sf.codexModel != "" {
 		setLLMModel(cfg, "codex", sf.codexModel)
 	}
+
+	// --merge-with overrides merge.preferred_llm. Without this branch,
+	// runtime merge selection honored the flag but `local-review config
+	// --merge-with claude` still printed `merge.preferred_llm: auto`,
+	// which made the preview misleading.
+	if sf.mergeWith != "" {
+		cfg.Merge.PreferredLLM = sf.mergeWith
+	}
 }
 
 func setLLMModel(cfg *config.Config, name, model string) {

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -304,14 +304,20 @@ func mergedHasBlocking(markdown string) bool {
 	return false
 }
 
+// recommendationRE matches the "**Recommendation**: <verdict>" line
+// the merge prompt emits in the Summary block. Pre-compiled at
+// package level so anyPerLLMHasBlocking + mergedHasBlocking don't
+// pay regexp.MustCompile on every per-LLM output (one call per
+// reviewer, but adds up in tests and on big PRs).
+var recommendationRE = regexp.MustCompile(`(?im)^\s*-?\s*\**Recommendation\**\s*:\s*(.+?)\s*$`)
+
 // recommendationIsBlocking parses the "**Recommendation**: <verdict>"
 // line the merge prompt emits in the Summary block. Returns true when
 // the verdict is BLOCK MERGE or REQUEST CHANGES (case-insensitive).
 // APPROVE / unrecognized verdicts return false — the section-content
 // backstop in mergedHasBlocking still runs.
 func recommendationIsBlocking(markdown string) bool {
-	re := regexp.MustCompile(`(?im)^\s*-?\s*\**Recommendation\**\s*:\s*(.+?)\s*$`)
-	m := re.FindStringSubmatch(markdown)
+	m := recommendationRE.FindStringSubmatch(markdown)
 	if m == nil {
 		return false
 	}

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -163,14 +163,14 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	}
 
 	// Per-LLM reviews succeeded but the merge step didn't produce
-	// content (mergeLLM unavailable, merger error, save failed, etc.).
-	// Without a merged report the blocking-finding gate can't run, and
-	// returning nil here would silently exit 0 — a pre-commit hook would
-	// treat the commit as clean even though no gate ever fired. Return
-	// a regular error so the caller exits non-zero (per project policy:
-	// non-zero from tool-failure paths is fail-open in hooks, but the
-	// user sees the message and knows the gate didn't run).
-	if mergedContent == "" {
+	// content (mergeLLM unavailable, merger error, save failed, or the
+	// merger returned only whitespace). Without a merged report the
+	// blocking-finding gate can't run, and returning nil would silently
+	// exit 0 — a pre-commit hook would treat the commit as clean even
+	// though no gate ever fired. TrimSpace (not just == "") catches the
+	// "merger returned `\n`" variant that codex flagged as bypassing the
+	// v0.5.1 fix.
+	if strings.TrimSpace(mergedContent) == "" {
 		return fmt.Errorf("merge step produced no output; per-LLM reviews are saved under %s but the blocking-finding gate did not run", cfg.Storage.BasePath)
 	}
 

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -229,15 +229,44 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 		return fmt.Errorf("merge step produced no output; per-LLM reviews are saved under %s but the blocking-finding gate did not run", cfg.Storage.BasePath)
 	}
 
-	// Restore the pre-commit gate broken by the v0.5 multi-default flip.
-	// Single-LLM has structured findings → exits 2 cleanly. Multi-LLM
-	// merger returns markdown, so we look for non-empty severity
-	// sections to decide whether to fail the commit. Returning the
-	// sentinel (rather than os.Exit) lets cobra and main() unwind defers.
-	if mergedHasBlocking(mergedContent) {
+	// Two independent signals trip the gate (any one is enough). False
+	// positives are preferred over false negatives — over-blocking is
+	// a re-run, under-blocking is a shipped bug.
+	//
+	//  1. The merged markdown — what the merger LLM concluded after
+	//     seeing the (possibly-truncated) per-LLM reviews.
+	//  2. Each per-LLM review's full Output — defends against the
+	//     8 KB merger-input truncation hiding blocking findings past
+	//     the cut. The merger only sees the first 8 KB of each
+	//     reviewer; without this independent check, a verbose
+	//     reviewer that puts a critical finding past byte 8000 would
+	//     produce a false-clean exit. The on-disk per-LLM file has
+	//     always had the full output; this just scans it before we
+	//     decide.
+	//
+	// Returning the sentinel (rather than os.Exit) lets cobra and
+	// main() unwind defers.
+	if mergedHasBlocking(mergedContent) || anyPerLLMHasBlocking(results) {
 		return errBlockingFindings
 	}
 	return nil
+}
+
+// anyPerLLMHasBlocking runs the same heuristic mergedHasBlocking uses
+// against each per-LLM Output, BEFORE the 8 KB truncation that
+// BuildMergeInput applies. If any reviewer raised a Critical / Major
+// finding (or BLOCK MERGE / REQUEST CHANGES verdict), the gate fires
+// even if the truncated merger input dropped it.
+func anyPerLLMHasBlocking(results []multi.ReviewResult) bool {
+	for _, r := range results {
+		if r.Output == "" {
+			continue
+		}
+		if mergedHasBlocking(r.Output) {
+			return true
+		}
+	}
+	return false
 }
 
 // mergedHasBlocking returns true when the merged markdown report

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -113,6 +113,12 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	if err != nil {
 		return fmt.Errorf("extract diff: %w", err)
 	}
+	// Apply review.include/review.exclude before fan-out. The single-
+	// LLM fallback already does this in internal/review/review.go; the
+	// multi-LLM path skipped it pre-v0.5.x, so users with tuned glob
+	// configs (e.g. exclude: ["**/generated/**"]) silently saw the LLM
+	// review their auto-generated files.
+	diffs = review.FilterDiffs(diffs, cfg.Review.IncludeGlobs, cfg.Review.ExcludeGlobs)
 	if len(diffs) == 0 {
 		fmt.Println("No changes to review.")
 		return nil

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -12,8 +12,10 @@ import (
 	"github.com/mshykov/local-review/internal/cli"
 	"github.com/mshykov/local-review/internal/config"
 	"github.com/mshykov/local-review/internal/git"
+	"github.com/mshykov/local-review/internal/lang"
 	"github.com/mshykov/local-review/internal/multi"
 	"github.com/mshykov/local-review/internal/output"
+	"github.com/mshykov/local-review/internal/prompts"
 	"github.com/mshykov/local-review/internal/review"
 )
 
@@ -145,6 +147,19 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	}
 	diffStr := formatDiffForLLM(diffs)
 
+	// Pick the language pack the same way the single-LLM path does
+	// (review.go:43-50). Pre-v0.6.x the multi-LLM path skipped this
+	// entirely — every agent ran with a generic 4-bullet prompt while
+	// the README claimed language-specific packs were applied. Now
+	// each agent gets the same Go/TS/Python/Rust pack the single-LLM
+	// path uses, with a markdown-output override appended (see
+	// multiLLMOutputOverride in cli/invoker.go) so the merger can
+	// consolidate prose across reviewers.
+	systemPrompt, err := selectPromptPack(cfg, diffs)
+	if err != nil {
+		return err
+	}
+
 	commit, branch, err := resolveCommitBranch(mode, ref)
 	if err != nil {
 		return err
@@ -154,7 +169,7 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	storage := multi.NewStorage(cfg.Storage.BasePath)
 	orch := multi.NewOrchestrator(active, storage)
 
-	results, err := orch.RunParallel(ctx, diffStr, commit, branch)
+	results, err := orch.RunParallel(ctx, systemPrompt, diffStr, commit, branch)
 	if err != nil {
 		return fmt.Errorf("run reviews: %w", err)
 	}
@@ -615,4 +630,26 @@ func selectMergeLLM(results []multi.ReviewResult, available []cli.LLM, preferred
 		}
 	}
 	return nil
+}
+
+// selectPromptPack picks the language pack for this multi-LLM run.
+// Mirrors the single-LLM logic in internal/review/review.go: an
+// explicit review.prompt_pack in config wins, otherwise auto-detect
+// from the dominant language across the diff paths. The returned
+// string is the embedded pack content; the markdown-output override
+// is added by each invoker in internal/cli/invoker.go.
+func selectPromptPack(cfg config.Config, diffs []git.Diff) (string, error) {
+	packID := cfg.Review.PromptPack
+	if packID == "" {
+		paths := make([]string, len(diffs))
+		for i, d := range diffs {
+			paths[i] = d.Path
+		}
+		packID = lang.Dominant(paths)
+	}
+	pack, err := prompts.Get(packID)
+	if err != nil {
+		return "", fmt.Errorf("load prompt pack %q: %w", packID, err)
+	}
+	return pack, nil
 }

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -53,7 +53,7 @@ func selectAgents(detected []cli.LLM, ready map[string]bool, cfg config.Config, 
 			if !ready[llm.Name] {
 				continue
 			}
-			active = append(active, withTimeout(llm, cfg))
+			active = append(active, applyConfig(llm, cfg))
 		}
 		return active, nil
 	}
@@ -66,7 +66,7 @@ func selectAgents(detected []cli.LLM, ready map[string]bool, cfg config.Config, 
 			configDisabled = append(configDisabled, llm.Name)
 			continue
 		}
-		active = append(active, withTimeout(llm, cfg))
+		active = append(active, applyConfig(llm, cfg))
 	}
 	return active, configDisabled
 }
@@ -86,9 +86,21 @@ func parseOnlyList(s string) map[string]bool {
 	return out
 }
 
-func withTimeout(llm cli.LLM, cfg config.Config) cli.LLM {
-	if c, ok := cfg.LLMs[llm.Name]; ok && c.TimeoutSec > 0 {
-		llm.TimeoutSec = c.TimeoutSec
+// applyConfig threads per-agent config (model, timeout) onto the
+// detected LLM struct so it reaches the invoker — without this the
+// Detector returns name+path+version only and per-agent --*-model /
+// timeout config is silently dropped on the floor.
+//
+// Renamed from withTimeout to reflect the broader scope; the function
+// now owns "everything from cfg.LLMs[llm.Name] that the invoker needs".
+func applyConfig(llm cli.LLM, cfg config.Config) cli.LLM {
+	if c, ok := cfg.LLMs[llm.Name]; ok {
+		if c.TimeoutSec > 0 {
+			llm.TimeoutSec = c.TimeoutSec
+		}
+		if c.Model != "" {
+			llm.Model = c.Model
+		}
 	}
 	if llm.TimeoutSec == 0 {
 		llm.TimeoutSec = 120
@@ -401,7 +413,7 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 	}
 
 	mergeInput := multi.BuildMergeInput(results, cfg.Merge.ConsensusThreshold)
-	// pickAgents → withTimeout already enforces non-zero TimeoutSec on
+	// pickAgents → applyConfig already enforces non-zero TimeoutSec on
 	// every active LLM. Belt-and-suspenders: keep the explicit fallback
 	// so a future caller that bypasses pickAgents can't silently end up
 	// with `time.Duration(0)` = no timeout = a hung merge LLM hanging

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -26,7 +26,15 @@ var errBlockingFindings = errors.New("blocking findings present")
 // selectAgents with a real cli.DetectAll() + classify() call; tests
 // drive selectAgents directly with synthetic input.
 func pickAgents(cfg config.Config, sf *sharedFlags) (active []cli.LLM, configDisabled []string) {
-	detected := cli.DetectAll()
+	// Honor cfg.LLMs[*].CLIPath when set — corporate / nix-store installs
+	// at non-standard paths can override the default binary name.
+	overrides := make(map[string]string, len(cfg.LLMs))
+	for name, c := range cfg.LLMs {
+		if c.CLIPath != "" {
+			overrides[name] = c.CLIPath
+		}
+	}
+	detected := cli.DetectAllWithOverrides(overrides)
 	ready := make(map[string]bool, len(detected))
 	for _, llm := range detected {
 		status, _ := classify(llm)

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -457,7 +457,9 @@ func runSingleLLMFallback(ctx context.Context, cfg config.Config, sf *sharedFlag
 			return err
 		}
 	} else {
-		output.WriteText(os.Stdout, rep)
+		if err := output.WriteText(os.Stdout, rep); err != nil {
+			return err
+		}
 	}
 
 	if hasBlocking(rep) {

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -417,14 +417,17 @@ func resolveCommitBranch(mode git.Mode, ref string) (string, string, error) {
 	branch := git.CurrentBranch()
 
 	if mode == git.ModeCommit && ref != "" {
-		commit = ref
-		if len(commit) < 40 {
-			resolved := git.ResolveRef(ref)
-			if resolved == "" {
-				return "", "", fmt.Errorf("failed to resolve ref '%s' to commit hash", ref)
-			}
-			commit = resolved
+		// Always resolve, even for full 40-char SHAs — `git rev-parse
+		// --short` normalizes everything (branch name, tag, short hash,
+		// full hash) to the same canonical short form, so the same
+		// commit can't end up under two different storage keys when
+		// the user invokes `local-review commit abc1234` once and
+		// `local-review commit <full-40-char-sha>` another time.
+		resolved := git.ResolveRef(ref)
+		if resolved == "" {
+			return "", "", fmt.Errorf("failed to resolve ref '%s' to commit hash", ref)
 		}
+		commit = resolved
 	}
 
 	if commit == "HEAD" {

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -39,7 +39,14 @@ func pickAgents(cfg config.Config, sf *sharedFlags) (active []cli.LLM, configDis
 	detected := cli.DetectAllWithOverrides(overrides)
 	ready := make(map[string]bool, len(detected))
 	for _, llm := range detected {
-		status, _ := classify(llm)
+		// Mirror doctor: honor cfg.LLMs[*].APIKeyEnv so a user with
+		// a key under a non-canonical env var gets ✓ ready instead
+		// of being silently filtered out.
+		var customEnvVar string
+		if c, ok := cfg.LLMs[llm.Name]; ok {
+			customEnvVar = c.APIKeyEnv
+		}
+		status, _ := classify(llm, customEnvVar)
 		ready[llm.Name] = status == statusReady
 	}
 	return selectAgents(detected, ready, cfg, sf)
@@ -110,6 +117,13 @@ func applyConfig(llm cli.LLM, cfg config.Config) cli.LLM {
 		}
 		if c.Model != "" {
 			llm.Model = c.Model
+		}
+		// APIKey is already resolved from c.APIKeyEnv by
+		// config.resolveAPIKeys() during Load(), so the value is
+		// either the user's custom-env-var key or empty (in which
+		// case the CLI's own auth flow takes over).
+		if c.APIKey != "" {
+			llm.APIKey = c.APIKey
 		}
 	}
 	if llm.TimeoutSec == 0 {

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -211,18 +211,54 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	return nil
 }
 
-// mergedHasBlocking returns true when the merged markdown report has a
-// "## Critical Issues" or "## Major Issues" section with at least one
-// finding (i.e., not just the placeholder *(None)* marker the merge
-// prompt template emits for empty buckets). Used to keep `local-review
-// staged` exiting 2 in a pre-commit hook even though the multi-LLM
-// merger returns prose, not structured findings.
+// mergedHasBlocking returns true when the merged markdown report
+// indicates blocking findings. We use two independent signals so that
+// LLM drift on one shape doesn't silently disable the gate:
+//
+//  1. The Recommendation line in the Summary block. The merge prompt
+//     pins this to "BLOCK MERGE" / "REQUEST CHANGES" / "APPROVE" — both
+//     of the first two count as blocking. Strongest signal because
+//     it's an explicit decision the merger has already made.
+//  2. Any non-placeholder content under a Critical / Major section
+//     heading (with a few common heading variants). Backstop for the
+//     case where the LLM forgets the Recommendation line but still
+//     enumerates findings.
+//
+// Either signal independently trips the gate. False positives are
+// preferred to false negatives — this is a security gate, the cost
+// of over-blocking is a re-run, the cost of under-blocking is a
+// shipped bug.
 func mergedHasBlocking(markdown string) bool {
 	if markdown == "" {
 		return false
 	}
-	return sectionHasContent(markdown, "Critical Issues") ||
-		sectionHasContent(markdown, "Major Issues")
+	if recommendationIsBlocking(markdown) {
+		return true
+	}
+	for _, name := range []string{
+		"Critical Issues", "Critical issues", "CRITICAL ISSUES", "Critical",
+		"Major Issues", "Major issues", "MAJOR ISSUES", "Major",
+	} {
+		if sectionHasContent(markdown, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// recommendationIsBlocking parses the "**Recommendation**: <verdict>"
+// line the merge prompt emits in the Summary block. Returns true when
+// the verdict is BLOCK MERGE or REQUEST CHANGES (case-insensitive).
+// APPROVE / unrecognized verdicts return false — the section-content
+// backstop in mergedHasBlocking still runs.
+func recommendationIsBlocking(markdown string) bool {
+	re := regexp.MustCompile(`(?im)^\s*-?\s*\**Recommendation\**\s*:\s*(.+?)\s*$`)
+	m := re.FindStringSubmatch(markdown)
+	if m == nil {
+		return false
+	}
+	verdict := strings.ToUpper(strings.Trim(m[1], "* `"))
+	return strings.Contains(verdict, "BLOCK MERGE") || strings.Contains(verdict, "REQUEST CHANGES")
 }
 
 // sectionHasContent returns true when a "## <name>" heading has any

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/mshykov/local-review/internal/cli"
 	"github.com/mshykov/local-review/internal/config"
+	"github.com/mshykov/local-review/internal/multi"
 )
 
 // fakeDetected is the standard 3-CLI setup used across selectAgents tests.
@@ -419,6 +421,35 @@ func TestMergedHasBlocking(t *testing.T) {
 // is the user-visible promise: detached HEAD must produce a stable,
 // per-commit synthetic name so storage doesn't collide. A future
 // "just error in detached HEAD" regression should fail this test loudly.
+func TestAnyPerLLMHasBlocking_DefendsAgainstMergerTruncation(t *testing.T) {
+	// MaxReviewBytesForMerge truncates each per-LLM review to 8 KB
+	// before feeding the merger. A reviewer that places a Critical
+	// finding on byte 9000+ would have it dropped from the merger
+	// input → merged output → mergedHasBlocking. The on-disk file
+	// still has it, but the gate would exit 0. Independent
+	// pre-truncation scan closes that gap.
+	clean := "## Summary\n- **Recommendation**: APPROVE\n\n## Critical Issues\n*(None)*\n"
+	withBlock := strings.Repeat("Filler line.\n", 1000) +
+		"\n## Critical Issues\n- **file.go:42** — buffer overflow under load\n"
+
+	if anyPerLLMHasBlocking([]multi.ReviewResult{{LLM: "x", Output: clean}}) {
+		t.Error("clean output should not trip the gate")
+	}
+	if !anyPerLLMHasBlocking([]multi.ReviewResult{{LLM: "x", Output: withBlock}}) {
+		t.Error("blocking finding past 8 KB cutoff must still trip the gate")
+	}
+	mixed := []multi.ReviewResult{
+		{LLM: "a", Output: clean},
+		{LLM: "b", Output: withBlock},
+	}
+	if !anyPerLLMHasBlocking(mixed) {
+		t.Error("any blocking review in the set must trip the gate")
+	}
+	if anyPerLLMHasBlocking([]multi.ReviewResult{{LLM: "x", Output: ""}}) {
+		t.Error("empty review output must not be treated as blocking")
+	}
+}
+
 func TestSyntheticDetachedBranch(t *testing.T) {
 	for _, branch := range []string{"HEAD", "unknown"} {
 		const sha = "abc123def456789012345678901234567890aaaa"

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -366,6 +366,31 @@ func TestMergedHasBlocking(t *testing.T) {
 			md:   "## Critical Issues\nNone.\n\n## Major Issues\n*(None)*\n",
 			want: false,
 		},
+		{
+			name: "Recommendation: BLOCK MERGE blocks even with empty sections",
+			md:   "## Summary\n- **Recommendation**: BLOCK MERGE\n\n## Critical Issues\n*(None)*\n",
+			want: true,
+		},
+		{
+			name: "Recommendation: REQUEST CHANGES blocks too",
+			md:   "## Summary\n**Recommendation**: REQUEST CHANGES\n\n## Critical Issues\n*(None)*\n",
+			want: true,
+		},
+		{
+			name: "Recommendation: APPROVE alone does not block",
+			md:   "## Summary\n- **Recommendation**: APPROVE\n\n## Critical Issues\n*(None)*\n",
+			want: false,
+		},
+		{
+			name: "alternate heading 'Critical' (without 'Issues') with content blocks",
+			md:   "## Critical\n- something is broken at file:42\n\n## Major\n*(None)*\n",
+			want: true,
+		},
+		{
+			name: "ALL-CAPS 'CRITICAL ISSUES' heading still blocks",
+			md:   "## CRITICAL ISSUES\n- file:99 race condition\n",
+			want: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -134,7 +134,7 @@ func TestSelectAgents_OnlyTrimsSpaces(t *testing.T) {
 func TestSelectAgents_TimeoutCarriesOver(t *testing.T) {
 	// Per-LLM timeout from config must be threaded through; previously a
 	// codex review with 240s timeout would silently get the default 120
-	// because withTimeout wasn't called consistently.
+	// because applyConfig wasn't called consistently.
 	ready := map[string]bool{"claude": true}
 	cfg := config.Config{
 		LLMs: map[string]config.LLMConfig{
@@ -150,6 +150,29 @@ func TestSelectAgents_TimeoutCarriesOver(t *testing.T) {
 	}
 	if got != 240 {
 		t.Errorf("claude.TimeoutSec: want 240 (from config), got %d", got)
+	}
+}
+
+func TestSelectAgents_ModelCarriesOver(t *testing.T) {
+	// Per-LLM model from config (or --claude-model flag, which writes
+	// to cfg before pickAgents runs) must reach the runtime LLM struct
+	// so the invoker can pass it on the CLI command line. Pre-fix this
+	// silently dropped on the floor — the roster printed the configured
+	// model but the invoker only saw Path.
+	ready := map[string]bool{"claude": true, "gemini": true, "codex": true}
+	cfg := config.Config{
+		LLMs: map[string]config.LLMConfig{
+			"claude": {Model: "claude-opus-4-7"},
+			"gemini": {Model: "gemini-2.0-flash"},
+			"codex":  {Model: "gpt-5"},
+		},
+	}
+	active, _ := selectAgents(fakeDetected(), ready, cfg, &sharedFlags{})
+	want := map[string]string{"claude": "claude-opus-4-7", "gemini": "gemini-2.0-flash", "codex": "gpt-5"}
+	for _, llm := range active {
+		if llm.Model != want[llm.Name] {
+			t.Errorf("%s.Model: want %q, got %q", llm.Name, want[llm.Name], llm.Model)
+		}
 	}
 }
 

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -353,12 +353,12 @@ func TestMergedHasBlocking(t *testing.T) {
 	}
 }
 
-func TestResolveCommitBranch_DetachedHEADGetsSyntheticName(t *testing.T) {
-	// We can't easily fake git here, so exercise the synthetic-name
-	// codepath directly via the helper logic: when CurrentBranch() returns
-	// "HEAD" (detached) we substitute `detached-<short-sha>`. Pin the
-	// shape so a future "just error in detached HEAD" regression fails
-	// loudly — the v0 path worked there and we promised not to break it.
+// Note: this exercises the syntheticDetachedBranch helper directly,
+// not resolveCommitBranch (which shells out to git). The shape it pins
+// is the user-visible promise: detached HEAD must produce a stable,
+// per-commit synthetic name so storage doesn't collide. A future
+// "just error in detached HEAD" regression should fail this test loudly.
+func TestSyntheticDetachedBranch(t *testing.T) {
 	for _, branch := range []string{"HEAD", "unknown"} {
 		const sha = "abc123def456789012345678901234567890aaaa"
 		got := syntheticDetachedBranch(branch, sha)

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -206,6 +206,19 @@ func TestApplyFlagsToConfig_PerAgentModelOnEmptyMap(t *testing.T) {
 	}
 }
 
+func TestApplyFlagsToConfig_MergeWithReflectsInConfig(t *testing.T) {
+	// `local-review config --merge-with claude` should print the
+	// chosen agent in the rendered YAML's merge.preferred_llm. Pre-fix
+	// applyFlagsToConfig didn't touch Merge, so the preview was
+	// misleading even though runtime merge selection honored the flag.
+	cfg := config.Defaults()
+	sf := &sharedFlags{mergeWith: "claude"}
+	applyFlagsToConfig(&cfg, sf)
+	if cfg.Merge.PreferredLLM != "claude" {
+		t.Errorf("Merge.PreferredLLM: want claude, got %q", cfg.Merge.PreferredLLM)
+	}
+}
+
 func TestApplyFlagsToConfig_v0SingleLLMFlags(t *testing.T) {
 	cfg := config.Defaults()
 	sf := &sharedFlags{

--- a/docs/index.html
+++ b/docs/index.html
@@ -545,7 +545,7 @@
             </svg>
           </div>
           <h3>Privacy First</h3>
-          <p>Your code stays local. No SaaS signup, no telemetry, no data leaving your machine.</p>
+          <p>No SaaS signup, no telemetry, no auto-update calls. Your diff goes only to the LLM(s) you authenticate — point at Ollama for a fully-offline review.</p>
         </div>
         <div class="feature">
           <div class="feature-icon">

--- a/examples/.local-review-multi.yml
+++ b/examples/.local-review-multi.yml
@@ -15,14 +15,12 @@
 llms:
   claude:
     # enabled: true                     # default; omit to use auto-detect
-    mode: cli                           # 'cli' or 'api'
     cli_path: claude                    # auto-detected if empty
     model: claude-3-5-sonnet-20241022
-    api_key_env: ANTHROPIC_API_KEY      # used if CLI auth fails
+    api_key_env: ANTHROPIC_API_KEY      # surfaced in the empty-key error message
     timeout_seconds: 120
 
   gemini:
-    mode: cli
     cli_path: gemini
     model: gemini-1.5-pro
     api_key_env: GEMINI_API_KEY         # free key from https://aistudio.google.com/apikey
@@ -32,7 +30,6 @@ llms:
   # an OpenAI API key (pay-per-token, usually cheaper for occasional use).
   # Runs by default if you've authenticated. Set `enabled: false` to opt out.
   codex:
-    mode: cli
     cli_path: codex
     model: gpt-4
     api_key_env: OPENAI_API_KEY

--- a/install.sh
+++ b/install.sh
@@ -40,9 +40,11 @@ if [ "$VERSION" = "latest" ]; then
   fi
 fi
 
-# ----- Download + install ------------------------------------------------
+# ----- Download + verify + install ---------------------------------------
 asset="local-review_${os}_${arch}.tar.gz"
 url="https://github.com/${REPO}/releases/download/${VERSION}/${asset}"
+checksums="local-review_${VERSION}_checksums.txt"
+checksums_url="https://github.com/${REPO}/releases/download/${VERSION}/${checksums}"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
@@ -50,7 +52,37 @@ trap 'rm -rf "$tmp"' EXIT
 echo "Downloading ${url}"
 curl -fsSL "$url" -o "${tmp}/${asset}"
 
-cd "$tmp"
+# SHA-256 verification before extract. The checksums manifest ships
+# alongside the tarball in every v0.6+ release; for older versions
+# (no manifest) we fall through with a loud warning so the user can
+# still install but knows verification didn't run.
+echo "Downloading ${checksums_url}"
+if curl -fsSL "$checksums_url" -o "${tmp}/${checksums}" 2>/dev/null; then
+  cd "$tmp"
+  if command -v sha256sum >/dev/null 2>&1; then
+    # GNU coreutils (Linux, Homebrew on macOS).
+    if ! grep " ${asset}\$" "$checksums" | sha256sum -c -; then
+      echo "❌ checksum mismatch for ${asset}" >&2
+      echo "   refusing to install — possible tampering or corrupted download" >&2
+      exit 1
+    fi
+  elif command -v shasum >/dev/null 2>&1; then
+    # macOS default: shasum -a 256 -c reads <hash>  <file> lines.
+    if ! grep " ${asset}\$" "$checksums" | shasum -a 256 -c -; then
+      echo "❌ checksum mismatch for ${asset}" >&2
+      echo "   refusing to install — possible tampering or corrupted download" >&2
+      exit 1
+    fi
+  else
+    echo "⚠️  no sha256sum / shasum binary found — skipping integrity check" >&2
+    echo "   install one of: coreutils (sha256sum) or perl (shasum) for tamper resistance" >&2
+  fi
+else
+  echo "⚠️  no checksums.txt for ${VERSION} — skipping integrity check" >&2
+  echo "   (releases before v0.6.0 don't ship a manifest; upgrade to v0.6+ for verified installs)" >&2
+  cd "$tmp"
+fi
+
 tar -xzf "$asset"
 
 mkdir -p "$INSTALL_DIR"

--- a/internal/cli/detector.go
+++ b/internal/cli/detector.go
@@ -16,7 +16,14 @@ type LLM struct {
 	// resolves but whose version probe fails (broken symlink, corrupted
 	// install, missing runtime) is reported Available=false so callers
 	// don't try to invoke an unusable tool.
-	Available  bool
+	Available bool
+	// Model is the agent-specific model id (e.g., "claude-opus-4-7",
+	// "gemini-2.0-flash", "gpt-5"). Threaded through from cfg.LLMs[*]
+	// .Model so per-agent model overrides on the runner actually reach
+	// the invoker — pre-fix the field was set in config and printed in
+	// the roster but the invoker only got Path, so users got false
+	// confirmation that the requested model ran.
+	Model      string
 	TimeoutSec int // timeout in seconds for this LLM (from config)
 }
 

--- a/internal/cli/detector.go
+++ b/internal/cli/detector.go
@@ -23,8 +23,27 @@ type LLM struct {
 	// the invoker — pre-fix the field was set in config and printed in
 	// the roster but the invoker only got Path, so users got false
 	// confirmation that the requested model ran.
-	Model      string
+	Model string
+	// APIKey is the resolved API-key value sourced from
+	// cfg.LLMs[name].APIKeyEnv (or the legacy hard-coded env var when
+	// APIKeyEnv is empty). The invoker injects it into the subprocess
+	// env under the *canonical* variable name each CLI expects
+	// (ANTHROPIC_API_KEY / GEMINI_API_KEY / OPENAI_API_KEY) so users
+	// can stash the key under any env name they like and the agent
+	// still authenticates.
+	APIKey     string
 	TimeoutSec int // timeout in seconds for this LLM (from config)
+}
+
+// CanonicalAPIKeyEnv is the env var each CLI itself reads to find its
+// API key. Doctor uses these as the default check when the user hasn't
+// configured a custom APIKeyEnv; invokers use them as the injection
+// target when the user *has* (so a key in $MY_GEMINI_KEY still ends
+// up as $GEMINI_API_KEY for the gemini subprocess).
+var CanonicalAPIKeyEnv = map[string]string{
+	"claude": "ANTHROPIC_API_KEY",
+	"gemini": "GEMINI_API_KEY",
+	"codex":  "OPENAI_API_KEY",
 }
 
 // DetectAll checks for all supported LLM CLIs and returns their status.

--- a/internal/cli/detector.go
+++ b/internal/cli/detector.go
@@ -28,16 +28,31 @@ type LLM struct {
 }
 
 // DetectAll checks for all supported LLM CLIs and returns their status.
-// Returns a slice of LLM structs, one per supported CLI (even if not found).
-// Runs detections concurrently to avoid sequential timeouts.
+// Returns a slice of LLM structs, one per supported CLI (even if not
+// found). Runs detections concurrently to avoid sequential timeouts.
+//
+// Equivalent to DetectAllWithOverrides(nil) — kept for callers that
+// don't need cli_path overrides (e.g. tests).
 func DetectAll() []LLM {
-	// Map of LLM names to their binary names (for cases where they differ)
-	llmBinaries := map[string]string{
+	return DetectAllWithOverrides(nil)
+}
+
+// DetectAllWithOverrides is DetectAll plus per-LLM cli_path overrides
+// from config (cfg.LLMs[name].CLIPath). An override may be an absolute
+// path (`/opt/corporate/bin/claude`) or a bare binary name; exec.LookPath
+// handles both — anything with a slash bypasses $PATH per Go's docs.
+//
+// Pre-fix the orchestrator detected only the hardcoded `claude` /
+// `gemini` / `codex` binary names, so the cli_path field shipped in
+// every example config was inert. Users with corporate installs at
+// non-standard paths got "✗ not installed" with no path-override
+// escape hatch.
+func DetectAllWithOverrides(overrides map[string]string) []LLM {
+	defaults := map[string]string{
 		"claude": "claude",
 		"gemini": "gemini",
 		"codex":  "codex",
 	}
-
 	llms := []string{"claude", "gemini", "codex"}
 	results := make([]LLM, len(llms))
 	var wg sync.WaitGroup
@@ -46,7 +61,10 @@ func DetectAll() []LLM {
 		wg.Add(1)
 		go func(idx int, llmName string) {
 			defer wg.Done()
-			binaryName := llmBinaries[llmName]
+			binaryName := defaults[llmName]
+			if override, ok := overrides[llmName]; ok && override != "" {
+				binaryName = override
+			}
 			results[idx] = detectWithBinary(llmName, binaryName)
 		}(i, name)
 	}

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -60,23 +60,43 @@ func buildReviewPrompt(systemPrompt string) string {
 	return systemPrompt + multiLLMOutputOverride
 }
 
-// NewInvoker creates an invoker for the given LLM. The Model field on
-// LLM is threaded into each invoker so per-agent --claude-model /
-// --gemini-model / --codex-model flag overrides actually reach the CLI
-// command line. An empty Model leaves the CLI on its default.
+// NewInvoker creates an invoker for the given LLM. The Model and
+// APIKey fields on LLM are threaded into each invoker so per-agent
+// --claude-model / --gemini-model / --codex-model flag overrides
+// actually reach the CLI command line, and so a key sourced from a
+// user-named env var (cfg.LLMs[name].APIKeyEnv) still reaches the
+// subprocess under the canonical name the CLI itself expects.
+// An empty Model leaves the CLI on its default; an empty APIKey
+// means "rely on the CLI's own auth flow / OAuth session."
 //
 // Returns nil if the LLM name is unknown.
 func NewInvoker(llm LLM) Invoker {
 	switch llm.Name {
 	case "claude":
-		return &ClaudeInvoker{path: llm.Path, model: llm.Model}
+		return &ClaudeInvoker{path: llm.Path, model: llm.Model, apiKey: llm.APIKey}
 	case "gemini":
-		return &GeminiInvoker{path: llm.Path, model: llm.Model}
+		return &GeminiInvoker{path: llm.Path, model: llm.Model, apiKey: llm.APIKey}
 	case "codex":
-		return &CodexInvoker{path: llm.Path, model: llm.Model}
+		return &CodexInvoker{path: llm.Path, model: llm.Model, apiKey: llm.APIKey}
 	default:
 		return nil
 	}
+}
+
+// withInjectedKey returns os.Environ() augmented (or overridden) with
+// canonicalEnv=apiKey when apiKey is non-empty. This lets a user keep
+// the key under any env-var name they like in their shell — the CLI
+// always sees the canonical name it knows how to read.
+//
+// Pre-existing env vars set by the parent shell still pass through;
+// our line wins because Go's exec.Cmd uses last-occurrence semantics
+// when the same name appears multiple times.
+func withInjectedKey(canonicalEnv, apiKey string) []string {
+	env := os.Environ()
+	if apiKey == "" {
+		return env
+	}
+	return append(env, canonicalEnv+"="+apiKey)
 }
 
 // CodexInvoker runs the OpenAI Codex CLI.
@@ -94,8 +114,9 @@ func NewInvoker(llm LLM) Invoker {
 // git tree, conflicting with the orchestrator's "extract once, fan out
 // to all LLMs with the same diff string" contract.
 type CodexInvoker struct {
-	path  string
-	model string // codex exec -m <model>; empty = CLI default
+	path   string
+	model  string // codex exec -m <model>; empty = CLI default
+	apiKey string // injected as OPENAI_API_KEY into subprocess env
 }
 
 func (c *CodexInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
@@ -135,6 +156,7 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 	}
 	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
+	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["codex"], c.apiKey)
 	if combined, err := cmd.CombinedOutput(); err != nil {
 		// Surface the CLI's own stderr so users can see "auth required",
 		// "rate limited", etc. instead of a bare "exit status 1".
@@ -151,8 +173,9 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 // GeminiInvoker runs the Google Gemini CLI.
 // Uses: git diff | gemini -p "Review these changes for bugs and security issues"
 type GeminiInvoker struct {
-	path  string
-	model string // gemini -m <model>; empty = CLI default
+	path   string
+	model  string // gemini -m <model>; empty = CLI default
+	apiKey string // injected as GEMINI_API_KEY into subprocess env
 }
 
 func (g *GeminiInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
@@ -165,6 +188,7 @@ func (g *GeminiInvoker) Review(ctx context.Context, systemPrompt, diff string) (
 	}
 	cmd := exec.CommandContext(ctx, g.path, args...)
 	cmd.Stdin = strings.NewReader(buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff)
+	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -187,6 +211,7 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, e
 	}
 	cmd := exec.CommandContext(ctx, g.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
+	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("gemini failed: %w", err)
@@ -197,8 +222,9 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, e
 // ClaudeInvoker runs the Anthropic Claude CLI.
 // Uses stdin pipe similar to Gemini.
 type ClaudeInvoker struct {
-	path  string
-	model string // claude --model <id>; empty = CLI default
+	path   string
+	model  string // claude --model <id>; empty = CLI default
+	apiKey string // injected as ANTHROPIC_API_KEY into subprocess env
 }
 
 func (c *ClaudeInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
@@ -219,6 +245,7 @@ func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (strin
 	}
 	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
+	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["claude"], c.apiKey)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s failed: %w", errLabel, err)

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -15,16 +15,20 @@ type Invoker interface {
 	RunPrompt(ctx context.Context, prompt string) (string, error)
 }
 
-// NewInvoker creates an invoker for the given LLM.
+// NewInvoker creates an invoker for the given LLM. The Model field on
+// LLM is threaded into each invoker so per-agent --claude-model /
+// --gemini-model / --codex-model flag overrides actually reach the CLI
+// command line. An empty Model leaves the CLI on its default.
+//
 // Returns nil if the LLM name is unknown.
 func NewInvoker(llm LLM) Invoker {
 	switch llm.Name {
 	case "claude":
-		return &ClaudeInvoker{path: llm.Path}
+		return &ClaudeInvoker{path: llm.Path, model: llm.Model}
 	case "gemini":
-		return &GeminiInvoker{path: llm.Path}
+		return &GeminiInvoker{path: llm.Path, model: llm.Model}
 	case "codex":
-		return &CodexInvoker{path: llm.Path}
+		return &CodexInvoker{path: llm.Path, model: llm.Model}
 	default:
 		return nil
 	}
@@ -45,7 +49,8 @@ func NewInvoker(llm LLM) Invoker {
 // git tree, conflicting with the orchestrator's "extract once, fan out
 // to all LLMs with the same diff string" contract.
 type CodexInvoker struct {
-	path string
+	path  string
+	model string // codex exec -m <model>; empty = CLI default
 }
 
 func (c *CodexInvoker) Review(ctx context.Context, diff string) (string, error) {
@@ -76,7 +81,11 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 	tmp.Close()
 	defer os.Remove(tmpPath)
 
-	cmd := exec.CommandContext(ctx, c.path, "exec", "--output-last-message", tmpPath)
+	args := []string{"exec", "--output-last-message", tmpPath}
+	if c.model != "" {
+		args = append(args, "-m", c.model)
+	}
+	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	if combined, err := cmd.CombinedOutput(); err != nil {
 		// Surface the CLI's own stderr so users can see "auth required",
@@ -94,7 +103,8 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 // GeminiInvoker runs the Google Gemini CLI.
 // Uses: git diff | gemini -p "Review these changes for bugs and security issues"
 type GeminiInvoker struct {
-	path string
+	path  string
+	model string // gemini -m <model>; empty = CLI default
 }
 
 func (g *GeminiInvoker) Review(ctx context.Context, diff string) (string, error) {
@@ -102,7 +112,11 @@ func (g *GeminiInvoker) Review(ctx context.Context, diff string) (string, error)
 		"Provide specific findings with file names and line numbers. " +
 		"Format as markdown with severity levels (critical, major, warning, info)."
 
-	cmd := exec.CommandContext(ctx, g.path, "-p", prompt)
+	args := []string{"-p", prompt}
+	if g.model != "" {
+		args = append(args, "-m", g.model)
+	}
+	cmd := exec.CommandContext(ctx, g.path, args...)
 	cmd.Stdin = strings.NewReader(diff)
 
 	output, err := cmd.CombinedOutput()
@@ -120,7 +134,11 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, e
 	// goes via stdin — sidestepping ARG_MAX (~256KB on macOS, ~2MB on
 	// Linux) that the previous "whole prompt via -p" implementation hit
 	// on merger prompts that aggregate multiple per-LLM reviews.
-	cmd := exec.CommandContext(ctx, g.path, "-p", "Follow the instructions in stdin.")
+	args := []string{"-p", "Follow the instructions in stdin."}
+	if g.model != "" {
+		args = append(args, "-m", g.model)
+	}
+	cmd := exec.CommandContext(ctx, g.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -132,7 +150,8 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, e
 // ClaudeInvoker runs the Anthropic Claude CLI.
 // Uses stdin pipe similar to Gemini.
 type ClaudeInvoker struct {
-	path string
+	path  string
+	model string // claude --model <id>; empty = CLI default
 }
 
 func (c *ClaudeInvoker) Review(ctx context.Context, diff string) (string, error) {
@@ -144,24 +163,25 @@ func (c *ClaudeInvoker) Review(ctx context.Context, diff string) (string, error)
 		"Provide specific findings with file names and line numbers.\n" +
 		"Format as markdown with severity levels (critical, major, warning, info).\n\n" +
 		"Diff:\n" + diff
-
-	// Use stdin as primary method
-	cmd := exec.CommandContext(ctx, c.path)
-	cmd.Stdin = strings.NewReader(prompt)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("claude review failed: %w", err)
-	}
-
-	return string(output), nil
+	return c.run(ctx, prompt, "claude review")
 }
 
 func (c *ClaudeInvoker) RunPrompt(ctx context.Context, prompt string) (string, error) {
-	cmd := exec.CommandContext(ctx, c.path)
+	return c.run(ctx, prompt, "claude")
+}
+
+// run is the shared driver. Splits args into "model + stdin prompt" so
+// per-agent --claude-model overrides reach the CLI.
+func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (string, error) {
+	var args []string
+	if c.model != "" {
+		args = append(args, "--model", c.model)
+	}
+	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("claude failed: %w", err)
+		return "", fmt.Errorf("%s failed: %w", errLabel, err)
 	}
 	return string(output), nil
 }

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -114,10 +114,14 @@ func (g *GeminiInvoker) Review(ctx context.Context, diff string) (string, error)
 }
 
 func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, error) {
-	// Pass prompt via -p flag (Gemini CLI doesn't read prompts from stdin)
-	// Note: Very large prompts may hit ARG_MAX limits (~2MB on Linux, ~256KB on macOS)
-	// If this becomes an issue, we'd need to investigate alternative invocation patterns
-	cmd := exec.CommandContext(ctx, g.path, "-p", prompt)
+	// gemini's --help: "-p, --prompt: Run in non-interactive mode with
+	// the given prompt. Appended to input on stdin (if any)." So a tiny
+	// marker via -p activates headless mode and the real prompt body
+	// goes via stdin — sidestepping ARG_MAX (~256KB on macOS, ~2MB on
+	// Linux) that the previous "whole prompt via -p" implementation hit
+	// on merger prompts that aggregate multiple per-LLM reviews.
+	cmd := exec.CommandContext(ctx, g.path, "-p", "Follow the instructions in stdin.")
+	cmd.Stdin = strings.NewReader(prompt)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("gemini failed: %w", err)

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -192,7 +192,11 @@ func (g *GeminiInvoker) Review(ctx context.Context, systemPrompt, diff string) (
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("gemini review failed: %w", err)
+		// Surface gemini's own stderr alongside the exit status —
+		// "auth required", "rate limited", "model not found" etc.
+		// otherwise collapse to a bare "exit status 1" that's
+		// impossible to diagnose. Matches the codex invoker.
+		return "", fmt.Errorf("gemini review failed: %w (output: %s)", err, strings.TrimSpace(string(output)))
 	}
 
 	return string(output), nil
@@ -214,7 +218,7 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, e
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("gemini failed: %w", err)
+		return "", fmt.Errorf("gemini failed: %w (output: %s)", err, strings.TrimSpace(string(output)))
 	}
 	return string(output), nil
 }
@@ -248,7 +252,10 @@ func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (strin
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["claude"], c.apiKey)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%s failed: %w", errLabel, err)
+		// Preserve claude's stderr/stdout — auth, rate-limit, and
+		// usage-quota errors otherwise collapse to "exit status 1"
+		// with no actionable signal. Matches the codex invoker.
+		return "", fmt.Errorf("%s failed: %w (output: %s)", errLabel, err, strings.TrimSpace(string(output)))
 	}
 	return string(output), nil
 }

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -30,8 +31,19 @@ func NewInvoker(llm LLM) Invoker {
 }
 
 // CodexInvoker runs the OpenAI Codex CLI.
-// Note: Actual CLI invocation pattern needs verification - current implementation
-// may not work correctly. Disabled by default pending confirmation.
+//
+// Bare `codex` (no subcommand) opens an interactive TUI — that's what the
+// pre-v0.5.1 invoker was doing, which is why every codex review failed
+// with `exit status 1`. We use `codex exec` (non-interactive), pipe the
+// prompt over stdin, and have codex write only the final assistant
+// message to a temp file via --output-last-message. That sidesteps both
+// the interactive-TUI failure AND the noisy "session id / tokens used"
+// preamble that codex exec normally prints to stdout.
+//
+// We deliberately don't use `codex review` (the dedicated review
+// subcommand) because it re-extracts the diff itself from the local
+// git tree, conflicting with the orchestrator's "extract once, fan out
+// to all LLMs with the same diff string" contract.
 type CodexInvoker struct {
 	path string
 }
@@ -45,25 +57,38 @@ func (c *CodexInvoker) Review(ctx context.Context, diff string) (string, error) 
 		"Provide specific findings with file names and line numbers.\n" +
 		"Format as markdown with severity levels (critical, major, warning, info).\n\n" +
 		"Diff:\n" + diff
-
-	cmd := exec.CommandContext(ctx, c.path)
-	cmd.Stdin = strings.NewReader(prompt)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("codex review failed: %w", err)
-	}
-
-	return string(output), nil
+	return c.runExec(ctx, prompt, "codex review")
 }
 
 func (c *CodexInvoker) RunPrompt(ctx context.Context, prompt string) (string, error) {
-	cmd := exec.CommandContext(ctx, c.path)
-	cmd.Stdin = strings.NewReader(prompt)
-	output, err := cmd.CombinedOutput()
+	return c.runExec(ctx, prompt, "codex")
+}
+
+// runExec is the shared `codex exec --output-last-message` driver for
+// Review and RunPrompt. errLabel customises the error prefix so callers
+// can tell "review failed" from "merge failed" in logs.
+func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (string, error) {
+	tmp, err := os.CreateTemp("", "codex-out-*.txt")
 	if err != nil {
-		return "", fmt.Errorf("codex failed: %w", err)
+		return "", fmt.Errorf("%s: create temp output file: %w", errLabel, err)
 	}
-	return string(output), nil
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+
+	cmd := exec.CommandContext(ctx, c.path, "exec", "--output-last-message", tmpPath)
+	cmd.Stdin = strings.NewReader(prompt)
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		// Surface the CLI's own stderr so users can see "auth required",
+		// "rate limited", etc. instead of a bare "exit status 1".
+		return "", fmt.Errorf("%s failed: %w (output: %s)", errLabel, err, strings.TrimSpace(string(combined)))
+	}
+
+	out, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return "", fmt.Errorf("%s: read codex output: %w", errLabel, err)
+	}
+	return string(out), nil
 }
 
 // GeminiInvoker runs the Google Gemini CLI.

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -9,10 +9,55 @@ import (
 )
 
 // Invoker runs an LLM CLI with a diff and returns the review output.
+//
+// Review takes a `systemPrompt` (the language-specific prompt pack
+// content the runner has already loaded via lang.Dominant +
+// prompts.Get) so each agent reviews against the same review-rules,
+// severity tiering, and hard rules the single-LLM path uses. Empty
+// systemPrompt means "fall back to the agent's built-in generic
+// prompt" — useful for tests and as a defensive default.
 type Invoker interface {
-	Review(ctx context.Context, diff string) (string, error)
+	Review(ctx context.Context, systemPrompt, diff string) (string, error)
 	// RunPrompt sends a raw prompt to the LLM without wrapping it in a code-review context
 	RunPrompt(ctx context.Context, prompt string) (string, error)
+}
+
+// multiLLMOutputOverride tells the agent to respond in markdown
+// instead of JSON. The prompt packs mandate JSON output for the
+// single-LLM path (which parses structured findings); multi-LLM
+// agents need to emit markdown so the merger can consolidate prose
+// across reviewers. We append this AFTER the pack so the LLM's most
+// recent instruction wins.
+const multiLLMOutputOverride = `
+
+---
+**Output format for this review**: respond in human-readable markdown
+with severity headings (## Critical Issues, ## Major Issues, ## Warnings,
+## Info / Notes). Each finding: file path + line number, short title,
+brief explanation, suggested fix. Do NOT return JSON — a separate
+merger step will consolidate findings across reviewers.
+`
+
+// buildReviewPrompt assembles the per-agent review prompt from the
+// caller-supplied systemPrompt (a language-specific prompt pack from
+// internal/prompts) and the multi-LLM markdown-output override.
+//
+// An empty systemPrompt falls back to a generic 4-bullet review prompt
+// so the agent still does *something* useful — defends against tests
+// or callers that haven't been updated to pass the pack content. The
+// generic fallback used to be the *default* in every invoker; since
+// v0.6.x the runner threads the pack through, so this is just a safety
+// net.
+func buildReviewPrompt(systemPrompt string) string {
+	if systemPrompt == "" {
+		systemPrompt = "You are a code reviewer. Review the diff below for:\n" +
+			"1. Bugs and logical errors\n" +
+			"2. Security vulnerabilities\n" +
+			"3. Performance issues\n" +
+			"4. Best practices violations\n\n" +
+			"Provide specific findings with file names and line numbers."
+	}
+	return systemPrompt + multiLLMOutputOverride
 }
 
 // NewInvoker creates an invoker for the given LLM. The Model field on
@@ -53,15 +98,8 @@ type CodexInvoker struct {
 	model string // codex exec -m <model>; empty = CLI default
 }
 
-func (c *CodexInvoker) Review(ctx context.Context, diff string) (string, error) {
-	prompt := "You are a code reviewer. Review the following git diff for:\n" +
-		"1. Bugs and logical errors\n" +
-		"2. Security vulnerabilities\n" +
-		"3. Performance issues\n" +
-		"4. Best practices violations\n\n" +
-		"Provide specific findings with file names and line numbers.\n" +
-		"Format as markdown with severity levels (critical, major, warning, info).\n\n" +
-		"Diff:\n" + diff
+func (c *CodexInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
+	prompt := buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff
 	return c.runExec(ctx, prompt, "codex review")
 }
 
@@ -117,17 +155,16 @@ type GeminiInvoker struct {
 	model string // gemini -m <model>; empty = CLI default
 }
 
-func (g *GeminiInvoker) Review(ctx context.Context, diff string) (string, error) {
-	prompt := "Review these code changes for bugs, security issues, and best practices. " +
-		"Provide specific findings with file names and line numbers. " +
-		"Format as markdown with severity levels (critical, major, warning, info)."
-
-	args := []string{"-p", prompt}
+func (g *GeminiInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
+	// gemini's `-p` is appended to stdin in headless mode (per its
+	// --help). Put a marker in -p, route the full pack-prompt + diff
+	// via stdin to dodge ARG_MAX on long pack content.
+	args := []string{"-p", "Follow the instructions in stdin."}
 	if g.model != "" {
 		args = append(args, "-m", g.model)
 	}
 	cmd := exec.CommandContext(ctx, g.path, args...)
-	cmd.Stdin = strings.NewReader(diff)
+	cmd.Stdin = strings.NewReader(buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -164,15 +201,8 @@ type ClaudeInvoker struct {
 	model string // claude --model <id>; empty = CLI default
 }
 
-func (c *ClaudeInvoker) Review(ctx context.Context, diff string) (string, error) {
-	prompt := "You are a code reviewer. Review the following git diff for:\n" +
-		"1. Bugs and logical errors\n" +
-		"2. Security vulnerabilities\n" +
-		"3. Performance issues\n" +
-		"4. Best practices violations\n\n" +
-		"Provide specific findings with file names and line numbers.\n" +
-		"Format as markdown with severity levels (critical, major, warning, info).\n\n" +
-		"Diff:\n" + diff
+func (c *ClaudeInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
+	prompt := buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff
 	return c.run(ctx, prompt, "claude review")
 }
 

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -72,6 +72,16 @@ func (c *CodexInvoker) RunPrompt(ctx context.Context, prompt string) (string, er
 // runExec is the shared `codex exec --output-last-message` driver for
 // Review and RunPrompt. errLabel customises the error prefix so callers
 // can tell "review failed" from "merge failed" in logs.
+//
+// Why a temp file: `codex exec` prints session metadata
+// ("session id: ...", "tokens used", banner output) intermixed with
+// the assistant's reply on stdout. There's no flag for "raw last
+// message to stdout"; --output-last-message is the only documented
+// non-prose path and writes to a file. Parsing the prose stdout is
+// fragile (codex's banner format has changed across minor versions),
+// so we accept the disk I/O — one temp file per review, deleted via
+// defer — as the price of a stable contract. If codex ever ships a
+// stdout-only flag, drop the file.
 func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (string, error) {
 	tmp, err := os.CreateTemp("", "codex-out-*.txt")
 	if err != nil {

--- a/internal/cli/invoker_test.go
+++ b/internal/cli/invoker_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -62,17 +63,11 @@ func TestInvokerInterface(t *testing.T) {
 }
 
 func TestCodexInvoker_Review(t *testing.T) {
-	// This is a unit test with a non-existent path (will fail as expected)
-	// Real integration testing happens in manual testing phase
+	// Unit test with a non-existent path (will fail as expected). Real
+	// integration testing happens in manual testing phase.
 	invoker := &CodexInvoker{path: "/nonexistent/codex"}
 
-	ctx := context.Background()
-	diff := "sample diff"
-
-	_, err := invoker.Review(ctx, diff)
-
-	// Should error because the path doesn't exist
-	if err == nil {
+	if _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
 		t.Error("Expected error with non-existent path, got nil")
 	}
 }
@@ -80,13 +75,7 @@ func TestCodexInvoker_Review(t *testing.T) {
 func TestGeminiInvoker_Review(t *testing.T) {
 	invoker := &GeminiInvoker{path: "/nonexistent/gemini"}
 
-	ctx := context.Background()
-	diff := "sample diff"
-
-	_, err := invoker.Review(ctx, diff)
-
-	// Should error because the path doesn't exist
-	if err == nil {
+	if _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
 		t.Error("Expected error with non-existent path, got nil")
 	}
 }
@@ -94,13 +83,34 @@ func TestGeminiInvoker_Review(t *testing.T) {
 func TestClaudeInvoker_Review(t *testing.T) {
 	invoker := &ClaudeInvoker{path: "/nonexistent/claude"}
 
-	ctx := context.Background()
-	diff := "sample diff"
-
-	_, err := invoker.Review(ctx, diff)
-
-	// Should error because the path doesn't exist
-	if err == nil {
+	if _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
 		t.Error("Expected error with non-existent path, got nil")
 	}
+}
+
+func TestBuildReviewPrompt(t *testing.T) {
+	// Pin the contract every Review() depends on:
+	//   - Empty systemPrompt → falls back to the generic 4-bullet prompt
+	//     (defends against tests / out-of-tree callers that haven't
+	//     learned to pass a pack).
+	//   - Non-empty systemPrompt → that pack content is included verbatim.
+	//   - The markdown-output override is always appended so multi-LLM
+	//     agents emit prose the merger can consolidate, regardless of
+	//     what the pack itself prescribes for output format (the packs
+	//     mandate JSON for the single-LLM path).
+	if got := buildReviewPrompt(""); !contains(got, "code reviewer") || !contains(got, "markdown") {
+		t.Errorf("empty systemPrompt should yield generic prompt + markdown override, got:\n%s", got)
+	}
+	pack := "## Custom Pack\n- Look for SQL injection.\n"
+	got := buildReviewPrompt(pack)
+	if !contains(got, "Custom Pack") {
+		t.Errorf("pack content not preserved verbatim:\n%s", got)
+	}
+	if !contains(got, "Do NOT return JSON") {
+		t.Errorf("markdown-output override not appended:\n%s", got)
+	}
+}
+
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,11 +58,17 @@ type Org struct {
 }
 
 // LLMConfig holds configuration for a single LLM (v0.1+).
+//
+// Note: a `mode: cli|api` field shipped in v0.1's example config but
+// was never wired through to the orchestrator (multi-LLM always
+// invokes via CLI). It was removed in v0.5.x. Existing YAML configs
+// with a `mode:` line still load — yaml.v3 silently ignores unknown
+// fields. The "API fallback when CLI auth fails" idea is parked in
+// do-not-merge/v06-fully-local-ollama-preset.md.
 type LLMConfig struct {
 	Enabled    *bool  `yaml:"enabled"`
-	Mode       string `yaml:"mode"`            // "cli" or "api"
 	CLIPath    string `yaml:"cli_path"`        // path to CLI binary (auto-detect if empty)
-	Model      string `yaml:"model"`           // model name (used in API mode)
+	Model      string `yaml:"model"`           // model name passed to the agent CLI
 	APIKeyEnv  string `yaml:"api_key_env"`     // env var name for API key
 	APIKey     string `yaml:"api_key"`         // DEPRECATED: use environment variable instead
 	TimeoutSec int    `yaml:"timeout_seconds"` // per-call timeout
@@ -105,7 +111,6 @@ func Defaults() Config {
 		LLMs: map[string]LLMConfig{
 			"claude": {
 				Enabled:    boolPtr(true),
-				Mode:       "cli",
 				CLIPath:    "claude",
 				Model:      "claude-3-5-sonnet-20241022",
 				APIKeyEnv:  "ANTHROPIC_API_KEY",
@@ -113,7 +118,6 @@ func Defaults() Config {
 			},
 			"gemini": {
 				Enabled:    boolPtr(true),
-				Mode:       "cli",
 				CLIPath:    "gemini",
 				Model:      "gemini-1.5-pro",
 				APIKeyEnv:  "GEMINI_API_KEY",
@@ -124,7 +128,6 @@ func Defaults() Config {
 				// codex is paid (ChatGPT Plus or pay-per-token via OPENAI_API_KEY),
 				// but we only invoke it when the user has explicitly authenticated,
 				// so running by default doesn't surprise anyone with a bill.
-				Mode:       "cli",
 				CLIPath:    "codex",
 				Model:      "gpt-4",
 				APIKeyEnv:  "OPENAI_API_KEY",
@@ -259,9 +262,6 @@ func merge(dst *Config, src Config) {
 		for name, llmCfg := range src.LLMs {
 			// If LLM exists in dst, merge fields
 			if existing, ok := dst.LLMs[name]; ok {
-				if llmCfg.Mode != "" {
-					existing.Mode = llmCfg.Mode
-				}
 				if llmCfg.CLIPath != "" {
 					existing.CLIPath = llmCfg.CLIPath
 				}
@@ -391,13 +391,6 @@ func (c *Config) Validate() error {
 		}
 		if llm.Enabled != nil && !*llm.Enabled {
 			return fmt.Errorf("merge.preferred_llm '%s' is disabled (must be enabled to use for merging)", c.Merge.PreferredLLM)
-		}
-	}
-
-	// Validate LLM modes
-	for name, llm := range c.LLMs {
-		if llm.Enabled != nil && *llm.Enabled && llm.Mode != "" && llm.Mode != "cli" && llm.Mode != "api" {
-			return fmt.Errorf("llm '%s' has invalid mode '%s' (must be 'cli' or 'api')", name, llm.Mode)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,6 +214,24 @@ func mergeFrom(dst *Config, path string) error {
 // merge does a shallow overlay: any non-zero field in src replaces dst.
 // Slices are replaced wholesale (not appended) so users can override
 // defaults like ExcludeGlobs cleanly.
+//
+// ⚠ MAINTENANCE CONTRACT ⚠
+//
+// This function manually walks every Config field. A reflection-based
+// merger (mergo, etc.) would be terser but the project deliberately
+// avoids vendor SDKs / heavy reflection to keep the binary small and
+// the cascade behavior auditable. The cost is: when you add a field
+// to Config / Provider / Review / LLMConfig / MergeConfig / StorageConfig,
+// you MUST add a corresponding overlay branch here, or user overrides
+// for that field will silently no-op.
+//
+// History: this contract was violated in v0.1 — `LLMConfig.Mode` was
+// added to the schema but never wired through, leaving the documented
+// `mode: api` config inert until v0.5.x.
+//
+// TestMergeCoversAllExportedFields (config_test.go) uses reflection to
+// fail at test time when a new exported field is added without an
+// overlay branch here. Don't bypass the test — extend merge() instead.
 func merge(dst *Config, src Config) {
 	// v0: Provider settings
 	if src.Provider.BaseURL != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -306,24 +306,17 @@ func TestMergeCoversAllExportedFields(t *testing.T) {
 	merge(&dst, src)
 
 	missing := findZeroFields(reflect.ValueOf(dst), "")
-	// Filter out fields we deliberately don't merge: the deprecated
-	// inline APIKey on Provider/LLMConfig (security warning emits a
-	// stderr nudge instead — copying it through merge would entrench
-	// the anti-pattern) and CLIPath on LLMConfig because Defaults
-	// already populates it (merge is overlay-only when src is non-zero).
-	var actual []string
-	for _, f := range missing {
-		if f == "Provider.APIKey" || strings.HasSuffix(f, ".APIKey") {
-			continue
-		}
-		actual = append(actual, f)
-	}
-
-	if len(actual) > 0 {
+	// merge() actually DOES copy the deprecated inline APIKey field
+	// for v0.4.x backward compat — a user with `api_key:` in their
+	// YAML still works, and warnDeprecatedAPIKeys nudges them toward
+	// env vars via stderr instead of silently dropping their key.
+	// So nothing is filtered out; if any exported field is missing,
+	// merge() needs an overlay branch.
+	if len(missing) > 0 {
 		t.Errorf("merge() didn't propagate these fields:\n  %s\n\n"+
 			"Add an overlay branch in merge() for each one. See the\n"+
 			"MAINTENANCE CONTRACT comment above merge().",
-			strings.Join(actual, "\n  "))
+			strings.Join(missing, "\n  "))
 	}
 }
 
@@ -337,7 +330,7 @@ func nonZeroConfig() Config {
 		Provider: Provider{
 			BaseURL:    "https://example.test/v1",
 			Model:      "test-model",
-			APIKey:     "sk-test", // deliberately set; merge() skips, contract OK
+			APIKey:     "sk-test", // merge() does copy this for v0.4.x compat; warnDeprecatedAPIKeys nudges
 			APIKeyEnv:  "TEST_KEY",
 			TimeoutSec: 99,
 		},
@@ -357,7 +350,7 @@ func nonZeroConfig() Config {
 				CLIPath:    "/opt/test/claude",
 				Model:      "claude-test",
 				APIKeyEnv:  "TEST_ANTHROPIC",
-				APIKey:     "sk-test", // deliberately set; merge() skips
+				APIKey:     "sk-test", // merge() copies for v0.4.x compat; deprecated, warnings nudge to env
 				TimeoutSec: 240,
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -285,4 +287,126 @@ func TestValidate_StrayModeFieldIsIgnored(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("Validate failed on default config: %v", err)
 	}
+}
+
+// TestMergeCoversAllExportedFields enforces the maintenance contract
+// documented above merge(): every exported field on Config and its
+// nested structs must be wired into the overlay logic.
+//
+// Strategy: synthesize a `src` Config where every exported field has
+// a non-zero sentinel, merge onto a zeroed `dst`, then walk the result
+// via reflection and fail loudly on any field that's still its zero
+// value. Catches the "added field, forgot overlay branch" footgun the
+// reviewer flagged — `LLMConfig.Mode` shipped that way for several
+// minor releases until v0.5.x. The test costs nothing at runtime;
+// drift is caught the moment a new field lands.
+func TestMergeCoversAllExportedFields(t *testing.T) {
+	src := nonZeroConfig()
+	var dst Config
+	merge(&dst, src)
+
+	missing := findZeroFields(reflect.ValueOf(dst), "")
+	// Filter out fields we deliberately don't merge: the deprecated
+	// inline APIKey on Provider/LLMConfig (security warning emits a
+	// stderr nudge instead — copying it through merge would entrench
+	// the anti-pattern) and CLIPath on LLMConfig because Defaults
+	// already populates it (merge is overlay-only when src is non-zero).
+	var actual []string
+	for _, f := range missing {
+		if f == "Provider.APIKey" || strings.HasSuffix(f, ".APIKey") {
+			continue
+		}
+		actual = append(actual, f)
+	}
+
+	if len(actual) > 0 {
+		t.Errorf("merge() didn't propagate these fields:\n  %s\n\n"+
+			"Add an overlay branch in merge() for each one. See the\n"+
+			"MAINTENANCE CONTRACT comment above merge().",
+			strings.Join(actual, "\n  "))
+	}
+}
+
+// nonZeroConfig returns a Config where every exported (non-deprecated)
+// field is set to a unique non-zero value. Sentinel values aren't
+// meaningful — we only assert presence after merge.
+func nonZeroConfig() Config {
+	enabled := true
+	dedup := true
+	return Config{
+		Provider: Provider{
+			BaseURL:    "https://example.test/v1",
+			Model:      "test-model",
+			APIKey:     "sk-test", // deliberately set; merge() skips, contract OK
+			APIKeyEnv:  "TEST_KEY",
+			TimeoutSec: 99,
+		},
+		Review: Review{
+			MinSeverity:  "major",
+			MaxFindings:  42,
+			IncludeGlobs: []string{"**/*.go"},
+			ExcludeGlobs: []string{"**/vendor/**"},
+			PromptPack:   "go",
+		},
+		Org: Org{
+			ConfigURL: "https://internal.test/lr.yml",
+		},
+		LLMs: map[string]LLMConfig{
+			"claude": {
+				Enabled:    &enabled,
+				CLIPath:    "/opt/test/claude",
+				Model:      "claude-test",
+				APIKeyEnv:  "TEST_ANTHROPIC",
+				APIKey:     "sk-test", // deliberately set; merge() skips
+				TimeoutSec: 240,
+			},
+		},
+		Merge: MergeConfig{
+			PreferredLLM:       "claude",
+			Deduplicate:        &dedup,
+			ConsensusThreshold: 7,
+		},
+		Storage: StorageConfig{
+			BasePath: "/tmp/test-reviews",
+		},
+	}
+}
+
+// findZeroFields walks v's exported fields and returns dotted paths of
+// any that are still their zero value. Used to detect merge() drift.
+func findZeroFields(v reflect.Value, prefix string) []string {
+	var out []string
+	switch v.Kind() {
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			fv := v.Field(i)
+			ft := t.Field(i)
+			if !ft.IsExported() {
+				continue
+			}
+			path := prefix + ft.Name
+			out = append(out, findZeroFields(fv, path+".")...)
+		}
+	case reflect.Map:
+		if v.Len() == 0 {
+			out = append(out, strings.TrimSuffix(prefix, "."))
+			return out
+		}
+		// Recurse into one entry — sufficient to catch "the inner struct
+		// type isn't fully merged"; we don't need to walk every key.
+		for _, k := range v.MapKeys() {
+			out = append(out, findZeroFields(v.MapIndex(k), prefix+k.String()+".")...)
+			break
+		}
+	case reflect.Pointer:
+		if v.IsNil() {
+			out = append(out, strings.TrimSuffix(prefix, "."))
+		}
+	default:
+		if v.IsZero() {
+			out = append(out, strings.TrimSuffix(prefix, "."))
+		}
+	}
+	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -141,11 +141,10 @@ func TestMergeReplaces_V01(t *testing.T) {
 		LLMs: map[string]LLMConfig{
 			"claude": {
 				Enabled: boolPtr(false), // disable claude
-				Mode:    "api",
+				Model:   "claude-3-haiku",
 			},
 			"custom": {
 				Enabled:    boolPtr(true),
-				Mode:       "cli",
 				CLIPath:    "custom-llm",
 				TimeoutSec: 60,
 			},
@@ -164,8 +163,8 @@ func TestMergeReplaces_V01(t *testing.T) {
 	if dst.LLMs["claude"].Enabled != nil && *dst.LLMs["claude"].Enabled {
 		t.Error("claude should be disabled after merge")
 	}
-	if dst.LLMs["claude"].Mode != "api" {
-		t.Errorf("claude mode = %q, want api", dst.LLMs["claude"].Mode)
+	if dst.LLMs["claude"].Model != "claude-3-haiku" {
+		t.Errorf("claude model = %q, want claude-3-haiku", dst.LLMs["claude"].Model)
 	}
 
 	// Check that custom LLM was added
@@ -208,7 +207,6 @@ llms:
   claude:
     enabled: false
   gemini:
-    mode: api
     model: gemini-1.5-flash
 merge:
   preferred_llm: gemini
@@ -227,9 +225,6 @@ storage:
 	// Check that LLMs were merged
 	if cfg.LLMs["claude"].Enabled != nil && *cfg.LLMs["claude"].Enabled {
 		t.Error("claude should be disabled")
-	}
-	if cfg.LLMs["gemini"].Mode != "api" {
-		t.Errorf("gemini mode = %q, want api", cfg.LLMs["gemini"].Mode)
 	}
 	if cfg.LLMs["gemini"].Model != "gemini-1.5-flash" {
 		t.Errorf("gemini model = %q", cfg.LLMs["gemini"].Model)
@@ -280,14 +275,14 @@ func TestValidate_InvalidPreferredLLM(t *testing.T) {
 	}
 }
 
-func TestValidate_InvalidMode(t *testing.T) {
+func TestValidate_StrayModeFieldIsIgnored(t *testing.T) {
+	// `mode:` was removed from LLMConfig in v0.5.x — it shipped in the
+	// v0.1 example but was never wired through to the orchestrator.
+	// Existing user YAML configs with `mode: cli|api|whatever` lines
+	// must keep loading: yaml.v3 silently drops unknown fields, and
+	// Validate must not refuse to start because of this legacy line.
 	cfg := Defaults()
-	claude := cfg.LLMs["claude"]
-	claude.Mode = "invalid"
-	cfg.LLMs["claude"] = claude
-
-	err := cfg.Validate()
-	if err == nil {
-		t.Error("expected error for invalid mode")
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate failed on default config: %v", err)
 	}
 }

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -116,13 +116,27 @@ func parseUnifiedDiff(s string) []Diff {
 		case strings.HasPrefix(line, "diff --git"):
 			flushFile()
 			cur = &Diff{}
+		case strings.HasPrefix(line, "--- a/"):
+			// Capture the original path as a fallback for deletions —
+			// `+++ /dev/null` is the standard `git diff` shape for a
+			// deleted file, so reading +++ alone would attribute every
+			// deletion to "/dev/null" and silently break filtering,
+			// finding attribution, and any path-based downstream logic.
+			if cur != nil {
+				cur.Path = strings.TrimPrefix(line, "--- a/")
+			}
 		case strings.HasPrefix(line, "+++ b/"):
 			if cur != nil {
 				cur.Path = strings.TrimPrefix(line, "+++ b/")
 			}
 		case strings.HasPrefix(line, "+++ ") && cur != nil && cur.Path == "":
-			// Fallback for unusual paths
-			cur.Path = strings.TrimPrefix(line, "+++ ")
+			// Fallback for unusual paths (e.g. patches with non-standard
+			// prefixes). Skip the "+++ /dev/null" deletion shape — we
+			// already captured the original path from --- above.
+			suffix := strings.TrimPrefix(line, "+++ ")
+			if suffix != "/dev/null" {
+				cur.Path = suffix
+			}
 		case strings.HasPrefix(line, "@@"):
 			flushHunk()
 			hunk = &Hunk{Header: line, NewFrom: parseNewFrom(line)}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -138,22 +138,25 @@ func ValidateRef(ref string) error {
 // We don't need a fully-featured patch library — just enough to feed
 // content + line numbers to the LLM.
 //
-// Streams via bufio.Scanner so a large diff doesn't double-buffer
+// Streams via bufio.Reader so a large diff doesn't double-buffer
 // (legacy: stdout.String() + strings.Split slice). Each hunk's body
 // builds in a strings.Builder so even a single huge hunk doesn't go
 // quadratic on the content concatenation.
 //
-// Returns an error when the scanner itself fails (oversize line,
-// underlying I/O error). The caller MUST treat that as fail-closed:
-// a partial diff would let the review gate exit 0 on what's
-// materially an incomplete read of the change set.
+// We use Reader.ReadString('\n') rather than Scanner because Scanner
+// caps line size (we'd previously bumped to 4 MB, but a single
+// minified-bundle line in a vendored blob can easily exceed that and
+// would trip ErrTooLong, aborting the entire review even if globs
+// would have excluded that file). Reader has no per-line limit —
+// memory grows with the longest single line, which is the same
+// memory the input string already used in the legacy path.
+//
+// Returns an error when read itself fails (underlying I/O error).
+// Caller MUST treat that as fail-closed: a partial diff would let the
+// review gate exit 0 on what's materially an incomplete read of the
+// change set.
 func parseUnifiedDiff(r io.Reader) ([]Diff, error) {
-	sc := bufio.NewScanner(r)
-	// Default scanner buffer is 64 KB / line; bump to 4 MB so a single
-	// long line in a generated file doesn't truncate the diff. (The
-	// review excludes most generated files via globs, but the parser
-	// itself shouldn't depend on that.)
-	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	br := bufio.NewReader(r)
 
 	var diffs []Diff
 	var cur *Diff
@@ -184,57 +187,60 @@ func parseUnifiedDiff(r io.Reader) ([]Diff, error) {
 	// silently overwriting cur.Path AND swallowing the line from the
 	// hunk content. Putting `hunk != nil` ahead of the header cases
 	// makes header recognition pre-@@ only.
-	for sc.Scan() {
-		// Strip trailing \r so CRLF input doesn't leak \r into paths
-		// or hunk content. (Same job the old strings.ReplaceAll did,
-		// done per-line during streaming.)
-		line := strings.TrimRight(sc.Text(), "\r")
-		switch {
-		case strings.HasPrefix(line, "diff --git"):
-			flushFile()
-			cur = &Diff{}
-		case strings.HasPrefix(line, "@@"):
-			flushHunk()
-			hunk = &Hunk{Header: line, NewFrom: parseNewFrom(line)}
-		case hunk != nil:
-			// Inside a hunk → all lines are content, regardless of
-			// what they look like. See the "Case order matters" comment
-			// above for why this can't move below the header cases.
-			hunkBody.WriteString(line)
-			hunkBody.WriteByte('\n')
-		case strings.HasPrefix(line, "--- a/"):
-			// Capture the original path as a fallback for deletions —
-			// `+++ /dev/null` is the standard `git diff` shape for a
-			// deleted file, so reading +++ alone would attribute every
-			// deletion to "/dev/null" and silently break filtering,
-			// finding attribution, and any path-based downstream logic.
-			if cur != nil {
-				cur.Path = strings.TrimPrefix(line, "--- a/")
+	for {
+		raw, readErr := br.ReadString('\n')
+		// ReadString returns the partial line + io.EOF when input
+		// ends mid-line (no trailing newline). Process the line we
+		// have, then break on EOF; only non-EOF errors are fatal.
+		if len(raw) > 0 {
+			// Strip trailing \n then \r so CRLF input doesn't leak
+			// \r into paths or hunk content. (Same job the old
+			// strings.ReplaceAll did, done per-line during streaming.)
+			line := strings.TrimRight(strings.TrimSuffix(raw, "\n"), "\r")
+			switch {
+			case strings.HasPrefix(line, "diff --git"):
+				flushFile()
+				cur = &Diff{}
+			case strings.HasPrefix(line, "@@"):
+				flushHunk()
+				hunk = &Hunk{Header: line, NewFrom: parseNewFrom(line)}
+			case hunk != nil:
+				// Inside a hunk → all lines are content, regardless of
+				// what they look like. See the "Case order matters" comment
+				// above for why this can't move below the header cases.
+				hunkBody.WriteString(line)
+				hunkBody.WriteByte('\n')
+			case strings.HasPrefix(line, "--- a/"):
+				// Capture the original path as a fallback for deletions —
+				// `+++ /dev/null` is the standard `git diff` shape for a
+				// deleted file, so reading +++ alone would attribute every
+				// deletion to "/dev/null" and silently break filtering,
+				// finding attribution, and any path-based downstream logic.
+				if cur != nil {
+					cur.Path = strings.TrimPrefix(line, "--- a/")
+				}
+			case strings.HasPrefix(line, "+++ b/"):
+				if cur != nil {
+					cur.Path = strings.TrimPrefix(line, "+++ b/")
+				}
+			case strings.HasPrefix(line, "+++ ") && cur != nil && cur.Path == "":
+				// Fallback for unusual paths (e.g. patches with non-standard
+				// prefixes). Skip the "+++ /dev/null" deletion shape — we
+				// already captured the original path from --- above.
+				suffix := strings.TrimPrefix(line, "+++ ")
+				if suffix != "/dev/null" {
+					cur.Path = suffix
+				}
 			}
-		case strings.HasPrefix(line, "+++ b/"):
-			if cur != nil {
-				cur.Path = strings.TrimPrefix(line, "+++ b/")
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
 			}
-		case strings.HasPrefix(line, "+++ ") && cur != nil && cur.Path == "":
-			// Fallback for unusual paths (e.g. patches with non-standard
-			// prefixes). Skip the "+++ /dev/null" deletion shape — we
-			// already captured the original path from --- above.
-			suffix := strings.TrimPrefix(line, "+++ ")
-			if suffix != "/dev/null" {
-				cur.Path = suffix
-			}
+			return nil, fmt.Errorf("scan diff: %w", readErr)
 		}
 	}
 	flushFile()
-
-	// Scanner errors mean we only got the prefix of the diff — fail
-	// closed. The earlier "best-effort, swallow" comment was the
-	// wrong call for a security gate: a truncated diff exits the
-	// gate on incomplete input, hiding any blocking change in the
-	// unscanned tail.
-	if err := sc.Err(); err != nil {
-		return nil, fmt.Errorf("scan diff: %w", err)
-	}
 
 	// Drop any malformed entries (no path means we never saw a file header)
 	out := diffs[:0]

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -144,11 +144,27 @@ func parseUnifiedDiff(s string) []Diff {
 		cur = nil
 	}
 
+	// Case order matters here — once we're inside a hunk (post-@@),
+	// every line is content even if it happens to start with `--- a/`
+	// or `+++ b/`. A deleted SQL comment `-- a/users` renders as
+	// `--- a/users` in the diff (the leading `-` is the diff prefix),
+	// and the previous case order matched that as a file header,
+	// silently overwriting cur.Path AND swallowing the line from the
+	// hunk content. Putting `hunk != nil` ahead of the header cases
+	// makes header recognition pre-@@ only.
 	for _, line := range strings.Split(s, "\n") {
 		switch {
 		case strings.HasPrefix(line, "diff --git"):
 			flushFile()
 			cur = &Diff{}
+		case strings.HasPrefix(line, "@@"):
+			flushHunk()
+			hunk = &Hunk{Header: line, NewFrom: parseNewFrom(line)}
+		case hunk != nil:
+			// Inside a hunk → all lines are content, regardless of
+			// what they look like. See the "Case order matters" comment
+			// above for why this can't move below the header cases.
+			hunk.Content += line + "\n"
 		case strings.HasPrefix(line, "--- a/"):
 			// Capture the original path as a fallback for deletions —
 			// `+++ /dev/null` is the standard `git diff` shape for a
@@ -170,11 +186,6 @@ func parseUnifiedDiff(s string) []Diff {
 			if suffix != "/dev/null" {
 				cur.Path = suffix
 			}
-		case strings.HasPrefix(line, "@@"):
-			flushHunk()
-			hunk = &Hunk{Header: line, NewFrom: parseNewFrom(line)}
-		case hunk != nil:
-			hunk.Content += line + "\n"
 		}
 	}
 	flushFile()

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -7,9 +7,11 @@
 package git
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"time"
@@ -59,7 +61,11 @@ func Extract(mode Mode, ref string) ([]Diff, error) {
 		return nil, fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, stderr.String())
 	}
 
-	return parseUnifiedDiff(stdout.String()), nil
+	// Stream-parse stdout via bytes.NewReader → bufio.Scanner so we
+	// don't double-buffer the diff (string copy + strings.Split slice).
+	// Large monorepo branch diffs hit 10s of MB; the legacy version
+	// held 3-4 copies of that in flight.
+	return parseUnifiedDiff(bytes.NewReader(stdout.Bytes())), nil
 }
 
 func argsFor(mode Mode, ref string) ([]string, error) {
@@ -123,18 +129,31 @@ func ValidateRef(ref string) error {
 // parseUnifiedDiff walks `git diff` output and groups hunks by file.
 // We don't need a fully-featured patch library — just enough to feed
 // content + line numbers to the LLM.
-func parseUnifiedDiff(s string) []Diff {
-	// Normalize CRLF so trailing \r doesn't end up in paths/hunks.
-	s = strings.ReplaceAll(s, "\r\n", "\n")
+//
+// Streams via bufio.Scanner so a large diff doesn't double-buffer
+// (legacy: stdout.String() + strings.Split slice). Each hunk's body
+// builds in a strings.Builder so even a single huge hunk doesn't go
+// quadratic on the content concatenation.
+func parseUnifiedDiff(r io.Reader) []Diff {
+	sc := bufio.NewScanner(r)
+	// Default scanner buffer is 64 KB / line; bump to 4 MB so a single
+	// long line in a generated file doesn't truncate the diff. (The
+	// review excludes most generated files via globs, but the parser
+	// itself shouldn't depend on that.)
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+
 	var diffs []Diff
 	var cur *Diff
 	var hunk *Hunk
+	var hunkBody strings.Builder
 
 	flushHunk := func() {
 		if cur != nil && hunk != nil {
+			hunk.Content = hunkBody.String()
 			cur.Hunks = append(cur.Hunks, *hunk)
 		}
 		hunk = nil
+		hunkBody.Reset()
 	}
 	flushFile := func() {
 		flushHunk()
@@ -152,7 +171,11 @@ func parseUnifiedDiff(s string) []Diff {
 	// silently overwriting cur.Path AND swallowing the line from the
 	// hunk content. Putting `hunk != nil` ahead of the header cases
 	// makes header recognition pre-@@ only.
-	for _, line := range strings.Split(s, "\n") {
+	for sc.Scan() {
+		// Strip trailing \r so CRLF input doesn't leak \r into paths
+		// or hunk content. (Same job the old strings.ReplaceAll did,
+		// done per-line during streaming.)
+		line := strings.TrimRight(sc.Text(), "\r")
 		switch {
 		case strings.HasPrefix(line, "diff --git"):
 			flushFile()
@@ -164,7 +187,8 @@ func parseUnifiedDiff(s string) []Diff {
 			// Inside a hunk → all lines are content, regardless of
 			// what they look like. See the "Case order matters" comment
 			// above for why this can't move below the header cases.
-			hunk.Content += line + "\n"
+			hunkBody.WriteString(line)
+			hunkBody.WriteByte('\n')
 		case strings.HasPrefix(line, "--- a/"):
 			// Capture the original path as a fallback for deletions —
 			// `+++ /dev/null` is the standard `git diff` shape for a
@@ -189,6 +213,10 @@ func parseUnifiedDiff(s string) []Diff {
 		}
 	}
 	flushFile()
+	// Scanner errors (oversized line, I/O failure) are deliberately
+	// swallowed — the diff is best-effort review input, not a
+	// correctness-critical parse. A truncated diff still produces
+	// useful findings for whatever was parsed before the error.
 
 	// Drop any malformed entries (no path means we never saw a file header)
 	out := diffs[:0]

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -74,17 +74,50 @@ func argsFor(mode Mode, ref string) ([]string, error) {
 		if ref == "" {
 			ref = "HEAD"
 		}
+		if err := ValidateRef(ref); err != nil {
+			return nil, err
+		}
 		// `show` by itself includes the commit message. We just want the diff.
 		return []string{"show", ctx, "--format=", ref}, nil
 	case ModeBranch:
 		if ref == "" {
 			ref = "main"
 		}
+		if err := ValidateRef(ref); err != nil {
+			return nil, err
+		}
 		// Three-dot: diff from common ancestor to current HEAD.
+		// Note: we can't use `--` to separate the ref from positional
+		// args here because `<ref>...HEAD` is itself a single ref-spec
+		// argument, not a path. ValidateRef above is the defense.
 		return []string{"diff", ctx, ref + "...HEAD"}, nil
 	default:
 		return nil, fmt.Errorf("unknown mode %d", mode)
 	}
+}
+
+// ValidateRef rejects user-supplied git refs that could be parsed by
+// git as command-line flags rather than refs. A ref starting with `-`
+// (e.g., `--output=/tmp/xyz`, `-c core.editor=...`) would be treated
+// as a flag in `git diff <ref>...HEAD` or `git show <ref>` despite
+// looking like a positional argument, so we refuse anything that
+// shape rather than relying on a `--` separator that doesn't apply
+// uniformly across git subcommands.
+//
+// We also reject refs containing newlines or NUL bytes because they
+// can't survive a shell pipeline correctly and almost always indicate
+// caller bugs (or attempted injection from a wrapping script).
+func ValidateRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("ref is empty")
+	}
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("invalid ref %q: refs starting with '-' are rejected to prevent flag injection", ref)
+	}
+	if strings.ContainsAny(ref, "\x00\n\r") {
+		return fmt.Errorf("invalid ref %q: contains control characters", ref)
+	}
+	return nil
 }
 
 // parseUnifiedDiff walks `git diff` output and groups hunks by file.
@@ -242,12 +275,19 @@ func SanitizeCommit(commit string) string {
 }
 
 // ResolveRef resolves a git ref (branch name, tag, short hash) to a full commit hash.
-// Returns the first 7 characters of the commit hash, or empty string if resolution fails or times out.
+// Returns the first 7 characters of the commit hash, or empty string
+// if resolution fails / times out / the ref is rejected by ValidateRef
+// (refs starting with `-` would otherwise be parsed by git as flags).
 func ResolveRef(ref string) string {
+	if err := ValidateRef(ref); err != nil {
+		return ""
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--short", ref)
+	// `--` after the flags ensures the ref is treated as a positional
+	// argument even if a future caller bypasses ValidateRef.
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--short", "--", ref)
 	output, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -65,7 +65,15 @@ func Extract(mode Mode, ref string) ([]Diff, error) {
 	// don't double-buffer the diff (string copy + strings.Split slice).
 	// Large monorepo branch diffs hit 10s of MB; the legacy version
 	// held 3-4 copies of that in flight.
-	return parseUnifiedDiff(bytes.NewReader(stdout.Bytes())), nil
+	diffs, err := parseUnifiedDiff(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		// Fail closed: a scanner error means we have only the prefix
+		// of the diff, and the unscanned tail might contain blocking
+		// changes. Returning a partial slice + nil err would let the
+		// gate exit 0 on a materially incomplete review.
+		return nil, fmt.Errorf("parse diff: %w", err)
+	}
+	return diffs, nil
 }
 
 func argsFor(mode Mode, ref string) ([]string, error) {
@@ -134,7 +142,12 @@ func ValidateRef(ref string) error {
 // (legacy: stdout.String() + strings.Split slice). Each hunk's body
 // builds in a strings.Builder so even a single huge hunk doesn't go
 // quadratic on the content concatenation.
-func parseUnifiedDiff(r io.Reader) []Diff {
+//
+// Returns an error when the scanner itself fails (oversize line,
+// underlying I/O error). The caller MUST treat that as fail-closed:
+// a partial diff would let the review gate exit 0 on what's
+// materially an incomplete read of the change set.
+func parseUnifiedDiff(r io.Reader) ([]Diff, error) {
 	sc := bufio.NewScanner(r)
 	// Default scanner buffer is 64 KB / line; bump to 4 MB so a single
 	// long line in a generated file doesn't truncate the diff. (The
@@ -213,10 +226,15 @@ func parseUnifiedDiff(r io.Reader) []Diff {
 		}
 	}
 	flushFile()
-	// Scanner errors (oversized line, I/O failure) are deliberately
-	// swallowed — the diff is best-effort review input, not a
-	// correctness-critical parse. A truncated diff still produces
-	// useful findings for whatever was parsed before the error.
+
+	// Scanner errors mean we only got the prefix of the diff — fail
+	// closed. The earlier "best-effort, swallow" comment was the
+	// wrong call for a security gate: a truncated diff exits the
+	// gate on incomplete input, hiding any blocking change in the
+	// unscanned tail.
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scan diff: %w", err)
+	}
 
 	// Drop any malformed entries (no path means we never saw a file header)
 	out := diffs[:0]
@@ -225,7 +243,7 @@ func parseUnifiedDiff(r io.Reader) []Diff {
 			out = append(out, d)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // parseNewFrom extracts the "+N" line number from a hunk header

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -26,7 +26,7 @@ index 222..333 100644
 `
 
 func TestParseUnifiedDiff(t *testing.T) {
-	diffs := parseUnifiedDiff(sample)
+	diffs := parseUnifiedDiff(strings.NewReader(sample))
 	if len(diffs) != 2 {
 		t.Fatalf("expected 2 files, got %d", len(diffs))
 	}
@@ -53,7 +53,7 @@ func TestParseUnifiedDiff_CRLF(t *testing.T) {
 		"@@ -1,1 +1,2 @@\r\n" +
 		" hello\r\n" +
 		"+world\r\n"
-	diffs := parseUnifiedDiff(crlf)
+	diffs := parseUnifiedDiff(strings.NewReader(crlf))
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 file, got %d", len(diffs))
 	}
@@ -85,7 +85,7 @@ index abc..0000000
 -
 -func Old() {}
 `
-	diffs := parseUnifiedDiff(deleted)
+	diffs := parseUnifiedDiff(strings.NewReader(deleted))
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}
@@ -114,7 +114,7 @@ index 1..2 100644
 +++ b/customers replaces it
 +DROP TABLE customers;
 `
-	diffs := parseUnifiedDiff(sql)
+	diffs := parseUnifiedDiff(strings.NewReader(sql))
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}
@@ -148,7 +148,7 @@ index aaa..bbb 100644
 +// new comment
  func F() {}
 `
-	diffs := parseUnifiedDiff(renamed)
+	diffs := parseUnifiedDiff(strings.NewReader(renamed))
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -182,6 +182,51 @@ func TestCurrentBranch(t *testing.T) {
 	}
 }
 
+func TestValidateRef(t *testing.T) {
+	cases := []struct {
+		ref     string
+		wantErr bool
+	}{
+		{"main", false},
+		{"feature/auth-fix", false},
+		{"v1.2.3", false},
+		{"abc1234", false},
+		{"HEAD", false},
+		{"", true},
+		{"--output=/tmp/xyz", true},    // flag injection
+		{"-c", true},                   // flag injection
+		{"--upload-pack=/tmp/x", true}, // git-specific flag injection
+		{"main\nmalice", true},         // newline injection
+		{"main\x00main", true},         // NUL injection
+	}
+	for _, tc := range cases {
+		err := ValidateRef(tc.ref)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ValidateRef(%q) err=%v, wantErr=%v", tc.ref, err, tc.wantErr)
+		}
+	}
+}
+
+func TestArgsFor_RejectsFlagShapedRef(t *testing.T) {
+	// argsFor must refuse to construct a `git diff` / `git show` that
+	// would interpret a user-controlled ref as a flag. Defends against
+	// `git diff --output=/tmp/x...HEAD` — `...HEAD` makes it look
+	// positional but git still parses the leading `--` as a flag.
+	if _, err := argsFor(ModeBranch, "--output=/tmp/x"); err == nil {
+		t.Error("ModeBranch with flag-shaped ref: want error, got nil")
+	}
+	if _, err := argsFor(ModeCommit, "-c"); err == nil {
+		t.Error("ModeCommit with flag-shaped ref: want error, got nil")
+	}
+	// Sanity: legitimate refs still pass through.
+	if _, err := argsFor(ModeBranch, "main"); err != nil {
+		t.Errorf("ModeBranch with 'main': want no error, got %v", err)
+	}
+	if _, err := argsFor(ModeCommit, "v1.2.3"); err != nil {
+		t.Errorf("ModeCommit with 'v1.2.3': want no error, got %v", err)
+	}
+}
+
 func TestSanitizeBranchName(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,9 +1,27 @@
 package git
 
 import (
+	"io"
 	"strings"
 	"testing"
 )
+
+// errReader returns r.pre on the first read, then r.err on every
+// subsequent read. Used to simulate a real I/O failure mid-stream so
+// the parser's fail-closed contract is exercised end-to-end.
+type errReader struct {
+	pre []byte
+	err error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if len(r.pre) > 0 {
+		n := copy(p, r.pre)
+		r.pre = r.pre[n:]
+		return n, nil
+	}
+	return 0, r.err
+}
 
 const sample = `diff --git a/src/foo.ts b/src/foo.ts
 index 1234567..abcdefg 100644
@@ -26,7 +44,7 @@ index 222..333 100644
 `
 
 func TestParseUnifiedDiff(t *testing.T) {
-	diffs := parseUnifiedDiff(strings.NewReader(sample))
+	diffs, _ := parseUnifiedDiff(strings.NewReader(sample))
 	if len(diffs) != 2 {
 		t.Fatalf("expected 2 files, got %d", len(diffs))
 	}
@@ -53,7 +71,7 @@ func TestParseUnifiedDiff_CRLF(t *testing.T) {
 		"@@ -1,1 +1,2 @@\r\n" +
 		" hello\r\n" +
 		"+world\r\n"
-	diffs := parseUnifiedDiff(strings.NewReader(crlf))
+	diffs, _ := parseUnifiedDiff(strings.NewReader(crlf))
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 file, got %d", len(diffs))
 	}
@@ -85,7 +103,7 @@ index abc..0000000
 -
 -func Old() {}
 `
-	diffs := parseUnifiedDiff(strings.NewReader(deleted))
+	diffs, _ := parseUnifiedDiff(strings.NewReader(deleted))
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}
@@ -114,7 +132,7 @@ index 1..2 100644
 +++ b/customers replaces it
 +DROP TABLE customers;
 `
-	diffs := parseUnifiedDiff(strings.NewReader(sql))
+	diffs, _ := parseUnifiedDiff(strings.NewReader(sql))
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}
@@ -148,12 +166,30 @@ index aaa..bbb 100644
 +// new comment
  func F() {}
 `
-	diffs := parseUnifiedDiff(strings.NewReader(renamed))
+	diffs, _ := parseUnifiedDiff(strings.NewReader(renamed))
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}
 	if diffs[0].Path != "new.go" {
 		t.Errorf("renamed-file path = %q, want %q", diffs[0].Path, "new.go")
+	}
+}
+
+func TestParseUnifiedDiff_FailsClosedOnScannerError(t *testing.T) {
+	// A partial diff must NOT silently produce "no findings". The gate
+	// downstream relies on having seen the whole change set; a truncated
+	// read with the unscanned tail dropped would let a blocking change
+	// slip through. Pin: scanner error → returned err, not partial slice.
+	r := &errReader{
+		pre: []byte("diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1,1 +1,1 @@\n"),
+		err: io.ErrUnexpectedEOF,
+	}
+	_, err := parseUnifiedDiff(r)
+	if err == nil {
+		t.Fatal("want error from parseUnifiedDiff on truncated input, got nil")
+	}
+	if !strings.Contains(err.Error(), "scan diff") {
+		t.Errorf("error should mention scan diff, got: %v", err)
 	}
 }
 

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -44,7 +44,10 @@ index 222..333 100644
 `
 
 func TestParseUnifiedDiff(t *testing.T) {
-	diffs, _ := parseUnifiedDiff(strings.NewReader(sample))
+	diffs, err := parseUnifiedDiff(strings.NewReader(sample))
+	if err != nil {
+		t.Fatalf("parseUnifiedDiff(sample): %v", err)
+	}
 	if len(diffs) != 2 {
 		t.Fatalf("expected 2 files, got %d", len(diffs))
 	}
@@ -71,7 +74,10 @@ func TestParseUnifiedDiff_CRLF(t *testing.T) {
 		"@@ -1,1 +1,2 @@\r\n" +
 		" hello\r\n" +
 		"+world\r\n"
-	diffs, _ := parseUnifiedDiff(strings.NewReader(crlf))
+	diffs, err := parseUnifiedDiff(strings.NewReader(crlf))
+	if err != nil {
+		t.Fatalf("parseUnifiedDiff(crlf): %v", err)
+	}
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 file, got %d", len(diffs))
 	}
@@ -103,7 +109,10 @@ index abc..0000000
 -
 -func Old() {}
 `
-	diffs, _ := parseUnifiedDiff(strings.NewReader(deleted))
+	diffs, err := parseUnifiedDiff(strings.NewReader(deleted))
+	if err != nil {
+		t.Fatalf("parseUnifiedDiff(deleted): %v", err)
+	}
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}
@@ -132,7 +141,10 @@ index 1..2 100644
 +++ b/customers replaces it
 +DROP TABLE customers;
 `
-	diffs, _ := parseUnifiedDiff(strings.NewReader(sql))
+	diffs, err := parseUnifiedDiff(strings.NewReader(sql))
+	if err != nil {
+		t.Fatalf("parseUnifiedDiff(sql): %v", err)
+	}
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}
@@ -166,7 +178,10 @@ index aaa..bbb 100644
 +// new comment
  func F() {}
 `
-	diffs, _ := parseUnifiedDiff(strings.NewReader(renamed))
+	diffs, err := parseUnifiedDiff(strings.NewReader(renamed))
+	if err != nil {
+		t.Fatalf("parseUnifiedDiff(renamed): %v", err)
+	}
 	if len(diffs) != 1 {
 		t.Fatalf("want 1 diff, got %d", len(diffs))
 	}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -68,6 +68,57 @@ func TestParseUnifiedDiff_CRLF(t *testing.T) {
 	}
 }
 
+func TestParseUnifiedDiff_DeletedFileKeepsOriginalPath(t *testing.T) {
+	// `git diff` emits `+++ /dev/null` when a file is deleted. Pre-fix
+	// the parser took the path from +++, so deletions were attributed
+	// to "/dev/null" — silently broke include/exclude filtering, the
+	// per-file finding output, and any path-based downstream logic.
+	// Now we capture --- a/<path> first and only let +++ b/<path>
+	// overwrite it for non-deletion diffs.
+	deleted := `diff --git a/legacy/old.go b/legacy/old.go
+deleted file mode 100644
+index abc..0000000
+--- a/legacy/old.go
++++ /dev/null
+@@ -1,3 +0,0 @@
+-package legacy
+-
+-func Old() {}
+`
+	diffs := parseUnifiedDiff(deleted)
+	if len(diffs) != 1 {
+		t.Fatalf("want 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Path != "legacy/old.go" {
+		t.Errorf("deleted-file path = %q, want %q (was '/dev/null' pre-fix)", diffs[0].Path, "legacy/old.go")
+	}
+}
+
+func TestParseUnifiedDiff_RenameUsesNewPath(t *testing.T) {
+	// Renames should attribute to the new path — that's what reviewers
+	// will navigate to. This pins the existing behavior so the
+	// deleted-file fix doesn't accidentally invert it.
+	renamed := `diff --git a/old.go b/new.go
+similarity index 80%
+rename from old.go
+rename to new.go
+index aaa..bbb 100644
+--- a/old.go
++++ b/new.go
+@@ -1,3 +1,4 @@
+ package x
++// new comment
+ func F() {}
+`
+	diffs := parseUnifiedDiff(renamed)
+	if len(diffs) != 1 {
+		t.Fatalf("want 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Path != "new.go" {
+		t.Errorf("renamed-file path = %q, want %q", diffs[0].Path, "new.go")
+	}
+}
+
 func TestParseNewFrom(t *testing.T) {
 	cases := map[string]int{
 		"@@ -1,2 +37,5 @@":  37,

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -94,6 +94,44 @@ index abc..0000000
 	}
 }
 
+func TestParseUnifiedDiff_HunkContentLooksLikeHeader(t *testing.T) {
+	// A deleted SQL comment `-- a/users` (or any code where a deleted
+	// line happens to start with `-- a/` or an added line with `++ b/`)
+	// renders inside a hunk as `--- a/users` / `+++ b/users` after the
+	// diff's leading `-` / `+`. Pre-fix, the parser matched those as
+	// file headers and BOTH overwrote cur.Path AND lost the line from
+	// the hunk content. Pin the corrected behavior:
+	//   - cur.Path stays attributed to the real file (migrations.sql)
+	//   - the deleted/added lines remain in the hunk content verbatim
+	sql := `diff --git a/migrations.sql b/migrations.sql
+index 1..2 100644
+--- a/migrations.sql
++++ b/migrations.sql
+@@ -1,4 +1,4 @@
+ SELECT 1;
+--- a/users is the legacy table
+-DROP TABLE users;
++++ b/customers replaces it
++DROP TABLE customers;
+`
+	diffs := parseUnifiedDiff(sql)
+	if len(diffs) != 1 {
+		t.Fatalf("want 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Path != "migrations.sql" {
+		t.Errorf("path = %q, want migrations.sql (header-look-alike inside hunk leaked into Path)", diffs[0].Path)
+	}
+	if len(diffs[0].Hunks) != 1 {
+		t.Fatalf("want 1 hunk, got %d", len(diffs[0].Hunks))
+	}
+	body := diffs[0].Hunks[0].Content
+	for _, want := range []string{"-- a/users is the legacy table", "++ b/customers replaces it"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("hunk content missing %q (was eaten by header recognition)\n--- got ---\n%s", want, body)
+		}
+	}
+}
+
 func TestParseUnifiedDiff_RenameUsesNewPath(t *testing.T) {
 	// Renames should attribute to the new path — that's what reviewers
 	// will navigate to. This pins the existing behavior so the

--- a/internal/lang/detect.go
+++ b/internal/lang/detect.go
@@ -11,13 +11,13 @@ import (
 // Identifier returned by Detect. These match the pack file names in
 // internal/prompts/packs (e.g. Detect("foo.ts") → "typescript" → typescript.md).
 //
-// JavaScript intentionally maps to TypeScript: there's no dedicated
-// javascript.md pack and shipping one would duplicate ~95% of the TS
-// pack content (TS is a superset; the React/Next.js/Node patterns
-// covered by the TS pack apply equally to plain JS). Better to point
-// at one well-tuned pack than maintain two near-duplicates. If JS-
-// specific concerns ever diverge meaningfully, ship a javascript.md
-// and flip this constant.
+// JavaScript routes to the TypeScript pack — see the byExt map below
+// for the .js/.jsx/.mjs/.cjs entries. There's no dedicated javascript.md
+// pack; shipping one would duplicate ~95% of the TS pack content (TS
+// is a superset; the React/Next.js/Node patterns the TS pack covers
+// apply equally to plain JS). If JS-specific concerns ever diverge
+// meaningfully from TS, add a JavaScript constant here, ship a
+// javascript.md pack, and re-point the .js* entries in byExt.
 const (
 	Default    = "default"
 	TypeScript = "typescript"
@@ -33,7 +33,7 @@ const (
 var byExt = map[string]string{
 	".ts":   TypeScript,
 	".tsx":  TypeScript,
-	".js":   TypeScript, // see comment on the JavaScript constant above
+	".js":   TypeScript, // see the const-block comment above for why JS → TS
 	".jsx":  TypeScript,
 	".mjs":  TypeScript,
 	".cjs":  TypeScript,

--- a/internal/lang/detect.go
+++ b/internal/lang/detect.go
@@ -10,10 +10,17 @@ import (
 
 // Identifier returned by Detect. These match the pack file names in
 // internal/prompts/packs (e.g. Detect("foo.ts") → "typescript" → typescript.md).
+//
+// JavaScript intentionally maps to TypeScript: there's no dedicated
+// javascript.md pack and shipping one would duplicate ~95% of the TS
+// pack content (TS is a superset; the React/Next.js/Node patterns
+// covered by the TS pack apply equally to plain JS). Better to point
+// at one well-tuned pack than maintain two near-duplicates. If JS-
+// specific concerns ever diverge meaningfully, ship a javascript.md
+// and flip this constant.
 const (
 	Default    = "default"
 	TypeScript = "typescript"
-	JavaScript = "javascript"
 	Go         = "go"
 	Python     = "python"
 	Java       = "java"
@@ -26,10 +33,10 @@ const (
 var byExt = map[string]string{
 	".ts":   TypeScript,
 	".tsx":  TypeScript,
-	".js":   JavaScript,
-	".jsx":  JavaScript,
-	".mjs":  JavaScript,
-	".cjs":  JavaScript,
+	".js":   TypeScript, // see comment on the JavaScript constant above
+	".jsx":  TypeScript,
+	".mjs":  TypeScript,
+	".cjs":  TypeScript,
 	".go":   Go,
 	".py":   Python,
 	".pyw":  Python,

--- a/internal/lang/detect_test.go
+++ b/internal/lang/detect_test.go
@@ -12,7 +12,12 @@ func TestDetect(t *testing.T) {
 		"lib.rs":          Rust,
 		"unknown.xyz":     Default,
 		"no-extension":    Default,
-		"path/to/file.js": JavaScript,
+		// .js intentionally maps to TypeScript — see the comment on the
+		// (removed) JavaScript constant in detect.go for reasoning.
+		"path/to/file.js":  TypeScript,
+		"path/to/file.jsx": TypeScript,
+		"path/to/file.mjs": TypeScript,
+		"path/to/file.cjs": TypeScript,
 	}
 	for path, want := range cases {
 		if got := Detect(path); got != want {

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -11,9 +11,34 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
+
+// isLocalURL returns true when raw is a URL whose host points at the
+// local machine (localhost, 127.0.0.0/8, ::1, 0.0.0.0). Used to skip
+// the API-key requirement for Ollama / vLLM-style local-only setups
+// where the provider doesn't authenticate. Any non-local URL falls
+// through to the regular auth check.
+func isLocalURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	switch host {
+	case "localhost", "127.0.0.1", "0.0.0.0", "::1":
+		return true
+	}
+	// Also catch any 127.x.x.x — kept narrow on purpose; refusing
+	// to extend to RFC1918 ranges because a corporate API gateway
+	// at 10.0.0.5 still authenticates and shouldn't bypass the check.
+	return strings.HasPrefix(host, "127.")
+}
 
 // maxResponseBytes caps how much we'll read from a chat-completions
 // response. A typical review response is well under 100 KB; 10 MB is
@@ -81,7 +106,13 @@ type response struct {
 // providers respect this; for those that don't, the system prompt
 // should still steer the model to JSON.
 func (c *Client) Complete(ctx context.Context, msgs []Message, jsonMode bool) (string, error) {
-	if c.APIKey == "" {
+	if c.APIKey == "" && !isLocalURL(c.BaseURL) {
+		// Local-review init's "Ollama" preset writes a config with no
+		// api_key_env line because Ollama doesn't authenticate. A blank
+		// LOCAL_REVIEW_API_KEY (the legacy default) used to crash the
+		// review here despite the provider needing no key. Skip the
+		// check when base_url points at localhost/127.0.0.1/::1/0.0.0.0;
+		// any non-local URL still requires a key.
 		envName := c.APIKeyEnv
 		if envName == "" {
 			envName = "LOCAL_REVIEW_API_KEY"

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -139,7 +139,14 @@ func (c *Client) Complete(ctx context.Context, msgs []Message, jsonMode bool) (s
 		return "", fmt.Errorf("new request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	if c.APIKey != "" {
+		// Only set Authorization when we actually have a key. Sending
+		// `Authorization: Bearer ` with an empty token breaks some
+		// local OpenAI-compatible servers (Ollama, vLLM) that expect
+		// the header to be absent in unauthenticated mode. The empty-
+		// key case is reachable via the isLocalURL bypass above.
+		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
 
 	resp, err := c.HTTP.Do(httpReq)
 	if err != nil {

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -15,6 +15,14 @@ import (
 	"time"
 )
 
+// maxResponseBytes caps how much we'll read from a chat-completions
+// response. A typical review response is well under 100 KB; 10 MB is
+// generous headroom for an unusually verbose model and small enough
+// to crash the CLI with a clear error rather than exhaust RAM if a
+// provider streams unbounded data, hangs mid-transmission, or is
+// spoofed by a man-in-the-middle on the configured base URL.
+const maxResponseBytes = 10 * 1024 * 1024
+
 // Client wraps a base URL + API key. Construct once, reuse.
 type Client struct {
 	BaseURL string
@@ -108,9 +116,15 @@ func (c *Client) Complete(ctx context.Context, msgs []Message, jsonMode bool) (s
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	// LimitReader at maxResponseBytes+1 so we can distinguish "exactly
+	// at the cap" from "ran past the cap" — if we read >max bytes the
+	// provider returned more than we'll trust.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return "", fmt.Errorf("read response: %w", err)
+	}
+	if int64(len(respBody)) > maxResponseBytes {
+		return "", fmt.Errorf("llm %s: response exceeded %d-byte cap (possible runaway provider or spoofed endpoint)", c.BaseURL, maxResponseBytes)
 	}
 
 	if resp.StatusCode >= 400 {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -242,6 +242,26 @@ func TestComplete_EmptyChoicesReturnsError(t *testing.T) {
 	}
 }
 
+func TestComplete_RejectsOversizedResponse(t *testing.T) {
+	// A spoofed/runaway provider must not OOM the CLI by streaming
+	// unbounded bytes. The cap is 10 MB; write 12 MB and confirm we
+	// get a clear error instead of silently buffering 12 MB of garbage.
+	m := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// 12 MB of `x` — well past the 10 MB cap.
+		w.Write(make([]byte, 12*1024*1024))
+	})
+	c := New(m.server.URL, "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 30)
+
+	_, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false)
+	if err == nil {
+		t.Fatal("expected oversize error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Errorf("error should mention size cap, got: %v", err)
+	}
+}
+
 func TestComplete_MalformedJSONResponse(t *testing.T) {
 	m := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -242,6 +242,34 @@ func TestComplete_EmptyChoicesReturnsError(t *testing.T) {
 	}
 }
 
+func TestComplete_LocalURLOmitsAuthorizationHeaderOnEmptyKey(t *testing.T) {
+	// Pre-fix: even with an empty key (the local-URL bypass), we
+	// still set `Authorization: Bearer ` on the outgoing request.
+	// Some local OpenAI-compat servers (Ollama, vLLM) reject or
+	// log-spam on an empty bearer token; the absent-header form is
+	// what they expect for unauthenticated mode.
+	m := newMockServer(t, okResponse("ok"))
+	c := New(m.server.URL, "", "LOCAL_REVIEW_API_KEY", "ollama-model", 5)
+	if _, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := m.lastRequest.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization header should be absent on empty key, got %q", got)
+	}
+}
+
+func TestComplete_NonEmptyKeyStillSetsAuthorizationHeader(t *testing.T) {
+	// Sanity: the header conditional must not regress the normal path.
+	m := newMockServer(t, okResponse("ok"))
+	c := New(m.server.URL, "sk-real", "LOCAL_REVIEW_API_KEY", "gpt-4", 5)
+	if _, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := m.lastRequest.Header.Get("Authorization"), "Bearer sk-real"; got != want {
+		t.Errorf("Authorization: want %q, got %q", want, got)
+	}
+}
+
 func TestComplete_LocalURLSkipsKeyRequirement(t *testing.T) {
 	// Ollama / vLLM at localhost don't authenticate; the init wizard's
 	// Ollama preset deliberately omits api_key_env. Pre-fix we still

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -320,7 +320,10 @@ func TestComplete_RejectsOversizedResponse(t *testing.T) {
 	m := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		// 12 MB of `x` — well past the 10 MB cap.
-		w.Write(make([]byte, 12*1024*1024))
+		// errcheck/linter cleanliness: the write may short-circuit when
+		// the client side detects the cap and closes mid-stream, which
+		// is the whole point of this test. Discard the return.
+		_, _ = w.Write(make([]byte, 12*1024*1024))
 	})
 	c := New(m.server.URL, "sk-x", "LOCAL_REVIEW_API_KEY", "gpt-4", 30)
 

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -242,6 +242,49 @@ func TestComplete_EmptyChoicesReturnsError(t *testing.T) {
 	}
 }
 
+func TestComplete_LocalURLSkipsKeyRequirement(t *testing.T) {
+	// Ollama / vLLM at localhost don't authenticate; the init wizard's
+	// Ollama preset deliberately omits api_key_env. Pre-fix we still
+	// rejected with "no API key" for those URLs. Now: localhost-shaped
+	// base_url + empty key proceeds to the actual call (which the test
+	// mock satisfies).
+	m := newMockServer(t, okResponse("ok-local"))
+	// Replace the mock URL's host with 127.0.0.1 explicitly to exercise
+	// the local-host detector. httptest already binds there.
+	c := New(m.server.URL, "", "LOCAL_REVIEW_API_KEY", "ollama-model", 5)
+	got, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "x"}}, false)
+	if err != nil {
+		t.Fatalf("local URL with empty key should succeed, got %v", err)
+	}
+	if got != "ok-local" {
+		t.Errorf("response: got %q, want ok-local", got)
+	}
+}
+
+func TestIsLocalURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"http://localhost:11434/v1", true},
+		{"http://127.0.0.1:8080/v1", true},
+		{"http://127.99.0.1/v1", true},
+		{"http://[::1]:8000/v1", true},
+		{"http://0.0.0.0:11434/v1", true},
+		{"https://api.openai.com/v1", false},
+		{"https://api.anthropic.com/v1", false},
+		{"http://10.0.0.5:8080/v1", false}, // private but not loopback
+		{"http://192.168.1.10/v1", false},
+		{"", false},
+		{"::not a url::", false},
+	}
+	for _, tc := range cases {
+		if got := isLocalURL(tc.in); got != tc.want {
+			t.Errorf("isLocalURL(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestComplete_RejectsOversizedResponse(t *testing.T) {
 	// A spoofed/runaway provider must not OOM the CLI by streaming
 	// unbounded bytes. The cap is 10 MB; write 12 MB and confirm we

--- a/internal/multi/merger.go
+++ b/internal/multi/merger.go
@@ -71,8 +71,24 @@ func (m *Merger) Merge(ctx context.Context, input MergeInput) (string, error) {
 	return merged, nil
 }
 
+// MaxReviewBytesForMerge caps how much of any single per-LLM review
+// gets concatenated into the merger prompt. The merger LLM has a
+// finite context window; a verbose-enough reviewer (or one that
+// hallucinates a long preamble) can blow it out by itself, killing
+// the whole pipeline at the very last step.
+//
+// 8 KB ≈ 2k tokens at typical English density — enough room for a
+// detailed review while leaving plenty of context budget for the
+// other reviewers and the merger's own template / instructions.
+// Saved per-LLM review files on disk are NOT truncated; this limit
+// applies only to what the merger sees.
+const MaxReviewBytesForMerge = 8 * 1024
+
 // BuildMergeInput creates MergeInput from review results.
 // Includes all reviews that have output, even if saving to disk failed.
+// Per-review output is truncated to MaxReviewBytesForMerge with a
+// trailing notice so the merger can still pick up an explicit signal
+// that some content was clipped.
 func BuildMergeInput(results []ReviewResult, consensusThreshold int) MergeInput {
 	var reviews []ReviewContent
 	var llmNames []string
@@ -82,7 +98,7 @@ func BuildMergeInput(results []ReviewResult, consensusThreshold int) MergeInput 
 		if r.Output != "" {
 			reviews = append(reviews, ReviewContent{
 				LLM:     r.LLM,
-				Content: r.Output,
+				Content: truncateForMerge(r.Output),
 			})
 			llmNames = append(llmNames, r.LLM)
 		}
@@ -94,4 +110,21 @@ func BuildMergeInput(results []ReviewResult, consensusThreshold int) MergeInput 
 		ConsensusThreshold: consensusThreshold,
 		Reviews:            reviews,
 	}
+}
+
+// truncateForMerge clips an oversize per-LLM review to fit comfortably
+// inside the merger's context window. Returns the original string
+// when within the cap; otherwise truncates and appends an explicit
+// "[…truncated]" marker so a reader (human or LLM) can tell that
+// findings may continue in the saved per-LLM file.
+func truncateForMerge(s string) string {
+	if len(s) <= MaxReviewBytesForMerge {
+		return s
+	}
+	const marker = "\n\n[…truncated by local-review for merge: see the saved per-LLM file for full output]"
+	cut := MaxReviewBytesForMerge - len(marker)
+	if cut < 0 {
+		cut = 0
+	}
+	return s[:cut] + marker
 }

--- a/internal/multi/merger_test.go
+++ b/internal/multi/merger_test.go
@@ -1,0 +1,61 @@
+package multi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildMergeInput_TruncatesOversizeReviews(t *testing.T) {
+	// A verbose or hallucinating reviewer can dump a multi-megabyte
+	// payload that would blow the merger's context window if we
+	// concatenated it verbatim. Pin the cap.
+	huge := strings.Repeat("x", MaxReviewBytesForMerge*3)
+	results := []ReviewResult{
+		{LLM: "claude", Output: "small finding"},
+		{LLM: "gemini", Output: huge},
+	}
+	in := BuildMergeInput(results, 2)
+	if len(in.Reviews) != 2 {
+		t.Fatalf("want 2 reviews, got %d", len(in.Reviews))
+	}
+	// Find the gemini one — order is preserved by appearance.
+	var gem ReviewContent
+	for _, r := range in.Reviews {
+		if r.LLM == "gemini" {
+			gem = r
+		}
+	}
+	if len(gem.Content) > MaxReviewBytesForMerge {
+		t.Errorf("oversize review not truncated: len=%d, cap=%d", len(gem.Content), MaxReviewBytesForMerge)
+	}
+	if !strings.Contains(gem.Content, "truncated") {
+		t.Errorf("truncation marker missing from clipped content")
+	}
+}
+
+func TestBuildMergeInput_PassesNormalReviewsUnchanged(t *testing.T) {
+	body := "## Major Issues\n- file:42 — race condition.\n"
+	results := []ReviewResult{{LLM: "claude", Output: body}}
+	in := BuildMergeInput(results, 2)
+	if in.Reviews[0].Content != body {
+		t.Errorf("non-oversize review was modified — got:\n%s", in.Reviews[0].Content)
+	}
+}
+
+func TestBuildMergeInput_SkipsEmptyOutputs(t *testing.T) {
+	// Existing behavior preserved: a failed review with empty Output
+	// is dropped from the merge input rather than fed as an empty
+	// stub the merger has to interpret.
+	results := []ReviewResult{
+		{LLM: "claude", Output: "real finding"},
+		{LLM: "gemini", Output: ""},
+		{LLM: "codex", Output: "another"},
+	}
+	in := BuildMergeInput(results, 2)
+	if len(in.Reviews) != 2 {
+		t.Errorf("want 2 reviews (empty dropped), got %d", len(in.Reviews))
+	}
+	if in.LLMNames != "claude, codex" {
+		t.Errorf("LLMNames = %q, want %q", in.LLMNames, "claude, codex")
+	}
+}

--- a/internal/multi/orchestrator.go
+++ b/internal/multi/orchestrator.go
@@ -36,7 +36,13 @@ type ReviewResult struct {
 
 // RunParallel executes reviews concurrently for all configured LLMs.
 // Returns results for all LLMs (including failures).
-func (o *Orchestrator) RunParallel(ctx context.Context, diff, commit, branch string) ([]ReviewResult, error) {
+//
+// systemPrompt is the language-specific prompt pack content the
+// caller has already loaded (lang.Dominant + prompts.Get). Passed to
+// every invoker so all agents review the diff against identical
+// review-rules and severity tiering. Empty string is allowed — each
+// invoker has a generic fallback.
+func (o *Orchestrator) RunParallel(ctx context.Context, systemPrompt, diff, commit, branch string) ([]ReviewResult, error) {
 	var wg sync.WaitGroup
 	results := make([]ReviewResult, len(o.llms))
 
@@ -70,7 +76,7 @@ func (o *Orchestrator) RunParallel(ctx context.Context, diff, commit, branch str
 			defer cancel()
 
 			// Run review
-			output, err := invoker.Review(reviewCtx, diff)
+			output, err := invoker.Review(reviewCtx, systemPrompt, diff)
 			result.Duration = time.Since(start)
 
 			if err != nil {

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -59,36 +59,63 @@ func reset(on bool) string {
 	return ""
 }
 
-// WriteText renders a Report to w as terminal-friendly text.
-func WriteText(w io.Writer, r review.Report) {
+// WriteText renders a Report to w as terminal-friendly text. Returns
+// the first I/O error from the underlying writer. Previously this was
+// fire-and-forget — a broken-pipe (`local-review staged | head`) or
+// disk-full (`> /dev/full`) would silently exit 0 even though no
+// findings reached the user. Mirrors the errWriter pattern doctor.go
+// uses so callers get a single error to check at the end.
+func WriteText(w io.Writer, r review.Report) error {
+	ew := &errWriter{w: w}
 	color := useColor()
 	if len(r.Findings) == 0 {
-		fmt.Fprintf(w, "%sno findings%s — %d files reviewed via %s\n",
+		fmt.Fprintf(ew, "%sno findings%s — %d files reviewed via %s\n",
 			ifColor(color, colorDim), reset(color), r.Meta.Files, r.Meta.Model)
-		return
+		return ew.err
 	}
 
-	fmt.Fprintf(w, "%s%d finding(s)%s — %d files reviewed via %s\n\n",
+	fmt.Fprintf(ew, "%s%d finding(s)%s — %d files reviewed via %s\n\n",
 		ifColor(color, colorBold), len(r.Findings), reset(color), r.Meta.Files, r.Meta.Model)
 
 	for _, f := range r.Findings {
 		sevC := severityColor(f.Severity, color)
 		// Severity tag + location
-		fmt.Fprintf(w, "%s[%s]%s %s%s%s\n",
+		fmt.Fprintf(ew, "%s[%s]%s %s%s%s\n",
 			sevC, f.Severity, reset(color),
 			ifColor(color, colorCyan), f.Loc(), reset(color))
 		// Title
-		fmt.Fprintf(w, "  %s%s%s\n", ifColor(color, colorBold), f.Title, reset(color))
+		fmt.Fprintf(ew, "  %s%s%s\n", ifColor(color, colorBold), f.Title, reset(color))
 		// Body
 		if f.Body != "" {
-			fmt.Fprintf(w, "  %s\n", f.Body)
+			fmt.Fprintf(ew, "  %s\n", f.Body)
 		}
 		// Optional tag
 		if f.Tag != "" {
-			fmt.Fprintf(w, "  %s#%s%s\n", ifColor(color, colorMagenta), f.Tag, reset(color))
+			fmt.Fprintf(ew, "  %s#%s%s\n", ifColor(color, colorMagenta), f.Tag, reset(color))
 		}
-		fmt.Fprintln(w)
+		fmt.Fprintln(ew)
 	}
+	return ew.err
+}
+
+// errWriter is an io.Writer that captures the first error from the
+// underlying writer and short-circuits subsequent writes — same shape
+// as the doctor's errWriter so multi-line output can ignore the per-
+// fmt.Fprintf return values and check one error at the end.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) Write(p []byte) (int, error) {
+	if ew.err != nil {
+		return 0, ew.err
+	}
+	n, err := ew.w.Write(p)
+	if err != nil {
+		ew.err = err
+	}
+	return n, err
 }
 
 // WriteJSON renders a Report as machine-readable JSON.

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -1,0 +1,68 @@
+package output
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mshykov/local-review/internal/review"
+)
+
+// failingWriter returns the configured error after `succeedFor` bytes
+// have been written. Lets a single test exercise both the immediate-fail
+// path and the partial-write-then-fail path.
+type failingWriter struct {
+	succeedFor int
+	written    int
+	err        error
+}
+
+func (fw *failingWriter) Write(p []byte) (int, error) {
+	if fw.written >= fw.succeedFor {
+		return 0, fw.err
+	}
+	n := len(p)
+	if fw.written+n > fw.succeedFor {
+		n = fw.succeedFor - fw.written
+	}
+	fw.written += n
+	return n, nil
+}
+
+func TestWriteText_ReturnsWriteError(t *testing.T) {
+	// Previously this was fire-and-forget — broken-pipe / disk-full
+	// would silently exit 0 even though no findings reached the user.
+	// Pin the new contract: the first underlying error propagates.
+	rep := review.Report{
+		Findings: []review.Finding{
+			{File: "a.go", Line: 1, Severity: review.SeverityMajor, Title: "x", Body: "y"},
+		},
+		Meta: review.ReportMeta{Files: 1, Model: "test"},
+	}
+	want := errors.New("disk full")
+	fw := &failingWriter{succeedFor: 0, err: want}
+
+	got := WriteText(fw, rep)
+	if !errors.Is(got, want) {
+		t.Errorf("WriteText error: got %v, want %v", got, want)
+	}
+}
+
+func TestWriteText_NoFindingsAlsoPropagates(t *testing.T) {
+	// Empty-report path takes a shorter codepath; make sure it threads
+	// the error too, not just the loop body.
+	rep := review.Report{Meta: review.ReportMeta{Files: 0, Model: "test"}}
+	want := errors.New("broken pipe")
+	fw := &failingWriter{succeedFor: 0, err: want}
+	if got := WriteText(fw, rep); !errors.Is(got, want) {
+		t.Errorf("empty-report path: got %v, want %v", got, want)
+	}
+}
+
+func TestWriteText_SuccessReturnsNil(t *testing.T) {
+	// Sanity: happy path doesn't accidentally return a stale error.
+	rep := review.Report{Meta: review.ReportMeta{Files: 0, Model: "test"}}
+	fw := &failingWriter{succeedFor: 1 << 16, err: errors.New("never reached")}
+	if err := WriteText(fw, rep); err != nil {
+		t.Errorf("expected nil error on success, got %v", err)
+	}
+}

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/mshykov/local-review/internal/review"
@@ -25,6 +26,18 @@ func (fw *failingWriter) Write(p []byte) (int, error) {
 		n = fw.succeedFor - fw.written
 	}
 	fw.written += n
+	// io.Writer contract: a short write (n < len(p)) MUST return a
+	// non-nil error. Returning (n, nil) here would let fmt.Fprintf
+	// callers treat truncated writes as success and the error
+	// propagation we're testing wouldn't fire. Use io.ErrShortWrite
+	// so the assertion still catches via errors.Is(err, fw.err) when
+	// fw.err is set by the caller.
+	if n < len(p) {
+		if fw.err != nil {
+			return n, fw.err
+		}
+		return n, io.ErrShortWrite
+	}
 	return n, nil
 }
 

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -169,6 +169,14 @@ func applyFilters(in []Finding, min Severity, max int) []Finding {
 	return out
 }
 
+// FilterDiffs keeps diffs matching any include glob (when set) and not
+// matching any exclude glob. Exported so the multi-LLM runner can apply
+// the same review.include/review.exclude config the single-LLM path
+// already uses — pre-v0.5.x the multi path silently bypassed both.
+func FilterDiffs(diffs []git.Diff, include, exclude []string) []git.Diff {
+	return filter(diffs, include, exclude)
+}
+
 // filter keeps diffs matching any IncludeGlob (when set) and not
 // matching any ExcludeGlob.
 func filter(diffs []git.Diff, include, exclude []string) []git.Diff {

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -262,12 +262,20 @@ func FilterDiffs(diffs []git.Diff, include, exclude []string) []git.Diff {
 // loop. Pre-fix matchGlob did regexp.Compile inside the inner loop —
 // for a 500-file repo with 5 globs that's 2,500 compiles. Now it's
 // at most len(include)+len(exclude).
+//
+// Include semantics deliberately fail closed: if `include` was
+// non-empty but every pattern failed to compile, we drop everything.
+// The legacy matchGlob path also fail-closed (compile error → no
+// match → file excluded by the include test). Without this guard a
+// user typo'ing the only include rule would silently *expand* the
+// review to every file in the diff.
 func filter(diffs []git.Diff, include, exclude []string) []git.Diff {
 	includeRE := compileGlobs(include)
 	excludeRE := compileGlobs(exclude)
+	includeRequested := len(include) > 0
 	out := diffs[:0]
 	for _, d := range diffs {
-		if len(includeRE) > 0 && !matchesAnyCompiled(d.Path, includeRE) {
+		if includeRequested && !matchesAnyCompiled(d.Path, includeRE) {
 			continue
 		}
 		if matchesAnyCompiled(d.Path, excludeRE) {

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -257,13 +257,20 @@ func FilterDiffs(diffs []git.Diff, include, exclude []string) []git.Diff {
 
 // filter keeps diffs matching any IncludeGlob (when set) and not
 // matching any ExcludeGlob.
+//
+// Compiles each pattern to a regex exactly once before the per-file
+// loop. Pre-fix matchGlob did regexp.Compile inside the inner loop —
+// for a 500-file repo with 5 globs that's 2,500 compiles. Now it's
+// at most len(include)+len(exclude).
 func filter(diffs []git.Diff, include, exclude []string) []git.Diff {
+	includeRE := compileGlobs(include)
+	excludeRE := compileGlobs(exclude)
 	out := diffs[:0]
 	for _, d := range diffs {
-		if len(include) > 0 && !matchesAny(d.Path, include) {
+		if len(includeRE) > 0 && !matchesAnyCompiled(d.Path, includeRE) {
 			continue
 		}
-		if matchesAny(d.Path, exclude) {
+		if matchesAnyCompiled(d.Path, excludeRE) {
 			continue
 		}
 		out = append(out, d)
@@ -271,24 +278,55 @@ func filter(diffs []git.Diff, include, exclude []string) []git.Diff {
 	return out
 }
 
-func matchesAny(path string, patterns []string) bool {
+// compileGlobs converts each pattern to a regex via globToRegex.
+// Patterns that fail to compile are silently dropped (same fail-open
+// behavior as the legacy matchGlob, which returned false on compile
+// error). A failing pattern is invariably a config typo we can't fix
+// from this layer; the user-visible signal is that the glob doesn't
+// match anything.
+func compileGlobs(patterns []string) []*regexp.Regexp {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]*regexp.Regexp, 0, len(patterns))
 	for _, p := range patterns {
-		if matchGlob(path, p) {
+		if re, err := regexp.Compile(globToRegex(p)); err == nil {
+			out = append(out, re)
+		}
+	}
+	return out
+}
+
+func matchesAnyCompiled(path string, res []*regexp.Regexp) bool {
+	for _, re := range res {
+		if re.MatchString(path) {
 			return true
 		}
 	}
 	return false
 }
 
-// matchGlob is a tiny glob matcher with `**` support. We convert the
-// glob to a regex once per check — perf is fine because we run this
-// against handfuls of files, not millions.
+// matchesAny is the un-compiled variant kept for tests and any caller
+// that has a string slice handy and doesn't care about per-call regex
+// compile cost. Production filtering goes through compileGlobs +
+// matchesAnyCompiled.
+func matchesAny(path string, patterns []string) bool {
+	return matchesAnyCompiled(path, compileGlobs(patterns))
+}
+
+// matchGlob is a tiny glob matcher with `**` support. Kept for tests
+// and back-compat with any external caller; production filtering uses
+// compileGlobs + matchesAnyCompiled to amortize regex compilation
+// across all paths in a diff.
 //
 // Semantics:
 //
-//   - matches any chars except '/'
-//     ** matches any chars (including '/')
-//     ?  matches one char except '/'
+//	*   matches any chars except '/'
+//	**/ matches zero or more path segments (anchored to a path
+//	    boundary, so **/dist/** does NOT match src/mydist/file)
+//	**  matches any chars (including '/'); only at end of pattern
+//	?   matches one char except '/'
+//	[ab] / [a-z] / [!ab] character classes (glob-native, [!...] → [^...])
 func matchGlob(path, pattern string) bool {
 	re, err := regexp.Compile(globToRegex(pattern))
 	if err != nil {
@@ -304,19 +342,45 @@ func globToRegex(pattern string) string {
 		c := pattern[i]
 		switch {
 		case c == '*' && i+1 < len(pattern) && pattern[i+1] == '*':
-			sb.WriteString(".*")
-			i++
-			// `**/foo` — consume the slash so the regex doesn't
-			// require an extra `/` between `.*` and the next chunk.
+			i++ // consume the second *
+			// `**/x` should match "x at the start of any path segment"
+			// — emit (?:.*/)? so the trailing slash is part of the
+			// optional prefix. Pre-fix we emitted plain `.*`, which
+			// happily matched src/mydist/file against **/dist/** by
+			// gobbling "src/my" without requiring a path boundary.
 			if i+1 < len(pattern) && pattern[i+1] == '/' {
-				i++
+				sb.WriteString(`(?:.*/)?`)
+				i++ // consume the /
+			} else {
+				// `**` at end of pattern — match anything remaining.
+				sb.WriteString(".*")
 			}
 		case c == '*':
 			sb.WriteString("[^/]*")
 		case c == '?':
 			sb.WriteString("[^/]")
+		case c == '[':
+			// Glob character class. Copy verbatim until the matching ']',
+			// translating a leading '!' into regex '^' negation. If we
+			// don't find a closing ']' we fall back to escaping the '['
+			// — that's what filepath.Match does and what users on the
+			// receiving end of a malformed glob probably expect.
+			end := strings.IndexByte(pattern[i+1:], ']')
+			if end < 0 {
+				sb.WriteString(`\[`)
+				continue
+			}
+			body := pattern[i+1 : i+1+end]
+			sb.WriteByte('[')
+			if strings.HasPrefix(body, "!") {
+				sb.WriteByte('^')
+				body = body[1:]
+			}
+			sb.WriteString(body)
+			sb.WriteByte(']')
+			i += 1 + end // skip past the ']'
 		case c == '.', c == '+', c == '(', c == ')', c == '|',
-			c == '^', c == '$', c == '{', c == '}', c == '[', c == ']', c == '\\':
+			c == '^', c == '$', c == '{', c == '}', c == ']', c == '\\':
 			sb.WriteByte('\\')
 			sb.WriteByte(c)
 		default:

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -100,7 +100,14 @@ func buildUserMessage(diffs []git.Diff) string {
 }
 
 // parseFindings extracts the LLM's JSON. Tolerates surrounding prose
-// or markdown fences (some providers re-wrap in ```json```).
+// or markdown fences (some providers re-wrap in ```json```), and
+// multi-block output where the LLM shows an example object first and
+// the actual answer second ("Here's an example {...}. My result: {...}").
+//
+// The previous "first-{ to last-}" heuristic concatenated example +
+// prose + answer into one substring and then failed to unmarshal,
+// producing a confusing parse error on what should have been a clean
+// review response.
 func parseFindings(raw string) ([]Finding, error) {
 	body := strings.TrimSpace(raw)
 	body = strings.TrimPrefix(body, "```json")
@@ -108,32 +115,103 @@ func parseFindings(raw string) ([]Finding, error) {
 	body = strings.TrimSuffix(body, "```")
 	body = strings.TrimSpace(body)
 
-	first := strings.Index(body, "{")
-	last := strings.LastIndex(body, "}")
-	if first < 0 || last <= first {
+	candidates := topLevelJSONObjects(body)
+	if len(candidates) == 0 {
 		return nil, fmt.Errorf("no JSON object found in response")
 	}
-	body = body[first : last+1]
 
-	var envelope struct {
-		Findings []rawFinding `json:"findings"`
+	// Try the LAST candidate first. LLMs that emit an example block
+	// followed by the real answer always put the answer last, so this
+	// keeps the happy path one unmarshal call. Fall back through the
+	// earlier candidates so degraded outputs still parse.
+	//
+	// We probe each candidate with a `map[string]json.RawMessage` first
+	// to confirm it has a "findings" key — Go's json.Unmarshal silently
+	// ignores unknown fields, so a stray `{"note": "..."}` block at the
+	// end would otherwise look like a valid empty-findings envelope and
+	// shadow the real one earlier in the response.
+	var lastErr error
+	for i := len(candidates) - 1; i >= 0; i-- {
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(candidates[i]), &probe); err != nil {
+			lastErr = err
+			continue
+		}
+		raw, ok := probe["findings"]
+		if !ok {
+			continue
+		}
+		var findings []rawFinding
+		if err := json.Unmarshal(raw, &findings); err != nil {
+			lastErr = err
+			continue
+		}
+		out := make([]Finding, 0, len(findings))
+		for _, f := range findings {
+			out = append(out, Finding{
+				File:     f.File,
+				Line:     f.Line,
+				Severity: ParseSeverity(f.Severity),
+				Title:    f.Title,
+				Body:     f.Body,
+				Tag:      f.Tag,
+			})
+		}
+		return out, nil
 	}
-	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
-		return nil, err
+	if lastErr != nil {
+		return nil, lastErr
 	}
+	return nil, fmt.Errorf("no JSON object with a `findings` key found in response")
+}
 
-	out := make([]Finding, 0, len(envelope.Findings))
-	for _, f := range envelope.Findings {
-		out = append(out, Finding{
-			File:     f.File,
-			Line:     f.Line,
-			Severity: ParseSeverity(f.Severity),
-			Title:    f.Title,
-			Body:     f.Body,
-			Tag:      f.Tag,
-		})
+// topLevelJSONObjects scans s and returns every balanced top-level
+// `{...}` substring in order of appearance. Tracks string-literal
+// state (with backslash escaping) so braces inside JSON strings
+// don't mis-balance the scanner. Square brackets aren't tracked
+// because the LLM envelope is always an object.
+func topLevelJSONObjects(s string) []string {
+	var out []string
+	depth := 0
+	start := -1
+	inString := false
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth == 0 {
+				// Stray closing brace — ignore, no balanced object opens here.
+				continue
+			}
+			depth--
+			if depth == 0 && start >= 0 {
+				out = append(out, s[start:i+1])
+				start = -1
+			}
+		}
 	}
-	return out, nil
+	return out
 }
 
 type rawFinding struct {

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -1,6 +1,10 @@
 package review
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mshykov/local-review/internal/git"
+)
 
 func TestParseFindings(t *testing.T) {
 	cases := map[string]int{
@@ -130,5 +134,62 @@ func TestMatchesAny(t *testing.T) {
 	}
 	if matchesAny("src/foo.ts", []string{"**/*.lock"}) {
 		t.Error("did not expect **/*.lock to match src/foo.ts")
+	}
+}
+
+func TestMatchesAny_PathSegmentBoundary(t *testing.T) {
+	// Pre-fix `**/dist/**` emitted `.*dist/.*` which happily matched
+	// src/mydist/file because `.*` doesn't enforce a path boundary.
+	// New emission `(?:.*/)?dist/(?:.*)` requires `dist` at the start
+	// of a path segment.
+	if matchesAny("src/mydist/file.go", []string{"**/dist/**"}) {
+		t.Error("**/dist/** must NOT match src/mydist/file.go (no path-segment boundary)")
+	}
+	if matchesAny("src/mydist/file.go", []string{"**/mydist/**"}) {
+		// Sanity: the same path matches when the directory name is correct.
+	} else {
+		t.Error("**/mydist/** should match src/mydist/file.go")
+	}
+	// Cases that must still match: a directory named exactly `dist`.
+	for _, path := range []string{"dist/file.go", "src/dist/file.go", "a/b/c/dist/file.go"} {
+		if !matchesAny(path, []string{"**/dist/**"}) {
+			t.Errorf("**/dist/** should match %q", path)
+		}
+	}
+}
+
+func TestMatchesAny_CharacterClass(t *testing.T) {
+	// Bracket support: previously the matcher escaped `[` to a literal,
+	// so a glob like `**/foo[0-9].go` became regex \[0-9\] and matched
+	// nothing useful. Now bracket classes work like filepath.Match,
+	// with [!...] negation translated to regex [^...].
+	if !matchesAny("src/foo3.go", []string{"**/foo[0-9].go"}) {
+		t.Error("**/foo[0-9].go should match src/foo3.go")
+	}
+	if matchesAny("src/fooA.go", []string{"**/foo[0-9].go"}) {
+		t.Error("**/foo[0-9].go must NOT match src/fooA.go")
+	}
+	if !matchesAny("src/fooA.go", []string{"**/foo[!0-9].go"}) {
+		t.Error("**/foo[!0-9].go (negated class) should match src/fooA.go")
+	}
+}
+
+// Pin that compileGlobs is called O(globs) times, not O(globs * files).
+// This is a performance contract: filter() must amortize regex
+// compilation across the per-file loop, not pay it inside the loop.
+func TestFilterCompilesGlobsOnce(t *testing.T) {
+	// We can't directly observe regexp.Compile call counts without
+	// instrumentation, but we can confirm the public surface still
+	// produces correct output even when many files share the same
+	// glob set — the slow O(N*M) path passed too, this just guards
+	// the wiring stays through compileGlobs.
+	diffs := make([]git.Diff, 100)
+	for i := range diffs {
+		diffs[i].Path = "src/file.go"
+	}
+	diffs[0].Path = "vendor/x.go"
+	out := filter(diffs, nil, []string{"vendor/**"})
+	if len(out) != 99 {
+		t.Errorf("after excluding vendor/**: want 99 diffs, got %d", len(out))
 	}
 }

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -21,6 +21,75 @@ func TestParseFindings(t *testing.T) {
 	}
 }
 
+func TestParseFindings_PrefersLastTopLevelObject(t *testing.T) {
+	// Multi-block LLM output: a non-conforming "example" object first,
+	// the actual envelope second. The legacy first-{..last-} extractor
+	// concatenated both into one substring and failed to unmarshal;
+	// the brace-counter must skip past the example and parse the real
+	// answer.
+	raw := `Here is an example of the schema:
+{"example": "ignore me", "shape": {"foo": "bar"}}
+
+And here is my actual review:
+{"findings":[{"file":"a.go","severity":"major","title":"t","body":"b"}]}`
+	got, err := parseFindings(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Title != "t" {
+		t.Errorf("got %+v, expected one finding titled 't'", got)
+	}
+}
+
+func TestParseFindings_FallsBackToEarlierCandidates(t *testing.T) {
+	// If the *last* object isn't our envelope shape (e.g., the LLM
+	// trailed off into a "next steps" block), an earlier balanced
+	// object that *is* our shape should still parse. Defends against
+	// "post-answer chitchat" output drift.
+	raw := `{"findings":[{"file":"a","severity":"warning","title":"x","body":"y"}]}
+
+Note: I don't have access to the build system, so {"missing": "context"}.`
+	got, err := parseFindings(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("want 1 finding, got %d", len(got))
+	}
+}
+
+func TestTopLevelJSONObjects_HandlesBraceInString(t *testing.T) {
+	// `}` inside a JSON string literal must not close the object.
+	// Real LLM output regularly contains code snippets in `body`
+	// fields, e.g. "if err != nil { return err }".
+	in := `{"a": "if err != nil { return err }"}`
+	got := topLevelJSONObjects(in)
+	if len(got) != 1 || got[0] != in {
+		t.Errorf("expected one object %q, got %v", in, got)
+	}
+}
+
+func TestTopLevelJSONObjects_HandlesEscapedQuote(t *testing.T) {
+	// Escaped quotes inside strings must not flip the in-string state
+	// — otherwise `\"` would look like end-of-string and the next `}`
+	// would prematurely close the object.
+	in := `{"a": "she said \"hi\" } no really"}`
+	got := topLevelJSONObjects(in)
+	if len(got) != 1 || got[0] != in {
+		t.Errorf("expected one object %q, got %v", in, got)
+	}
+}
+
+func TestTopLevelJSONObjects_StrayCloseBraceIgnored(t *testing.T) {
+	// A garbage `}` before the first `{` shouldn't cause a panic or
+	// misalign the scanner.
+	in := `} stray { "ok": true }`
+	got := topLevelJSONObjects(in)
+	if len(got) != 1 || got[0] != `{ "ok": true }` {
+		t.Errorf("got %v", got)
+	}
+}
+
 func TestApplyFilters_SeverityCutoff(t *testing.T) {
 	in := []Finding{
 		{File: "a", Severity: SeverityNit, Title: "n"},

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -174,6 +174,33 @@ func TestMatchesAny_CharacterClass(t *testing.T) {
 	}
 }
 
+func TestFilter_AllInvalidIncludesFailClosed(t *testing.T) {
+	// Copilot caught this: when `include:` is set but every pattern
+	// fails to compile, compileGlobs returns an empty slice. Pre-fix
+	// the loop saw len(includeRE) == 0 and treated it as "no include
+	// filter set", silently *expanding* the review to all files —
+	// the opposite of what the user asked for. Now: include was
+	// requested but matched nothing → no files match (fail closed).
+	//
+	// `[!]` is the easiest reproducible invalid case: globToRegex
+	// emits regex `[^]`, which Go's regexp.Compile rejects with
+	// "missing closing ]". A user typing this as their only include
+	// rule must NOT accidentally get every file reviewed.
+	diffs := []git.Diff{
+		{Path: "src/foo.go"},
+		{Path: "src/bar.ts"},
+	}
+	out := filter(diffs, []string{"[!]"}, nil)
+	if len(out) != 0 {
+		t.Errorf("filter with all-invalid include should match nothing (fail-closed), got %d files", len(out))
+	}
+	// Sanity: a *valid* include still returns the matching subset.
+	out = filter(diffs, []string{"src/*.go"}, nil)
+	if len(out) != 1 || out[0].Path != "src/foo.go" {
+		t.Errorf("valid include should match correct subset, got %v", out)
+	}
+}
+
 // Pin that compileGlobs is called O(globs) times, not O(globs * files).
 // This is a performance contract: filter() must amortize regex
 // compilation across the per-file loop, not pay it inside the loop.

--- a/internal/review/types.go
+++ b/internal/review/types.go
@@ -36,7 +36,12 @@ func (s Severity) String() string {
 }
 
 // ParseSeverity converts a string ("nit", "info", "warning", "major",
-// "critical") to a Severity. Unknown values default to warning.
+// "critical") to a Severity. Unknown values default to **major** —
+// fail-closed for the pre-commit gate. Previously unknown values
+// defaulted to warning, which silently demoted LLM-typo'd severities
+// like "criticl" or "sev-high" out of the blocking range. The gate is
+// safety-critical, so we'd rather over-block on a malformed finding
+// than under-block on a real one.
 func ParseSeverity(s string) Severity {
 	switch s {
 	case "nit":
@@ -50,7 +55,7 @@ func ParseSeverity(s string) Severity {
 	case "critical":
 		return SeverityCritical
 	default:
-		return SeverityWarning
+		return SeverityMajor
 	}
 }
 

--- a/internal/review/types_test.go
+++ b/internal/review/types_test.go
@@ -33,13 +33,17 @@ func TestSeverityJSONRoundTrip(t *testing.T) {
 }
 
 func TestSeverityUnmarshalUnknown(t *testing.T) {
-	// Unknown strings demote to warning, matching ParseSeverity.
+	// Unknown strings *promote* to major — fail-closed for the gate.
+	// LLM typos ("criticl", "sev-high", "BLOCKER") used to silently
+	// demote to warning, hiding real blocking findings from the
+	// pre-commit hook. We'd rather over-block a malformed finding than
+	// under-block a real one.
 	var got Severity
 	if err := json.Unmarshal([]byte(`"bogus"`), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if got != SeverityWarning {
-		t.Errorf("unknown -> %v, want %v", got, SeverityWarning)
+	if got != SeverityMajor {
+		t.Errorf("unknown -> %v, want %v (fail-closed)", got, SeverityMajor)
 	}
 }
 


### PR DESCRIPTION
## Summary

38 commits accumulated across **5 rounds of code review** (claude self-review + 3 external audit batches + maintainer-requested CI/CD change). This is the first release that delivers on the v0.5.0 multi-LLM promise end-to-end: agents actually use the project's language-specific prompt packs, `api_key_env` actually works, and the privacy story is honest about what default mode does.

## Headline changes

### Multi-LLM finally honors the project's review rules
- Pre-fix, every multi-LLM agent ran with a generic 4-bullet prompt while README claimed it auto-picked language-specific packs. Fixed: `lang.Dominant` + `prompts.Get` now feed each agent the same Go/TS/Python/Rust pack the single-LLM path uses, with a markdown-output override appended so the merger can consolidate prose.

### `api_key_env` works end-to-end
- Doctor reads the configured env var (not the hardcoded canonical one), error hints point at *the user's* env var, and invokers inject the resolved key into the subprocess as the canonical name each CLI expects. A user with `api_key_env: MY_GEMINI_KEY` now sees ✓ ready and gemini actually authenticates.

### Privacy posture honest
- README's "Privacy" section was overclaiming for default multi-LLM (which fans the diff out to Claude/Gemini/Codex cloud backends). Replaced with a per-mode matrix.

### Release gate: Copilot review required (maintainer request)
- `release.yml` now refuses to tag/build/publish unless the merged PR has a complete Copilot review with every Copilot conversation resolved. Manual `workflow_dispatch` bypasses (escape hatch). See the new "Verify Copilot review" step in the prepare job.

## Detailed changelog (by area)

### Performance & correctness
- `parseUnifiedDiff` streams via `bufio.Scanner` — no more N+ MB doubling on large monorepo branch diffs.
- `filter`: globs compile once, not in the per-file loop. `**/dist/**` now correctly anchors to a path-segment boundary (was matching `src/mydist/file`). Bracket character classes (`[0-9]`, `[!a-z]`) actually work.
- LLM client caps response body at 10 MB (defends against runaway/spoofed providers).
- `parseFindings` uses brace-counting + a `findings`-key probe instead of first/last `{`/`}` index — handles multi-block LLM output (example + answer) without garbage between.
- Merger input truncated per-review (8 KB cap) to fit context window — verbose reviews can no longer crash the merge step.
- Diff parser preserves deleted-file paths (`+++ /dev/null` → original path from `---`).
- Hunk-content lookalikes (deleted SQL comments `-- a/users` etc.) no longer mistaken for file headers.

### Security / safety
- Git refs validated at boundary: `-`-prefixed input rejected (flag-injection defense).
- Severity parsing fails closed: unknown values → `major` (was `warning`, which silently demoted typo'd severities out of the blocking range).
- Pre-commit gate strengthened: also keys off Recommendation line + heading variants.
- `--only` refuses single-LLM fallback when nothing matches (privacy/cost footgun: typo'd agent name used to send the diff to whatever provider was configured).

### UX / config
- Per-agent model overrides (`--claude-model`, `--gemini-model`, `--codex-model`) actually take effect (was previously printed in the roster but never threaded to the invoker).
- `cli_path` honored: corporate / nix-store installs at non-standard paths work.
- `local-review config` applies CLI flag overrides (was claimed in --help but ignored).
- `--merge-with` reflected in `config` preview.
- Storage SHA normalized — full and short SHAs hit the same key.
- Ollama "no API key" path: empty key + localhost base_url proceeds without rejection.
- Banner switched to figlet small font (~70 cols, fits narrow terminals).
- README, CLAUDE.md, SECURITY.md sweep for staleness.

### Output / errors
- `WriteText` propagates I/O errors (broken pipe, disk full no longer silently exit 0).
- Gemini/Claude invokers preserve subprocess stderr on failure (match codex pattern).
- `configCmd` surfaces yaml-encoder Close errors.
- Detached-HEAD review writes to `detached-<short-sha>/` instead of colliding under `HEAD/`.
- Merge-failure-exits-0 gap closed (TrimSpace check).
- "no API key" error names the actual configured env var, not the legacy default.

### Architecture
- `LLMConfig.Mode` field removed (was never wired through).
- JavaScript routes to TypeScript pack (no separate `javascript.md` ships).
- CodexInvoker uses `codex exec --output-last-message` instead of bare `codex` (which was launching the interactive TUI in v0.5.0).
- `config.merge()` locked down with a reflection-based completeness test (catches "added field, forgot overlay branch" footguns at test time, no runtime dep).

## Test plan

- [x] `go test -race ./...` green across all packages
- [x] `go vet ./...` clean
- [x] `internal/multi` no longer `[no test files]` — first direct coverage via `merger_test.go`
- [x] New tests pin: glob path-segment boundary, bracket classes, merger truncation, Ollama localhost bypass, custom env var auth, multi-block JSON extraction, ref validation, severity fail-closed default
- [x] Release workflow YAML parsed + new "Verify Copilot review" step verified well-formed

## Notes for review

- This branch deliberately does NOT have a `release` label. The new Copilot gate would block the workflow anyway — please add `release` only after Copilot has reviewed and all its threads are resolved.
- Suggested bump: `minor`. There's no documented user-facing breaking change (the removed `mode:` field was inert; `LLMConfig` schema accepts unknown fields silently). If we want to be conservative about the multi-LLM-now-uses-packs behavior change, `major` is also defensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-LLM parallel review with merged, size-capped merge input, per-LLM model/key selection, and system-prompt support
  * Release artifacts now include a SHA-256 checksums manifest and installer verifies integrity

* **Bug Fixes**
  * Stronger blocking detection, safer diff parsing/ref validation, and robust I/O / oversized-response handling
  * Tighter CLI behavior for fallback/flags and help banner sizing

* **Documentation**
  * Updated privacy, security matrix, multi-LLM usage, and configuration guidance

* **Tests**
  * Expanded coverage across multi-LLM, diff parsing, glob filters, JSON extraction, and output/error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->