### PR TITLE
fix: restore figlet banner + landing-page UI polish + prompt-pack gap closure

### DIFF
--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -25,24 +25,37 @@ import (
 	"github.com/mshykov/local-review/internal/git"
 )
 
-// banner is the single-line "local-review" header shown atop --help on
-// a TTY. The previous 5-line figlet ate too much vertical space — for a
-// reviewer that runs from `git commit` editors and CI logs, compact
-// wins over decorative. helpHeader() still suppresses the banner for
+// banner is the figlet small-font "LOCAL-REVIEW" art shown atop --help.
+// Small font fits in ~70 columns vs the original block font's ~120, so
+// it stays readable on narrow tmux panes, the `git commit` editor, and
+// most CI logs without wrapping. helpHeader() suppresses it for
 // non-TTY stdout (pipes/files) so machine-readable callers get clean
-// text.
-const banner = "── local-review · multi-LLM code review ──"
+// text, and gates on terminal width so it doesn't garble narrow
+// terminals.
+const banner = `
+   _    ___   ___   _   _       ___ _____   _____ _____      __
+  | |  / _ \ / __| /_\ | |  ___| _ \ __\ \ / /_ _| __\ \    / /
+  | |_| (_) | (__ / _ \| |_|___|   / _| \ V / | || _| \ \/\/ /
+  |____\___/ \___/_/ \_\____|  |_|_\___| \_/ |___|___| \_/\_/
+`
 
-// helpHeader returns the banner when stdout is a TTY, or an empty
-// string otherwise. We use term.IsTerminal on the stdout fd; $COLUMNS
-// isn't reliable here because shells don't export it to child
-// processes by default.
+// helpHeader returns the banner when stdout is a wide-enough terminal,
+// or an empty string otherwise. The small-font banner is ~70 cols, so
+// the gate is set at 70.
+//
+// We use term.GetSize on the stdout fd. $COLUMNS isn't reliable here —
+// shells don't export it to child processes by default, so falling
+// back to it would silently disable the banner in the common case.
 func helpHeader() string {
 	fd := int(os.Stdout.Fd())
 	if !term.IsTerminal(fd) {
 		return ""
 	}
-	return banner + "\n\n"
+	w, _, err := term.GetSize(fd)
+	if err != nil || w < 70 {
+		return ""
+	}
+	return banner + "\n"
 }
 
 // sharedFlags collects every flag accepted by the review-shape commands.

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -25,23 +25,23 @@ import (
 	"github.com/mshykov/local-review/internal/git"
 )
 
+// bannerMinWidth is the minimum terminal column count at which the banner
+// renders without line-wrapping. Matches the width of the banner's longest line.
+const bannerMinWidth = 70
+
 // banner is the figlet small-font "LOCAL-REVIEW" art shown atop --help.
 // Small font fits in ~70 columns vs the original block font's ~120, so
-// it stays readable on narrow tmux panes, the `git commit` editor, and
-// most CI logs without wrapping. helpHeader() suppresses it for
-// non-TTY stdout (pipes/files) so machine-readable callers get clean
-// text, and gates on terminal width so it doesn't garble narrow
-// terminals.
-const banner = `
-   _    ___   ___   _   _       ___ _____   _____ _____      __
+// it stays readable on narrow tmux panes and the `git commit` editor.
+// helpHeader() suppresses it for non-TTY stdout (pipes/files) so
+// machine-readable callers get clean text, and gates on terminal width
+// so it doesn't garble narrow terminals.
+const banner = `   _    ___   ___   _   _       ___ _____   _____ _____      __
   | |  / _ \ / __| /_\ | |  ___| _ \ __\ \ / /_ _| __\ \    / /
   | |_| (_) | (__ / _ \| |_|___|   / _| \ V / | || _| \ \/\/ /
-  |____\___/ \___/_/ \_\____|  |_|_\___| \_/ |___|___| \_/\_/
-`
+  |____\___/ \___/_/ \_\____|  |_|_\___| \_/ |___|___| \_/\_/`
 
 // helpHeader returns the banner when stdout is a wide-enough terminal,
-// or an empty string otherwise. The small-font banner is ~70 cols, so
-// the gate is set at 70.
+// or an empty string otherwise.
 //
 // We use term.GetSize on the stdout fd. $COLUMNS isn't reliable here —
 // shells don't export it to child processes by default, so falling
@@ -52,10 +52,12 @@ func helpHeader() string {
 		return ""
 	}
 	w, _, err := term.GetSize(fd)
-	if err != nil || w < 70 {
+	if err != nil || w < bannerMinWidth {
 		return ""
 	}
-	return banner + "\n"
+	// Two newlines: one ends the last banner line, the second
+	// provides a blank-line gap before the Long description text.
+	return banner + "\n\n"
 }
 
 // sharedFlags collects every flag accepted by the review-shape commands.

--- a/docs/index.html
+++ b/docs/index.html
@@ -247,10 +247,30 @@
       background: #a0aec0;
     }
 
