### PR TITLE
chore: retro section in CLAUDE.md + landing-page UI fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,16 @@ Glob filtering (include/exclude) uses a custom `**` glob matcher (review.go:matc
 - **Tests required** — new logic needs a unit test
 - **One-line doc comments** — exported functions/types only
 
+## Recurring failure patterns (review retrospective)
+
+`cmd/local-review/runner.go` + `cmd/local-review/doctor.go` account for ~40% of all reviewer findings across v0.4.0–v0.6.1. Both are orchestration files where multiple concepts meet. Following the rules below avoids re-living the same review iteration cycle.
+
+1. **Migrating a shared helper or contract? Grep all callers in the same commit.** Doc comments, sibling sites, README quotes, CHANGELOG, prompt templates. Drift across files is the #1 reviewer-flagged class of defect on this codebase (the `CountSuccessful` → `CountWithOutput` migration drifted across 5 review rounds before all sites aligned).
+2. **Doc comments and cobra `Long:` strings describe the *current* behavior, not yesterday's.** A comment claiming a function is "optional" while the function always fires is a bug. Update the comment in the same edit that changes the behavior.
+3. **Default to fail-closed.** `TrimSpace` for emptiness checks; check `grep` exit code separately from `sha256sum`; honor `pageInfo.hasNextPage`; refuse on invalid input rather than silently passing it through. When in doubt, return an error and let the caller decide.
+4. **Writing a v2 code path next to a v1 path? Enumerate v1's invariants explicitly and re-exercise each in v2.** Filters, severity caps, prompt-pack selection, JSON output, glob behavior — none of these carry over implicitly. PR #34 (v0.5.0 multi-LLM rewrite) shipped 5 separate "v2 dropped this" findings.
+5. **User-visible strings drift fast.** When changing a CLI output line, error message, or warning, grep the repo for the prior wording — CHANGELOG, README, prompt templates, help text, and tests likely all need to update with it.
+
 ## Pre-push Workflow (dogfooding)
 
 **Before pushing any branch to GitHub, run a self-review with the project's own tool.**

--- a/docs/index.html
+++ b/docs/index.html
@@ -528,7 +528,11 @@
       color: #2d3748;
     }
 
-    .scope-col.is h3 { color: #2f855a; }
+    /* Match the saturation/weight of the red on the right column.
+       #2f855a was a light leaf-green that read as washed out next to
+       #c53030; #22543d (same tone as the FREE-pill text) lands closer
+       to the red's visual weight. */
+    .scope-col.is h3 { color: #22543d; }
     .scope-col.isnt h3 { color: #c53030; }
 
     .scope-col ul {
@@ -751,7 +755,7 @@
         <div class="llm-card paid">
           <h3>Codex</h3>
           <p>ChatGPT Plus subscription <strong>or</strong> OpenAI API key</p>
-          <span class="badge badge-paid">Paid (either way)</span>
+          <span class="badge badge-paid">Paid</span>
           <p style="margin-top: 10px; font-size: 0.9em; color: #666;">Disabled by default. API key path is pay-per-token (usually cheapest for occasional review).</p>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -530,7 +530,7 @@
 
     /* Match the saturation/weight of the red on the right column.
        #2f855a was a light leaf-green that read as washed out next to
-       #c53030; #22543d (same tone as the FREE-pill text) lands closer
+       #c53030; #22543d (same tone as the FREE badge text) lands closer
        to the red's visual weight. */
     .scope-col.is h3 { color: #22543d; }
     .scope-col.isnt h3 { color: #c53030; }


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: new \`Recurring failure patterns (review retrospective)\` section with 5 rules distilled from analysing 66 reviewer findings across PRs #27–#38 (v0.4.0 → v0.6.1).
- **Landing page**: shorten Codex pill to \`Paid\` so the three LLM-card pills line up. Darken the \`What it is\` heading from \`#2f855a\` to \`#22543d\` so it visually balances the right column's red.

No release.

## Why retro now

Eight PRs, ~66 inline findings, two hotspot files (\`runner.go\` 17 findings + \`doctor.go\` 10) accounting for ~41% of everything. Patterns:

| Pattern | Share | Example |
|---|---|---|
| Coupling drift | ~45% | \`CountSuccessful\` → \`CountWithOutput\` migration drifted across 5 review rounds |
| Fail-open silently | ~18% | empty checks not catching whitespace, pagination cap with no \`hasNextPage\`, grep-pipefail trap |
| v2 path skipped v1 invariants | ~9% | PR #34 dropped filters, severity caps, prompt-pack selection, JSON output |
| Test gaps for fail-closed paths | ~8% | new gate, no regression test |
| Boundary edges | ~5% | UTF-8 slicing, CRLF, short-SHA collisions |

The 5 rules in CLAUDE.md target the top 4 categories. Iterate if future PRs reveal different patterns.

## Test plan

- [ ] Eyeball landing page: three pills now match width
- [ ] Eyeball "What it is, what it isn't" block: green now reads as deliberate, not washed out
- [ ] CI green (markdown + html only, should be trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Recurring failure patterns (review retrospective)" section outlining five guidelines for review workflow consistency, invariant clarity, and preventing drift in behavior and user-facing strings.
  * Updated color styling for the "What it is" subsection title.
  * Simplified the Codex badge label text from "Paid (either way)" to "Paid".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->