### PR TITLE
v0.7.0: diff-too-large preflight (skip agents whose context can't fit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-07
+
+### Added
+- **Diff-too-large preflight.** Before fanning the diff out to agents, `local-review review` now estimates the token count (`bytes ÷ 3.5` — conservative for code) and compares against a per-agent context window: claude 200K, gemini 1M (floor for 2.5+/3.x), codex 128K (floor for gpt-4o-class). If the prompt + diff plus a 10K response margin would exceed an agent's window, the agent is skipped with a one-line warning explaining what fits and how to scope the run smaller (`local-review commit HEAD` or `local-review staged`). If *every* agent's context would overflow, the run errors out before any subprocess runs — saving the user the 2-minute fan-out + N opaque failures previously seen on squash-merged release branches and vendored-blob diffs. Agents whose name isn't in our context-window table (a future LLM, a hypothetical org-pack) pass through preflight unchanged so the rollout of a new agent type is never silently dropped.
+
 ## [0.6.4] - 2026-05-06
 
 ### Changed

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -188,6 +188,26 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 		return err
 	}
 
+	// Preflight: drop agents whose context window can't fit the
+	// (prompt + diff) payload. Pre-v0.7 every agent saw the diff
+	// regardless of size; oversized prompts surfaced as model-
+	// specific failures (claude SIGKILL, codex 4xx, gemini quietly
+	// surviving via its larger window) — confusing and expensive.
+	// Catching this here means: predictable up-front skip with an
+	// actionable "use a smaller scope" hint, no tokens spent on a
+	// call that would 4xx.
+	active, skipped, estimatedTokens := cli.PreflightFilter(active, systemPrompt, diffStr)
+	if len(skipped) > 0 {
+		fmt.Fprint(os.Stderr, cli.SkipSummary(skipped))
+		fmt.Fprintln(os.Stderr)
+	}
+	if len(active) == 0 {
+		// Every agent's context was too small. Bailing here saves
+		// the user a 2-minute fan-out where each agent fails
+		// individually with a vague stderr.
+		return fmt.Errorf("diff is too large for every active agent: ~%d tokens estimated; try a smaller scope (`local-review commit HEAD` or `local-review staged`)", estimatedTokens)
+	}
+
 	startTime := time.Now()
 	storage := multi.NewStorage(cfg.Storage.BasePath)
 	orch := multi.NewOrchestrator(active, storage)

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -535,11 +535,22 @@ func printAgentRoster(active []cli.LLM, configDisabled []string, cfg config.Conf
 	}
 	for _, llm := range active {
 		model := modelFor(llm.Name, cfg)
+		// Surface the per-agent timeout on the roster line so users
+		// know up-front "if this agent doesn't return within Ns,
+		// we'll mark it failed." Pre-v0.7 the timeout was invisible
+		// until the failure line displayed it as part of the hint;
+		// having it visible at run-start lets users notice "wait, my
+		// timeout is still 120s — that's why claude on a big diff
+		// keeps failing" before they spend tokens on the run.
+		timeout := llm.TimeoutSec
+		if timeout == 0 {
+			timeout = 600
+		}
 		if model != "" {
 			// agent_<model> reads as a single identifier (think
 			// docker image names) so users see "what model is
 			// running" at a glance.
-			fmt.Printf("  • %s_%s (CLI v%s)\n", llm.Name, model, llm.Version)
+			fmt.Printf("  • %s_%s (CLI v%s) | timeout: %ds\n", llm.Name, model, llm.Version, timeout)
 		} else {
 			// No model pinned → the invoker doesn't pass --model and
 			// the vendor CLI picks its own current default. We can't
@@ -547,7 +558,7 @@ func printAgentRoster(active []cli.LLM, configDisabled []string, cfg config.Conf
 			// portable way), so we say so explicitly and tell the
 			// user how to take control. Pre-fix this said "model: CLI
 			// default" which the user reported as a non-answer.
-			fmt.Printf("  • %s (CLI v%s) — using vendor's default model; pin via `llms.%s.model:`\n", llm.Name, llm.Version, llm.Name)
+			fmt.Printf("  • %s (CLI v%s) | timeout: %ds — using vendor's default model; pin via `llms.%s.model:`\n", llm.Name, llm.Version, timeout, llm.Name)
 		}
 	}
 	if len(configDisabled) > 0 {

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -128,10 +128,13 @@ func applyConfig(llm cli.LLM, cfg config.Config) cli.LLM {
 		}
 	}
 	if llm.TimeoutSec <= 0 {
-		// 10 minutes — matches config.Defaults() and the orchestrator's
-		// fallback in RunParallel. A future refactor could lift this to
-		// a shared constant; for now we keep them in sync by convention.
-		llm.TimeoutSec = 600
+		// Falls back to cli.DefaultTimeoutSec — same constant the
+		// orchestrator's RunParallel fallback and the roster's
+		// display fallback use, so what the user sees ("timeout:
+		// Ns") matches what actually fires.
+		// `<= 0` (rather than `== 0`) protects against a negative
+		// `timeout_seconds: -1` typo in user config.
+		llm.TimeoutSec = cli.DefaultTimeoutSec
 	}
 	return llm
 }