+    /* Inline <code> default: dark slate on white. The original rule
+       used the light terminal-green (#68d391) which was unreadable
+       on white card backgrounds (e.g. inside the scope block). The
+       terminal-block override below restores the green-on-dark look
+       for <pre><code> command snippets. */
     code {
       font-family: 'JetBrains Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
       font-size: 0.92em;
+      color: #1e293b;
+    }
+
+    pre code {
       color: #68d391;
+      font-size: inherit;
+    }
+
+    /* Subtle slate pill for inline code on the scope cards so it
+       reads as "code" without the legibility issue. Scoped narrowly
+       so the dark Quick Start section's inline-styled <code> tags
+       (color: #a0aec0 on #2d3748) keep their look. */
+    .scope-col code {
+      background: #f1f5f9;
+      padding: 1px 5px;
+      border-radius: 3px;
     }
 
     /* Compact GitHub-style copy button — same size on mobile and desktop */
@@ -401,7 +421,21 @@
       border-radius: 8px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.1);
       text-align: center;
+      /* Flex column with centred main axis so the shorter cards
+         (Claude, Gemini) vertically centre their content within the
+         row's stretched height instead of leaving whitespace at the
+         bottom relative to the taller Codex card. */
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
     }
+
+    /* Inline pills (FREE / $ OpenAI) are spans whose flex behavior
+       defaults to stretch — that yanks them edge-to-edge in a flex
+       column. Pin them back to intrinsic width so they still look
+       like pills. */
+    .llm-card .badge { align-self: center; }
 
     .llm-card.free {
       border: 2px solid #48bb78;
@@ -528,11 +562,12 @@
       color: #2d3748;
     }
 
-    /* Match the saturation/weight of the red on the right column.
-       #2f855a was a light leaf-green that read as washed out next to
-       #c53030; #22543d (same tone as the FREE badge text) lands closer
-       to the red's visual weight. */
-    .scope-col.is h3 { color: #22543d; }
+    /* Match the saturation of the red on the right column. #2f855a
+       was a light leaf-green that read as washed out; #22543d was
+       darker but muted; #15803d (Tailwind green-700) has comparable
+       saturation to red-700, so the two headings carry equal visual
+       weight on white. */
+    .scope-col.is h3 { color: #15803d; }
     .scope-col.isnt h3 { color: #c53030; }
 
     .scope-col ul {
@@ -754,9 +789,12 @@
         </div>
         <div class="llm-card paid">
           <h3>Codex</h3>
-          <p>ChatGPT Plus subscription <strong>or</strong> OpenAI API key</p>
-          <span class="badge badge-paid">Paid</span>
-          <p style="margin-top: 10px; font-size: 0.9em; color: #666;">Disabled by default. API key path is pay-per-token (usually cheapest for occasional review).</p>
+          <p>ChatGPT Plus or OpenAI API key</p>
+          <span class="badge badge-paid">$ OpenAI</span>
+          <p style="margin-top: 10px; font-size: 0.9em; color: #666;">Disabled by default</p>
+          <p style="margin-top: 8px; font-size: 0.75em; color: #888; font-style: italic;">
+            You pay OpenAI. <strong>local-review</strong> is 100% free.
+          </p>
         </div>
       </div>
     </div>

--- a/internal/prompts/packs/default.md
+++ b/internal/prompts/packs/default.md
@@ -23,22 +23,53 @@ You are a senior software engineer reviewing a code diff. Be **honest, specific,
 3. **Performance** — O(n²)+ algorithms over user-scaled data, N+1 database queries, blocking I/O on hot paths, unbounded memory allocations, missing caching for expensive operations, inefficient data structures, missing pagination.
 
 4. **Maintainability**:
-   - Single Responsibility violations (functions/classes doing too much)
-   - DRY violations (meaningful duplication, not just copy-paste)
+   - SOLID violations: Single Responsibility (most common), Open-Closed, Liskov Substitution, Interface Segregation, Dependency Inversion. Call them out by name when relevant.
+   - DRY violations (meaningful duplication, not just copy-paste). Before flagging duplication, ask whether similar functionality already exists in the codebase that could be reused.
    - Leaky abstractions exposing implementation details
    - Over-engineering (solving hypothetical future problems)
-   - Dead code or unreachable branches
+   - Dead code, unreachable branches, commented-out code
    - Poor naming that requires comments to understand
+   - Redundant or stale comments — comments that restate the code, lie about it, or describe behaviour the code no longer has
    - Functions > 50 lines (scrutinize for decomposition)
    - Deep nesting (>3 levels)
+   - File / package location — flag when a change introduces a type or function in a place that doesn't match the rest of the package's responsibility
 
-5. **Testing**:
+5. **Error handling and logging**:
+   - Errors handled at the right layer (close to the cause, not several frames up)
+   - Error messages are actionable for the user (they say *what* failed and *what to do*, not just "error: something went wrong")
+   - Log events are sufficient to debug a production incident without re-running the code
+   - No sensitive data (PII, secrets, tokens) in log lines
+   - Log levels match the actual severity (don't log INFO for things that need to page; don't log ERROR for recoverable conditions)
+
+6. **Testing**:
    - Missing tests for new features or bug fixes
-   - Tests that wouldn't fail if code breaks
+   - Tests that wouldn't fail if code breaks (over-mocked, asserting only that the function ran)
    - Uncovered edge cases
-   - Flaky or dependent tests (shared state)
+   - Flaky or dependent tests (shared state, time-dependent, network-dependent)
+   - Code that's hard to test — flag when production code's shape is making testing difficult (no seam to inject a fake, side effects in constructors, etc.)
 
-6. **Style** — naming, formatting, idiom drift. Mention only when it actively obscures intent or violates team conventions.
+7. **Backward compatibility and dependencies**:
+   - Public API changes (signature, return type, error shape) — flag if not opt-in or not deprecated first
+   - Config schema changes (renamed/removed fields) — flag if no migration path
+   - Persisted data shape changes — flag if no compatibility shim or migration
+   - Required updates to docs / CHANGELOG / config examples that this change implies but didn't include
+
+8. **Usability and accessibility** (for code that ships UI or public APIs):
+   - Public API: is it documented? Is the contract obvious from the name + signature?
+   - UI: keyboard navigation, screen-reader semantics (ARIA roles, alt text, focus order), color contrast (WCAG AA minimum), reasonable behaviour on small viewports
+   - Error states surface clearly to the user, not silently swallowed
+   - Defaults match the most common case, advanced behaviour is opt-in
+
+9. **Ethics and fairness** (when the change touches user data, ML/AI, or behaviour design):
+   - Manipulative patterns (dark patterns, attention-extraction loops, addictive feedback)
+   - Biased outcomes — does the model / heuristic / ranking systematically advantage or disadvantage a group?
+   - Exclusion — does the change require capabilities (high bandwidth, modern browsers, English) that exclude a meaningful user segment?
+   - Data minimisation — are we collecting more than we need? Retaining longer than necessary?
+   - Consent and disclosure — is the user informed about how their data is used?
+
+10. **Style** — naming, formatting, idiom drift. Mention only when it actively obscures intent or violates team conventions.
+
+11. **Specialist review needed?** — when the diff touches cryptography, auth flows, payments, ML model behaviour, accessibility, or other domains where surface-level review can miss serious issues, recommend a specialist look it over. Add this as an `info` finding, not as a blocker.
 
 ## Severity tiers
 
@@ -85,4 +116,4 @@ Return a single JSON object with this exact shape:
 }
 ```
 
-`file` and `line` must come from the diff. `severity` must be one of: `critical`, `major`, `warning`, `info`, `nit`. `tag` is optional (use one of: `correctness`, `security`, `perf`, `maintainability`, `testing`, `style`). If there are no findings, return `{"findings": []}`.
+`file` and `line` must come from the diff. `severity` must be one of: `critical`, `major`, `warning`, `info`, `nit`. `tag` is optional (use one of: `correctness`, `security`, `perf`, `maintainability`, `error_handling`, `testing`, `compat`, `ux`, `ethics`, `style`, `specialist`). If there are no findings, return `{"findings": []}`.


### PR DESCRIPTION
## Summary

Three commits bundled because they all landed together in the same session:

### 1. `8db5316` — Restore figlet banner on `--help`
Reverts the v0.6.1 single-line banner. Restored the 4-line small-font figlet (~70 cols) and the term.GetSize ≥70 width gate. Non-TTY stdout still suppresses the banner.

### 2. `bc52c85` — Landing-page UI polish
- Trim Codex card body so all three cards have equal height
- Vertically center card content (flex column + justify-content: center)
- Bump scope-block "What it is" green from `#22543d` → `#15803d` to match red-700 visual weight
- Fix inline `<code>` legibility on white (default → dark slate, scoped slate-100 pill on .scope-col, terminal-block green preserved on `pre code`)
- Codex pill "Paid" → "$ OpenAI" (clearer recipient)
- Add 0.75em italic monetisation caveat inside Codex card: "You pay OpenAI. **local-review** is 100% free."

### 3. `10d51a8` — Prompt-pack coverage gaps closed (vs mgreiler/code-review-checklist)
`internal/prompts/packs/default.md` covered ~70% of mgreiler's checklist. Closed the gaps:
- SOLID names under Maintainability (was just SRP/DRY)
- Comment hygiene (commented-out code, redundant/stale/lying comments)
- File/package location smell
- New section: Error handling and logging
- New section: Backward compatibility and dependencies
- New section: Usability and accessibility
- New section: Ethics and fairness
- "Specialist review needed?" prompt
- Updated JSON output `tag` enum to match new categories

Kept what mgreiler doesn't have: severity tiering, concrete measurables, LLM-specific hard rules, OWASP 2025 alignment.

## Test plan

- [ ] CI green
- [ ] Eyeball `local-review --help` in a wide terminal — figlet banner renders
- [ ] Eyeball landing page — three LLM cards equal height, content centered, green/red headings balanced, inline code reads dark on white, Codex pill says "$ OpenAI" with caveat below
- [ ] `go test ./internal/prompts/...` passes (default.md still embeds correctly)

## Why bundled

Single PR for now to keep the session-level review tight; if reviewers prefer split, I'll cherry-pick the prompt-pack commit into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the application banner to a multi-line ASCII art and made its display conditional on terminal suitability to avoid clutter on narrow/non-TTY outputs.
* **Documentation**
  * Refined docs styling, layout, and copy for improved readability and clearer UI presentation.
* **Content**
  * Expanded default review guidelines with detailed maintainability, testing, error-handling, accessibility, ethics, and review-scope guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->