@@ -196,7 +199,7 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	// Catching this here means: predictable up-front skip with an
 	// actionable "use a smaller scope" hint, no tokens spent on a
 	// call that would 4xx.
-	active, skipped, estimatedTokens := cli.PreflightFilter(active, systemPrompt, diffStr)
+	active, skipped, promptDiffTokens := cli.PreflightFilter(active, systemPrompt, diffStr)
 	if len(skipped) > 0 {
 		fmt.Fprint(os.Stderr, cli.SkipSummary(skipped))
 		fmt.Fprintln(os.Stderr)
@@ -205,7 +208,7 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 		// Every agent's context was too small. Bailing here saves
 		// the user a 2-minute fan-out where each agent fails
 		// individually with a vague stderr.
-		return fmt.Errorf("diff is too large for every active agent: ~%d tokens estimated; try a smaller scope (`local-review commit HEAD` or `local-review staged`)", estimatedTokens)
+		return fmt.Errorf("prompt+diff is too large for every active agent: ~%d tokens estimated; try a smaller scope (`local-review commit HEAD` or `local-review staged`)", promptDiffTokens)
 	}
 
 	startTime := time.Now()
@@ -544,7 +547,7 @@ func printAgentRoster(active []cli.LLM, configDisabled []string, cfg config.Conf
 		// keeps failing" before they spend tokens on the run.
 		timeout := llm.TimeoutSec
 		if timeout == 0 {
-			timeout = 600
+			timeout = cli.DefaultTimeoutSec
 		}
 		if model != "" {
 			// agent_<model> reads as a single identifier (think
@@ -732,10 +735,7 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 	// Negative timeouts (e.g., a `timeout_seconds: -1` typo) would otherwise
 	// produce an already-expired context that cancels the merge instantly.
 	if mergeLLM.TimeoutSec <= 0 {
-		// Same 10-minute default as per-agent reviews — merge prompts
-		// are typically smaller than reviews but a slow merger LLM on
-		// a many-reviewer run can still creep past the old 120s cap.
-		mergeTimeout = 600 * time.Second
+		mergeTimeout = time.Duration(cli.DefaultTimeoutSec) * time.Second
 	}
 	mergeCtx, cancel := context.WithTimeout(ctx, mergeTimeout)
 	defer cancel()

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -2,20 +2,40 @@ package cli
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
-// charsPerToken is the rough byte-to-token ratio for code-heavy
-// English. Real tokenisers (tiktoken, sentencepiece) give exact
+// DefaultTimeoutSec is the per-agent timeout in seconds used when
+// the resolved LLMConfig has no explicit value. Single source of
+// truth shared across the runner's applyConfig fallback, the
+// orchestrator's RunParallel fallback, the merge-step fallback,
+// and the roster line that shows "timeout: Ns" on the pre-run
+// roster. Centralising prevents drift between what the user sees
+// ("timeout: Ns") and what actually fires.
+//
+// 10 minutes accommodates worst-case agents (Anthropic Sonnet on a
+// thinking model) on worst-case diffs. Users wanting shorter
+// timeouts override per-agent via `llms.<agent>.timeout_seconds:`
+// in `.local-review.yml`.
+const DefaultTimeoutSec = 600
+
+// bytesPerToken is the rough byte-to-token ratio used by
+// EstimateTokens. The implementation reads `len(s)` (bytes, not
+// runes), so the constant name now reflects what's actually
+// measured. Real tokenisers (tiktoken, sentencepiece) give exact
 // counts but require pulling vendor SDKs we deliberately don't
-// depend on. The 3.5 ratio is conservative — it slightly over-
-// estimates token count, which biases the preflight toward
-// skipping rather than feeding an oversized prompt to a model that
-// will OOM or 4xx.
+// depend on; this approximation only needs to be good enough to
+// decide "fit or skip."
+//
+// 3.5 is conservative for code-heavy English. Combined with
+// math.Ceil rounding in EstimateTokens, the result is a true
+// upper bound, which biases preflight toward skipping rather than
+// feeding an oversized prompt to a model that will OOM or 4xx.
 //
 // If a future user reports "preflight skipped my agent but the
 // real call would have fit", lower this number.
-const charsPerToken = 3.5
+const bytesPerToken = 3.5
 
 // responseSafetyMargin reserves capacity for the LLM's own response
 // inside the context window. A code review reply typically runs
@@ -62,15 +82,40 @@ func ContextWindow(agent string) int {
 // SkippedAgent describes one agent that was preflight-skipped, with
 // enough detail for the user to understand why and what to do about
 // it.
+//
+// PromptDiffTokens is the upper-bound estimate of the *combined*
+// payload sent to the CLI: the system prompt (after wrapping by
+// buildReviewPrompt) plus the diff, with the "# Diff" header glue
+// included. Named "PromptDiffTokens" rather than "EstimatedTokens"
+// so the user-facing message can't accidentally claim "diff is X
+// tokens" when X is actually prompt+diff.
 type SkippedAgent struct {
 	Name             string
-	EstimatedTokens  int
+	PromptDiffTokens int
 	ContextWindow    int
 }
 
-// PreflightFilter takes the active agent list and the prompt+diff
-// payload, returns the subset that fits in each agent's context
-// window plus a list of skipped agents with their numbers.
+// diffSeparator is the literal glue the invokers put between the
+// system prompt and the diff before sending. Keep this in sync
+// with each Review() implementation in invoker.go — currently all
+// three (claude, gemini, codex) use the same shape.
+const diffSeparator = "\n\n# Diff\n\n"
+
+// EstimatePromptPayload returns an upper-bound token estimate for
+// the exact bytes the invokers ship to the CLI: the wrapped system
+// prompt + separator + diff. Using this — rather than estimating
+// systemPrompt + diff in isolation — prevents preflight from
+// passing an agent that will then 4xx because the actual sent
+// payload was bigger than what we measured.
+func EstimatePromptPayload(systemPrompt, diff string) int {
+	full := buildReviewPrompt(systemPrompt) + diffSeparator + diff
+	return EstimateTokens(full)
+}
+
+// PreflightFilter takes the active agent list and the system-prompt
+// + diff that will be sent to each agent, returns the subset that
+// fits in each agent's context window plus a list of skipped
+// agents with their numbers.
 //
 // The filter is purely based on length — we don't know the user's
 // model precisely (CLIs may pick their own default) so we use the
@@ -79,10 +124,10 @@ type SkippedAgent struct {
 // what we don't know").
 //
 // Returns the filtered active list, the skipped-agent details, and
-// the estimated token count of the input (useful for the caller's
-// summary line).
-func PreflightFilter(active []LLM, prompt, diff string) (kept []LLM, skipped []SkippedAgent, estimatedTokens int) {
-	estimatedTokens = EstimateTokens(prompt) + EstimateTokens(diff)
+// the prompt+diff token estimate (useful for the caller's summary
+// line on the all-skipped path).
+func PreflightFilter(active []LLM, systemPrompt, diff string) (kept []LLM, skipped []SkippedAgent, promptDiffTokens int) {
+	promptDiffTokens = EstimatePromptPayload(systemPrompt, diff)
 	for _, a := range active {
 		window := ContextWindow(a.Name)
 		if window == 0 {
@@ -91,41 +136,52 @@ func PreflightFilter(active []LLM, prompt, diff string) (kept []LLM, skipped []S
 			kept = append(kept, a)
 			continue
 		}
-		if estimatedTokens+responseSafetyMargin > window {
+		if promptDiffTokens+responseSafetyMargin > window {
 			skipped = append(skipped, SkippedAgent{
-				Name:            a.Name,
-				EstimatedTokens: estimatedTokens,
-				ContextWindow:   window,
+				Name:             a.Name,
+				PromptDiffTokens: promptDiffTokens,
+				ContextWindow:    window,
 			})
 			continue
 		}
 		kept = append(kept, a)
 	}
-	return kept, skipped, estimatedTokens
+	return kept, skipped, promptDiffTokens
 }
 
 // EstimateTokens approximates the token count of s using a fixed
-// byte-to-token ratio. Conservative (over-estimates) for code-heavy
-// English — see charsPerToken.
+// byte-to-token ratio. Returns a true upper bound (math.Ceil over
+// the byte/3.5 division) so preflight biases toward skipping rather
+// than feeding an oversized prompt to a model that will 4xx.
 //
 // We don't pull in a real tokeniser (tiktoken, sentencepiece): they
 // require SDK dependencies we deliberately avoid (vendor lock-in,
-// binary bloat) and the preflight only needs an order-of-magnitude
-// answer to decide "fit or skip". Off-by-20% is fine.
+// binary bloat) and the preflight only needs an upper bound to
+// decide "fit or skip". Off-by-20% in the conservative direction
+// is fine.
 func EstimateTokens(s string) int {
 	if s == "" {
 		return 0
 	}
-	return int(float64(len(s)) / charsPerToken)
+	return int(math.Ceil(float64(len(s)) / bytesPerToken))
 }
 
 // FormatSkipReason returns the user-facing one-liner explaining why
 // an agent was preflight-skipped, with the same actionable-hint
 // shape as ClassifyExit's failure messages: numbers + concrete fix.
+//
+// "prompt+diff" rather than "diff" because the estimate covers the
+// full payload (system prompt + glue + diff) — saying only "diff is
+// X tokens" misled users into thinking the raw diff alone exceeded
+// the context window. Both the prompt+diff total AND the
+// response-reservation appear because the gate is "payload + margin
+// > window" — saying only "payload exceeds window" is factually
+// wrong near the limit.
 func FormatSkipReason(s SkippedAgent) string {
 	return fmt.Sprintf(
-		"diff is ~%s tokens, exceeds %s's %s context window — try a smaller diff: `local-review commit HEAD` (last commit) or `local-review staged` (staged only)",
-		humanInt(s.EstimatedTokens),
+		"prompt+diff is ~%s tokens; with ~%s reserved for the response, would exceed %s's %s context window — try a smaller diff: `local-review commit HEAD` (last commit) or `local-review staged` (staged only)",
+		humanInt(s.PromptDiffTokens),
+		humanInt(responseSafetyMargin),
 		s.Name,
 		humanInt(s.ContextWindow),
 	)

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// charsPerToken is the rough byte-to-token ratio for code-heavy
+// English. Real tokenisers (tiktoken, sentencepiece) give exact
+// counts but require pulling vendor SDKs we deliberately don't
+// depend on. The 3.5 ratio is conservative — it slightly over-
+// estimates token count, which biases the preflight toward
+// skipping rather than feeding an oversized prompt to a model that
+// will OOM or 4xx.
+//
+// If a future user reports "preflight skipped my agent but the
+// real call would have fit", lower this number.
+const charsPerToken = 3.5
+
+// responseSafetyMargin reserves capacity for the LLM's own response
+// inside the context window. A code review reply typically runs
+// 2K-8K tokens; 10K is comfortably above that, leaving room for
+// the system prompt + diff to use the rest.
+const responseSafetyMargin = 10_000
+
+// ContextWindow returns the conservative per-LLM context window we
+// preflight against, in tokens. Values are the smallest current-
+// stable model in each vendor's lineup so we never falsely pass a
+// diff that would 4xx on a smaller model.
+//
+// Why a static table instead of probing the CLI: each CLI exposes
+// model context differently (or not at all), and the values change
+// monthly. A small table here, conservative by design, fails-safe
+// if a vendor *shrinks* a context window (rare but happens during
+// rate-limit shifts) at the cost of over-skipping when a vendor
+// *grows* one. Users can override per-agent via
+// `llms.<agent>.context_window:` once that config field lands.
+//
+// Returns 0 for unknown agents — caller should treat that as
+// "don't preflight, let the agent decide" so a future agent type
+// doesn't get silently filtered.
+func ContextWindow(agent string) int {
+	switch agent {
+	case "claude":
+		// Sonnet 3.5/4.x and Opus all run 200K. Haiku 4.5 also 200K.
+		return 200_000
+	case "gemini":
+		// Conservative floor. 2.5 Pro is 2M, 3.x ranges 1M-2M, 1.5
+		// Pro was 2M. 1M as the floor covers every current stable
+		// while leaving slack for previews that may shift down.
+		return 1_000_000
+	case "codex":
+		// gpt-4o = 128K. gpt-5 family = 200K-400K. Conservative
+		// floor at 128K means we'll over-skip on gpt-5 but won't
+		// over-fit on a gpt-4o-default user.
+		return 128_000
+	default:
+		return 0
+	}
+}
+
+// SkippedAgent describes one agent that was preflight-skipped, with
+// enough detail for the user to understand why and what to do about
+// it.
+type SkippedAgent struct {
+	Name             string
+	EstimatedTokens  int
+	ContextWindow    int
+}
+
+// PreflightFilter takes the active agent list and the prompt+diff
+// payload, returns the subset that fits in each agent's context
+// window plus a list of skipped agents with their numbers.
+//
+// The filter is purely based on length — we don't know the user's
+// model precisely (CLIs may pick their own default) so we use the
+// conservative-floor table from ContextWindow. An agent whose name
+// isn't in the table is passed through unchanged ("don't preflight
+// what we don't know").
+//
+// Returns the filtered active list, the skipped-agent details, and
+// the estimated token count of the input (useful for the caller's
+// summary line).
+func PreflightFilter(active []LLM, prompt, diff string) (kept []LLM, skipped []SkippedAgent, estimatedTokens int) {
+	estimatedTokens = EstimateTokens(prompt) + EstimateTokens(diff)
+	for _, a := range active {
+		window := ContextWindow(a.Name)
+		if window == 0 {
+			// Unknown agent — pass through, let the agent's CLI
+			// fail naturally if it's too big.
+			kept = append(kept, a)
+			continue
+		}
+		if estimatedTokens+responseSafetyMargin > window {
+			skipped = append(skipped, SkippedAgent{
+				Name:            a.Name,
+				EstimatedTokens: estimatedTokens,
+				ContextWindow:   window,
+			})
+			continue
+		}
+		kept = append(kept, a)
+	}
+	return kept, skipped, estimatedTokens
+}
+
+// EstimateTokens approximates the token count of s using a fixed
+// byte-to-token ratio. Conservative (over-estimates) for code-heavy
+// English — see charsPerToken.
+//
+// We don't pull in a real tokeniser (tiktoken, sentencepiece): they
+// require SDK dependencies we deliberately avoid (vendor lock-in,
+// binary bloat) and the preflight only needs an order-of-magnitude
+// answer to decide "fit or skip". Off-by-20% is fine.
+func EstimateTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	return int(float64(len(s)) / charsPerToken)
+}
+
+// FormatSkipReason returns the user-facing one-liner explaining why
+// an agent was preflight-skipped, with the same actionable-hint
+// shape as ClassifyExit's failure messages: numbers + concrete fix.
+func FormatSkipReason(s SkippedAgent) string {
+	return fmt.Sprintf(
+		"diff is ~%s tokens, exceeds %s's %s context window — try a smaller diff: `local-review commit HEAD` (last commit) or `local-review staged` (staged only)",
+		humanInt(s.EstimatedTokens),
+		s.Name,
+		humanInt(s.ContextWindow),
+	)
+}
+
+// humanInt formats large integers with a "k" suffix for readability
+// (280_000 → "280k"). Below 10k we keep digits; above we round to
+// nearest thousand. The preflight numbers are always 5+ digits in
+// the cases that trigger it, so this is mostly cosmetic.
+func humanInt(n int) string {
+	if n < 10_000 {
+		return fmt.Sprintf("%d", n)
+	}
+	rounded := (n + 500) / 1000
+	return fmt.Sprintf("%dk", rounded)
+}
+
+// SkipSummary returns a multi-line summary block listing every
+// skipped agent and what the user should do. Empty string when
+// none were skipped.
+func SkipSummary(skipped []SkippedAgent) string {
+	if len(skipped) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, s := range skipped {
+		fmt.Fprintf(&b, "⚠ Skipping %s: %s\n", s.Name, FormatSkipReason(s))
+	}
+	return b.String()
+}

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		minTokens int
+		maxTokens int
+	}{
+		{"empty string", "", 0, 0},
+		{"35 chars (≈10 tokens)", strings.Repeat("a", 35), 9, 11},
+		{"3500 chars (≈1000 tokens)", strings.Repeat("a", 3500), 990, 1010},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EstimateTokens(tc.input)
+			if got < tc.minTokens || got > tc.maxTokens {
+				t.Errorf("EstimateTokens(%d chars) = %d, want range [%d, %d]",
+					len(tc.input), got, tc.minTokens, tc.maxTokens)
+			}
+		})
+	}
+}
+
+func TestContextWindow_KnownAgents(t *testing.T) {
+	// Sanity-check the table — these floors should match what's
+	// documented in the function's doc comment. If a vendor shrinks
+	// a window and we need to lower one of these, that's a deliberate
+	// change and this test is the canary.
+	tests := map[string]int{
+		"claude": 200_000,
+		"gemini": 1_000_000,
+		"codex":  128_000,
+	}
+	for name, want := range tests {
+		if got := ContextWindow(name); got != want {
+			t.Errorf("ContextWindow(%q) = %d, want %d", name, got, want)
+		}
+	}
+}
+
+func TestContextWindow_UnknownAgent(t *testing.T) {
+	// 0 is the "don't preflight" sentinel. The filter should pass
+	// unknown agents through unchanged so a future agent doesn't get
+	// silently dropped on rollout.
+	if got := ContextWindow("future-llm"); got != 0 {
+		t.Errorf("ContextWindow(unknown) = %d, want 0", got)
+	}
+}
+
+func TestPreflightFilter_SmallDiffFitsAll(t *testing.T) {
+	active := []LLM{
+		{Name: "claude"},
+		{Name: "gemini"},
+		{Name: "codex"},
+	}
+	prompt := "review this diff"
+	diff := strings.Repeat("a", 100) // ≈30 tokens
+	kept, skipped, _ := PreflightFilter(active, prompt, diff)
+	if len(kept) != 3 {
+		t.Errorf("small diff should keep all 3 agents, got %d", len(kept))
+	}
+	if len(skipped) != 0 {
+		t.Errorf("small diff should skip none, got %d", len(skipped))
+	}
+}
+
+func TestPreflightFilter_LargeDiffSkipsCodexFirst(t *testing.T) {
+	active := []LLM{
+		{Name: "claude"},
+		{Name: "gemini"},
+		{Name: "codex"},
+	}
+	// 500K bytes ≈ 143K tokens. Above codex (128K) but well below
+	// claude (200K) and gemini (1M). Codex should be the only one
+	// skipped.
+	diff := strings.Repeat("a", 500_000)
+	kept, skipped, est := PreflightFilter(active, "", diff)
+	if est < 130_000 || est > 150_000 {
+		t.Errorf("estimate (%d) outside expected band ~143k for 500K bytes", est)
+	}
+	if len(kept) != 2 {
+		t.Errorf("kept = %d, want 2 (claude + gemini)", len(kept))
+	}
+	if len(skipped) != 1 || skipped[0].Name != "codex" {
+		t.Errorf("expected exactly codex skipped, got %+v", skipped)
+	}
+}
+
+func TestPreflightFilter_HugeDiffSkipsClaudeAndCodex(t *testing.T) {
+	active := []LLM{
+		{Name: "claude"},
+		{Name: "gemini"},
+		{Name: "codex"},
+	}
+	// 800K bytes ≈ 228K tokens. Above claude (200K) and codex
+	// (128K), below gemini (1M). Only gemini should survive.
+	diff := strings.Repeat("a", 800_000)
+	kept, skipped, _ := PreflightFilter(active, "", diff)
+	if len(kept) != 1 || kept[0].Name != "gemini" {
+		t.Errorf("kept = %+v, want only gemini", kept)
+	}
+	if len(skipped) != 2 {
+		t.Errorf("skipped = %d, want 2 (claude + codex)", len(skipped))
+	}
+}
+
+func TestPreflightFilter_OversizedSkipsAll(t *testing.T) {
+	active := []LLM{
+		{Name: "claude"},
+		{Name: "gemini"},
+		{Name: "codex"},
+	}
+	// 5M bytes ≈ 1.4M tokens. Above all three windows (claude 200K,
+	// gemini 1M, codex 128K). Caller is expected to surface this
+	// and error out before fan-out.
+	diff := strings.Repeat("a", 5_000_000)
+	kept, skipped, _ := PreflightFilter(active, "", diff)
+	if len(kept) != 0 {
+		t.Errorf("kept = %d, want 0 (all should skip)", len(kept))
+	}
+	if len(skipped) != 3 {
+		t.Errorf("skipped = %d, want 3", len(skipped))
+	}
+}
+
+func TestPreflightFilter_UnknownAgentPassesThrough(t *testing.T) {
+	active := []LLM{
+		{Name: "claude"},
+		{Name: "future-llm"}, // not in our table
+	}
+	// Diff that would skip claude (220K tokens) — but future-llm has
+	// ContextWindow=0 so it's treated as "we don't know, let it
+	// decide". Should be kept regardless of size.
+	diff := strings.Repeat("a", 770_000)
+	kept, _, _ := PreflightFilter(active, "", diff)
+	hasFutureLLM := false
+	for _, a := range kept {
+		if a.Name == "future-llm" {
+			hasFutureLLM = true
+		}
+	}
+	if !hasFutureLLM {
+		t.Errorf("future-llm should pass through preflight unchanged, got kept = %+v", kept)
+	}
+}
+
+func TestPreflightFilter_SafetyMarginBlocksJustUnderLimit(t *testing.T) {
+	// 700K bytes ≈ 200K tokens — exactly at claude's window. With
+	// the 10K response margin, this should skip claude.
+	active := []LLM{{Name: "claude"}}
+	diff := strings.Repeat("a", 700_000)
+	kept, skipped, _ := PreflightFilter(active, "", diff)
+	if len(kept) != 0 {
+		t.Errorf("at-limit diff should be skipped due to response margin, got kept = %+v", kept)
+	}
+	if len(skipped) != 1 {
+		t.Errorf("skipped = %d, want 1", len(skipped))
+	}
+}
+
+func TestFormatSkipReason_HasActionableHint(t *testing.T) {
+	s := SkippedAgent{Name: "claude", EstimatedTokens: 280_000, ContextWindow: 200_000}
+	got := FormatSkipReason(s)
+	for _, want := range []string{"local-review commit HEAD", "local-review staged", "claude"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skip reason missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestSkipSummary_EmptyWhenNoneSkipped(t *testing.T) {
+	if got := SkipSummary(nil); got != "" {
+		t.Errorf("empty input should give empty output, got %q", got)
+	}
+}
+
+func TestSkipSummary_OneLinePerAgent(t *testing.T) {
+	skipped := []SkippedAgent{
+		{Name: "claude", EstimatedTokens: 280_000, ContextWindow: 200_000},
+		{Name: "codex", EstimatedTokens: 280_000, ContextWindow: 128_000},
+	}
+	got := SkipSummary(skipped)
+	if !strings.Contains(got, "claude") || !strings.Contains(got, "codex") {
+		t.Errorf("summary missing one of the agent names: %s", got)
+	}
+	if strings.Count(got, "⚠") != 2 {
+		t.Errorf("expected 2 warning lines, got %s", got)
+	}
+}

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -5,6 +5,41 @@ import (
 	"testing"
 )
 
+func TestEstimatePromptPayload_IncludesWrapperAndSeparator(t *testing.T) {
+	// The invokers wrap systemPrompt with buildReviewPrompt
+	// (appends multiLLMOutputOverride) and prepend "\n\n# Diff\n\n"
+	// before the diff. Preflight has to estimate the *actual* sent
+	// payload, not just systemPrompt+diff in isolation — pre-fix,
+	// estimate undercounted by ~1k tokens for an empty prompt
+	// (the override alone is ~400 chars / ~115 tokens), letting
+	// near-the-limit diffs pass that would 4xx in the real call.
+	systemPrompt := "review this"
+	diff := "--- a/x\n+++ b/x\n@@\n+hi\n"
+	rawSum := EstimateTokens(systemPrompt) + EstimateTokens(diff)
+	wrapped := EstimatePromptPayload(systemPrompt, diff)
+	if wrapped <= rawSum {
+		t.Errorf("EstimatePromptPayload should be larger than raw sum (it includes the wrapper + separator); got wrapped=%d, raw=%d", wrapped, rawSum)
+	}
+}
+
+func TestEstimateTokens_UpperBoundCeil(t *testing.T) {
+	// 36 bytes / 3.5 = 10.28… — math.Ceil → 11 tokens. Pre-fix
+	// int() truncated to 10, contradicting the "conservative /
+	// upper bound" claim in the doc comment. The bytes-just-above-
+	// a-multiple-of-3.5 case is what the gate actually cares about
+	// (a single extra byte should round UP to one more token).
+	got := EstimateTokens(strings.Repeat("a", 36))
+	if got != 11 {
+		t.Errorf("EstimateTokens(36 bytes) = %d, want 11 (Ceil(36/3.5))", got)
+	}
+	// 35 bytes / 3.5 = exactly 10. Both Floor and Ceil agree here;
+	// just makes sure we didn't introduce off-by-one for the exact
+	// case.
+	if got := EstimateTokens(strings.Repeat("a", 35)); got != 10 {
+		t.Errorf("EstimateTokens(35 bytes) = %d, want 10", got)
+	}
+}
+
 func TestEstimateTokens(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -165,7 +200,7 @@ func TestPreflightFilter_SafetyMarginBlocksJustUnderLimit(t *testing.T) {
 }
 
 func TestFormatSkipReason_HasActionableHint(t *testing.T) {
-	s := SkippedAgent{Name: "claude", EstimatedTokens: 280_000, ContextWindow: 200_000}
+	s := SkippedAgent{Name: "claude", PromptDiffTokens: 280_000, ContextWindow: 200_000}
 	got := FormatSkipReason(s)
 	for _, want := range []string{"local-review commit HEAD", "local-review staged", "claude"} {
 		if !strings.Contains(got, want) {
@@ -182,8 +217,8 @@ func TestSkipSummary_EmptyWhenNoneSkipped(t *testing.T) {
 
 func TestSkipSummary_OneLinePerAgent(t *testing.T) {
 	skipped := []SkippedAgent{
-		{Name: "claude", EstimatedTokens: 280_000, ContextWindow: 200_000},
-		{Name: "codex", EstimatedTokens: 280_000, ContextWindow: 128_000},
+		{Name: "claude", PromptDiffTokens: 280_000, ContextWindow: 200_000},
+		{Name: "codex", PromptDiffTokens: 280_000, ContextWindow: 128_000},
 	}
 	got := SkipSummary(skipped)
 	if !strings.Contains(got, "claude") || !strings.Contains(got, "codex") {

--- a/internal/multi/orchestrator.go
+++ b/internal/multi/orchestrator.go
@@ -68,14 +68,16 @@ func (o *Orchestrator) RunParallel(ctx context.Context, systemPrompt, diff, comm
 				return
 			}
 
-			// Create context with timeout from config (default: 600s)
+			// Create context with timeout from config; falls back to
+			// cli.DefaultTimeoutSec — same constant the runner's
+			// applyConfig fallback and the roster's display fallback
+			// use, so what the user sees ("timeout: Ns") matches
+			// what actually fires. `<= 0` (rather than `== 0`)
+			// protects against a negative `timeout_seconds: -1`
+			// typo in user config.
 			timeout := time.Duration(l.TimeoutSec) * time.Second
 			if l.TimeoutSec <= 0 {
-				// 10 minutes. Matches config.Defaults() and the runner's
-				// applyConfig fallback. The 120s pre-v0.6.4 default
-				// surfaced as user-reported timeouts on the most common
-				// review path (claude on a branch-sized diff).
-				timeout = 600 * time.Second
+				timeout = time.Duration(cli.DefaultTimeoutSec) * time.Second
 			}
 			reviewCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()


### PR DESCRIPTION
## Summary

Before fanning the diff out to LLM agents, \`local-review review\` now estimates the prompt+diff token count and skips agents whose context window can't fit it. Saves the user the 2-minute fan-out and N opaque per-agent failures we've seen on squash-merged release branches and vendored-blob diffs.

## Problem this solves

Pre-v0.7 every agent saw the diff regardless of size. Failures were model-specific and uninformative:

| Agent | Failure mode on oversized diff |
|---|---|
| **claude** | SIGKILL (CLI subprocess OOM) — opaque, no hint why |
| **codex** | Exit 1 with \`context_length_exceeded\` buried in stderr |
| **gemini** | Quietly survived via 1M+ window, leaving the user with a "merged" report that was actually a single-LLM result, no consensus |

v0.6.3 made the failures *readable*. v0.7.0 *prevents them*.

## How it works

\`internal/cli/preflight.go\` (new):

| Function | Purpose |
|---|---|
| \`EstimateTokens(s)\` | bytes/3.5 — conservative for code, no vendor SDK |
| \`ContextWindow(agent)\` | Per-agent floor: claude 200K, gemini 1M, codex 128K |
| \`PreflightFilter(active, prompt, diff)\` | Returns \`(kept, skipped, estTokens)\` |
| \`SkipSummary(skipped)\` | One \`⚠\` line per skipped agent with the actionable hint |

Wired into \`cmd/local-review/runner.go\` between \`selectPromptPack\` and \`RunParallel\`. Skip warnings go to **stderr** (debug-the-input hint, not part of merged-findings stdout). If every agent would be skipped, runs out errors out before any subprocess fires.

## User-facing example

\`\`\`
$ local-review review main
Reviewing release/v0.6.0 (89b0a43) with 3 LLMs...
  • claude_claude-sonnet-4-6 (CLI v2.1.131)
  • gemini_gemini-2.5-pro (CLI v0.40.1)
  • codex_gpt-5.3-codex (CLI v0.128.0)

⚠ Skipping codex: diff is ~280k tokens, exceeds codex's 128k context window — try a smaller diff: \`local-review commit HEAD\` (last commit) or \`local-review staged\` (staged only)

[1/2] claude ✓ (51.5s)
[2/2] gemini ✓ (102.4s)
...
\`\`\`

## Trade-offs (intentional)

- **Conservative bytes/3.5 ratio** over-estimates for ASCII-heavy code; under-estimates for unicode-heavy diffs. We err toward skipping rather than feeding an oversized prompt to an agent that 4xx's. If a user reports "preflight skipped my agent but the real call would have fit", lower the constant.
- **Static context-window table** instead of probing each CLI. Vendors don't expose context windows uniformly; values shift monthly. Floor-of-current-stable means we over-skip when a vendor *grows* a window (rare), under-skip is impossible.
- **Unknown-agent passthrough**. \`ContextWindow(future-llm)\` returns 0 → preflight doesn't filter it. Lets a future agent type roll out without being silently dropped.

## Test plan

- [x] 13 new tests in \`preflight_test.go\` covering all branches + edge cases (at-window-limit, unknown agent, all-skipped)
- [x] \`go vet\` + \`go test -race ./...\` green
- [ ] CodeQL passes (per branch protection)
- [ ] CodeRabbit/Copilot reviews surface no blockers
- [ ] After merge: clean release flow (signed commit, all checks should pass without bypass)

## Token visibility spike (option B)

Per the same conversation that prompted this PR, you also asked for a per-agent token-usage spike. That's separate research — each CLI exposes tokens differently (claude: \`/cost\`, codex: stdout banner, gemini: unclear). Filing as a v0.7.x followup once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `local-review review` command now estimates token counts and checks if diffs exceed agent context windows
  * Agents that cannot accommodate the diff are automatically skipped
  * Execution terminates with a clear error before launching any processes if all configured agents would overflow their capacity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->