### PR TITLE
v0.6.6: per-LLM token visibility (see what each agent consumed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ✓ 3/3 LLMs produced output · total 2m51s · ~54k tokens
   ```
 
-  Token counts come from each CLI's structured output (claude `--output-format json`, gemini `-o json`) or stdout metadata (codex's session-summary block). When a CLI version is too old to surface usage, the suffix is omitted entirely rather than misleading users with "0 in / 0 out". Same data persists in `<commit>_metadata.json` per-review and per-merge, so paid-tier users (codex API, claude paid) can attribute spend per PR without round-tripping the vendor dashboard.
+  Token counts come from each CLI's structured output (claude `--output-format json`, gemini `-o json`) or stdout metadata (codex's session-summary block). Codex pre-v0.128 reports a single combined total instead of split input/output; we render that as "Nk total" rather than the misleading "Nk in / 0 out" (the model produced output, we just don't have the breakdown). Same data persists in `<commit>_metadata.json` per-review and per-merge, so paid-tier users (codex API, claude paid) can attribute spend per PR without round-tripping the vendor dashboard.
+
+  **Minimum CLI versions for token visibility:** claude-code v1+ (any version supporting `--output-format json`), gemini-cli with `-o json` support (newer releases), codex any version. Older CLIs that lack the JSON-output flag exit non-zero on the flag and the run fails fast — there is no silent "no tokens" fallback for that case. If your run errored out after this upgrade, update the offending CLI: `npm i -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex`.
 
 ### Internal
-- `Invoker.Review` and `Invoker.RunPrompt` now return a `cli.TokenUsage` alongside the response. `ReviewResult.Tokens` and `MergeMeta.{InputTokens,OutputTokens}` plumb the data through. JSON parsers gracefully fall back to zero usage on unknown shapes — older CLI versions degrade to "no token info" rather than failing the review.
+- `Invoker.Review` and `Invoker.RunPrompt` now return a `cli.TokenUsage` alongside the response. `ReviewResult.Tokens` and `MergeMeta.{InputTokens,OutputTokens,TotalOnlyTokens}` plumb the data through. `TokenUsage.TotalOnly` flags the codex legacy single-total case so display callers render "Nk total" instead of "Nk in / 0 out". JSON parsers fall back to raw text + zero usage when valid JSON has an unexpected shape (a future schema drift); they do *not* compensate for older CLIs missing the structured-output flag — those exit non-zero before the parser is reached.
 
 ## [0.6.5] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-05-07
+## [0.6.6] - 2026-05-07
+
+### Added
+- **Per-LLM token usage on every review.** `local-review review` now displays input/output token counts per agent on its completion line and aggregates a total at the end of the run:
+
+  ```
+  [1/3] claude ✓ (51.5s) · 12.3k in / 4.5k out
+  [2/3] gemini ✓ (102.4s) · 15k in / 3k out
+  [3/3] codex ✓ (85.0s) · 14k in / 4k out
+  ✓ 3/3 LLMs produced output · total 2m51s · ~54k tokens
+  ```
+
+  Token counts come from each CLI's structured output (claude `--output-format json`, gemini `-o json`) or stdout metadata (codex's session-summary block). When a CLI version is too old to surface usage, the suffix is omitted entirely rather than misleading users with "0 in / 0 out". Same data persists in `<commit>_metadata.json` per-review and per-merge, so paid-tier users (codex API, claude paid) can attribute spend per PR without round-tripping the vendor dashboard.
+
+### Internal
+- `Invoker.Review` and `Invoker.RunPrompt` now return a `cli.TokenUsage` alongside the response. `ReviewResult.Tokens` and `MergeMeta.{InputTokens,OutputTokens}` plumb the data through. JSON parsers gracefully fall back to zero usage on unknown shapes — older CLI versions degrade to "no token info" rather than failing the review.
+
+## [0.6.5] - 2026-05-07
 
 ### Added
 - **Diff-too-large preflight.** Before fanning the diff out to agents, `local-review review` now estimates the token count (`bytes ÷ 3.5` — conservative for code) and compares against a per-agent context window: claude 200K, gemini 1M (floor for 2.5+/3.x), codex 128K (floor for gpt-4o-class). If the prompt + diff plus a 10K response margin would exceed an agent's window, the agent is skipped with a one-line warning explaining what fits and how to scope the run smaller (`local-review commit HEAD` or `local-review staged`). If *every* agent's context would overflow, the run errors out before any subprocess runs — saving the user the 2-minute fan-out + N opaque failures previously seen on squash-merged release branches and vendored-blob diffs. Agents whose name isn't in our context-window table (a future LLM, a hypothetical org-pack) pass through preflight unchanged so the rollout of a new agent type is never silently dropped.

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -612,13 +612,14 @@ func aggregateTokens(results []multi.ReviewResult, mergeTokens cli.TokenUsage) i
 // humanTokens formats a token count for the per-LLM and closing
 // summary lines. Three bands:
 //   - Below 1000:   raw integer (e.g. "456") because at small scales
-//                   "0.5k" hides meaningful precision.
-//   - 1k to 99,999: one decimal "k" (e.g. "1.2k", "12.3k") because
-//                   cost-sensitive users need the tens-of-tokens
-//                   resolution here, where the gap between 4.5k and
-//                   5.0k is real money on a paid tier.
+//     "0.5k" hides meaningful precision.
+//   - 1k to 99,999: "k" values with one decimal only when needed
+//     (e.g. "1k", "1.2k", "12.3k") because cost-
+//     sensitive users need the tens-of-tokens
+//     resolution here, where the gap between 4.5k and
+//     5.0k is real money on a paid tier.
 //   - 100k and up:  rounded "k" (e.g. "120k") because at six figures
-//                   the decimal is just noise.
+//     the decimal is just noise.
 //
 // CodeRabbit's auto-fix proposed a simpler "always divide by 1000,
 // drop .0 for whole thousands" form. Rejected: that path renders
@@ -631,6 +632,9 @@ func humanTokens(n int) string {
 		return fmt.Sprintf("%d", n)
 	}
 	if n < 100_000 {
+		if n%1_000 == 0 {
+			return fmt.Sprintf("%dk", n/1_000)
+		}
 		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
 	}
 	rounded := (n + 500) / 1000

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -228,9 +228,9 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 			// has the actionable hint inline. No "review failed:"
 			// prefix or "(output: )" wrapping; "[N/M] agent ✗ <msg>"
 			// reads clean.
-			fmt.Printf("[%d/%d] %s ✗ %s\n", i+1, len(results), r.LLM, r.Error)
+			fmt.Printf("[%d/%d] %s ✗ %s%s\n", i+1, len(results), r.LLM, r.Error, formatTokenSuffix(r.Tokens))
 		} else {
-			fmt.Printf("[%d/%d] %s ✓ (%.1fs)\n", i+1, len(results), r.LLM, r.Duration.Seconds())
+			fmt.Printf("[%d/%d] %s ✓ (%.1fs)%s\n", i+1, len(results), r.LLM, r.Duration.Seconds(), formatTokenSuffix(r.Tokens))
 		}
 	}
 	fmt.Println()
@@ -296,7 +296,7 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 		}
 	}
 
-	mergedPath, mergedContent := mergeAndPrint(ctx, cfg, sf, active, results, storage, commit, branch, metadata)
+	mergedPath, mergedContent, mergeTokens := mergeAndPrint(ctx, cfg, sf, active, results, storage, commit, branch, metadata)
 	if _, err := storage.SaveMetadata(branch, commit, metadata); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to save metadata: %v\n", err)
 	}
@@ -308,7 +308,17 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	// drifted from the rest of the surface — a SaveReview-failed-
 	// with-output run would print "0/3 succeeded" while the merger
 	// happily consolidated all 3 outputs and the gate fired correctly.
-	fmt.Printf("✓ %d/%d LLMs produced output · total %s\n", mergeable, len(results), time.Since(startTime).Round(time.Second))
+	//
+	// Token total aggregates per-LLM review tokens + merge-step
+	// tokens. Omitted entirely when every agent reported zero (CLI
+	// version too old to surface usage) — printing "0 tokens" would
+	// mislead users into thinking the call was free.
+	totalTokens := aggregateTokens(results, mergeTokens)
+	if totalTokens > 0 {
+		fmt.Printf("✓ %d/%d LLMs produced output · total %s · ~%s tokens\n", mergeable, len(results), time.Since(startTime).Round(time.Second), humanTokens(totalTokens))
+	} else {
+		fmt.Printf("✓ %d/%d LLMs produced output · total %s\n", mergeable, len(results), time.Since(startTime).Round(time.Second))
+	}
 	if mergedPath != "" {
 		// Report-path label uses `rmode` (computed above alongside `mergeable`)
 		// so we don't call CountWithOutput a second time. Degraded/solo runs
@@ -585,6 +595,43 @@ func pluralS(n int) string {
 	return "s"
 }
 
+// aggregateTokens returns the sum of input+output tokens across all
+// per-LLM reviews plus the merge step's own usage. Used by the
+// closing-line "~Nk tokens" summary. Returns 0 when nothing was
+// reported — the closing-line caller checks for this and omits the
+// "tokens" suffix entirely so users don't see "0 tokens" and assume
+// the call was free.
+func aggregateTokens(results []multi.ReviewResult, mergeTokens cli.TokenUsage) int {
+	total := mergeTokens.Total()
+	for _, r := range results {
+		total += r.Tokens.Total()
+	}
+	return total
+}
+
+// humanTokens formats a token count with a "k" suffix above 10k for
+// quick scannability. Below 10k we keep digits because the
+// difference between 1234 and 1500 tokens is meaningful at small
+// scales but invisible at "1k" rounding.
+func humanTokens(n int) string {
+	if n < 10_000 {
+		return fmt.Sprintf("%d", n)
+	}
+	rounded := (n + 500) / 1000
+	return fmt.Sprintf("%dk", rounded)
+}
+
+// formatTokenSuffix returns " · 12.3k in / 4.5k out" for the per-LLM
+// completion line, or "" when usage wasn't reported (CLI version
+// too old). Mirrors the closing-line "omit when zero" rule so users
+// don't see misleading "0 in / 0 out" rows.
+func formatTokenSuffix(u cli.TokenUsage) string {
+	if u.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf(" · %s in / %s out", humanTokens(u.InputTokens), humanTokens(u.OutputTokens))
+}
+
 // resolveCommitBranch resolves the commit hash and branch name for the
 // current invocation. In detached-HEAD environments (CI checkouts,
 // `git checkout <tag>`, bisect) git returns "HEAD" as the branch name
@@ -685,7 +732,7 @@ func classifyRunMode(results []multi.ReviewResult) runMode {
 // the saved path and the merged content; both are "" on skip/failure.
 // The content is returned so the caller can run the blocking-finding
 // gate without re-reading from disk.
-func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, active []cli.LLM, results []multi.ReviewResult, storage *multi.ReviewStorage, commit, branch string, metadata *multi.Metadata) (string, string) {
+func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, active []cli.LLM, results []multi.ReviewResult, storage *multi.ReviewStorage, commit, branch string, metadata *multi.Metadata) (mergedPath, mergedContent string, mergeTokens cli.TokenUsage) {
 	mode := classifyRunMode(results)
 
 	switch mode {
@@ -706,7 +753,7 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 	if mergeLLM == nil {
 		fmt.Println("Warning: no LLM available for merging (skipping merge)")
 		metadata.Merge.Status = "skipped"
-		return "", ""
+		return "", "", cli.TokenUsage{}
 	}
 	switch mode {
 	case runModeDegraded:
@@ -722,7 +769,7 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 		fmt.Printf("Warning: failed to create merger: %v\n", err)
 		metadata.Merge.Status = "failed"
 		metadata.Merge.Error = err.Error()
-		return "", ""
+		return "", "", cli.TokenUsage{}
 	}
 
 	mergeInput := multi.BuildMergeInput(results, cfg.Merge.ConsensusThreshold)
@@ -741,17 +788,17 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 	defer cancel()
 
 	mergeStart := time.Now()
-	merged, err := merger.Merge(mergeCtx, mergeInput)
+	merged, mergeTokens, err := merger.Merge(mergeCtx, mergeInput)
 	mergeDuration := time.Since(mergeStart)
 
 	if err != nil {
 		fmt.Printf("Warning: merge failed: %v\n", err)
 		metadata.Merge.Status = "failed"
 		metadata.Merge.Error = err.Error()
-		return "", ""
+		return "", "", cli.TokenUsage{}
 	}
 
-	mergedPath, err := storage.SaveMerged(branch, commit, merged)
+	savedPath, err := storage.SaveMerged(branch, commit, merged)
 	if err != nil {
 		// SaveMerged failed (read-only mount, full disk, permission
 		// denied on .local-review/) — but the merger DID produce
@@ -775,15 +822,19 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 		metadata.Merge.Status = "failed"
 		metadata.Merge.Error = err.Error()
 		metadata.Merge.DurationMs = mergeDuration.Milliseconds()
+		metadata.Merge.InputTokens = mergeTokens.InputTokens
+		metadata.Merge.OutputTokens = mergeTokens.OutputTokens
 		fmt.Println("─── Findings (not persisted) ───")
 		fmt.Println(merged)
 		fmt.Println("─── End ───")
-		return "", merged
+		return "", merged, mergeTokens
 	}
 
 	metadata.Merge.LLM = mergeLLM.Name
 	metadata.Merge.Status = "success"
 	metadata.Merge.DurationMs = mergeDuration.Milliseconds()
+	metadata.Merge.InputTokens = mergeTokens.InputTokens
+	metadata.Merge.OutputTokens = mergeTokens.OutputTokens
 
 	switch mode {
 	case runModeDegraded:
@@ -799,7 +850,7 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 	fmt.Println(merged)
 	fmt.Println("─── End ───")
 
-	return mergedPath, merged
+	return savedPath, merged, mergeTokens
 }
 
 // runSingleLLMFallback is the v0 path: hit the configured provider's
@@ -868,13 +919,15 @@ func buildMetadata(commit, branch string, results []multi.ReviewResult, startTim
 			errMsg = r.Error.Error()
 		}
 		meta.Reviews[i] = multi.ReviewMeta{
-			LLM:        r.LLM,
-			Version:    r.Version,
-			Mode:       r.Mode,
-			Status:     status,
-			DurationMs: r.Duration.Milliseconds(),
-			OutputFile: r.FilePath,
-			Error:      errMsg,
+			LLM:          r.LLM,
+			Version:      r.Version,
+			Mode:         r.Mode,
+			Status:       status,
+			DurationMs:   r.Duration.Milliseconds(),
+			OutputFile:   r.FilePath,
+			Error:        errMsg,
+			InputTokens:  r.Tokens.InputTokens,
+			OutputTokens: r.Tokens.OutputTokens,
 		}
 	}
 	return meta

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -609,24 +609,46 @@ func aggregateTokens(results []multi.ReviewResult, mergeTokens cli.TokenUsage) i
 	return total
 }
 
-// humanTokens formats a token count with a "k" suffix for quick
-// scannability. Values are divided by 1000 and shown with at most
-// one decimal place, dropping ".0" for whole thousands.
+// humanTokens formats a token count for the per-LLM and closing
+// summary lines. Three bands:
+//   - Below 1000:   raw integer (e.g. "456") because at small scales
+//                   "0.5k" hides meaningful precision.
+//   - 1k to 99,999: one decimal "k" (e.g. "1.2k", "12.3k") because
+//                   cost-sensitive users need the tens-of-tokens
+//                   resolution here, where the gap between 4.5k and
+//                   5.0k is real money on a paid tier.
+//   - 100k and up:  rounded "k" (e.g. "120k") because at six figures
+//                   the decimal is just noise.
+//
+// CodeRabbit's auto-fix proposed a simpler "always divide by 1000,
+// drop .0 for whole thousands" form. Rejected: that path renders
+// 999 as "1.0k" (rounding hides the sub-1k case) and 156000 as
+// "156.0k" (the trailing .0 is noise at six figures). The three-band
+// shape covers the same docs example (12300 → "12.3k") without
+// either regression.
 func humanTokens(n int) string {
-	k := float64(n) / 1000.0
-	if k == float64(int(k)) {
-		return fmt.Sprintf("%dk", int(k))
+	if n < 1_000 {
+		return fmt.Sprintf("%d", n)
 	}
-	return fmt.Sprintf("%.1fk", k)
+	if n < 100_000 {
+		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
+	}
+	rounded := (n + 500) / 1000
+	return fmt.Sprintf("%dk", rounded)
 }
 
 // formatTokenSuffix returns " · 12.3k in / 4.5k out" for the per-LLM
-// completion line, or "" when usage wasn't reported (CLI version
-// too old). Mirrors the closing-line "omit when zero" rule so users
-// don't see misleading "0 in / 0 out" rows.
+// completion line, or " · 12.3k total" when only the combined total
+// is known (codex's legacy stdout shape pre-v0.128 doesn't split
+// input vs output — formatting as "X in / 0 out" would mislead
+// users into thinking the model returned nothing). Returns "" when
+// usage wasn't reported at all so we don't print "0 in / 0 out".
 func formatTokenSuffix(u cli.TokenUsage) string {
 	if u.IsZero() {
 		return ""
+	}
+	if u.TotalOnly {
+		return fmt.Sprintf(" · %s total", humanTokens(u.Total()))
 	}
 	return fmt.Sprintf(" · %s in / %s out", humanTokens(u.InputTokens), humanTokens(u.OutputTokens))
 }
@@ -823,6 +845,7 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 		metadata.Merge.DurationMs = mergeDuration.Milliseconds()
 		metadata.Merge.InputTokens = mergeTokens.InputTokens
 		metadata.Merge.OutputTokens = mergeTokens.OutputTokens
+		metadata.Merge.TotalOnlyTokens = mergeTokens.TotalOnly
 		fmt.Println("─── Findings (not persisted) ───")
 		fmt.Println(merged)
 		fmt.Println("─── End ───")
@@ -834,6 +857,7 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 	metadata.Merge.DurationMs = mergeDuration.Milliseconds()
 	metadata.Merge.InputTokens = mergeTokens.InputTokens
 	metadata.Merge.OutputTokens = mergeTokens.OutputTokens
+	metadata.Merge.TotalOnlyTokens = mergeTokens.TotalOnly
 
 	switch mode {
 	case runModeDegraded:
@@ -918,15 +942,16 @@ func buildMetadata(commit, branch string, results []multi.ReviewResult, startTim
 			errMsg = r.Error.Error()
 		}
 		meta.Reviews[i] = multi.ReviewMeta{
-			LLM:          r.LLM,
-			Version:      r.Version,
-			Mode:         r.Mode,
-			Status:       status,
-			DurationMs:   r.Duration.Milliseconds(),
-			OutputFile:   r.FilePath,
-			Error:        errMsg,
-			InputTokens:  r.Tokens.InputTokens,
-			OutputTokens: r.Tokens.OutputTokens,
+			LLM:             r.LLM,
+			Version:         r.Version,
+			Mode:            r.Mode,
+			Status:          status,
+			DurationMs:      r.Duration.Milliseconds(),
+			OutputFile:      r.FilePath,
+			Error:           errMsg,
+			InputTokens:     r.Tokens.InputTokens,
+			OutputTokens:    r.Tokens.OutputTokens,
+			TotalOnlyTokens: r.Tokens.TotalOnly,
 		}
 	}
 	return meta

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -609,16 +609,15 @@ func aggregateTokens(results []multi.ReviewResult, mergeTokens cli.TokenUsage) i
 	return total
 }
 
-// humanTokens formats a token count with a "k" suffix above 10k for
-// quick scannability. Below 10k we keep digits because the
-// difference between 1234 and 1500 tokens is meaningful at small
-// scales but invisible at "1k" rounding.
+// humanTokens formats a token count with a "k" suffix for quick
+// scannability. Values are divided by 1000 and shown with at most
+// one decimal place, dropping ".0" for whole thousands.
 func humanTokens(n int) string {
-	if n < 10_000 {
-		return fmt.Sprintf("%d", n)
+	k := float64(n) / 1000.0
+	if k == float64(int(k)) {
+		return fmt.Sprintf("%dk", int(k))
 	}
-	rounded := (n + 500) / 1000
-	return fmt.Sprintf("%dk", rounded)
+	return fmt.Sprintf("%.1fk", k)
 }
 
 // formatTokenSuffix returns " · 12.3k in / 4.5k out" for the per-LLM

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -632,8 +632,9 @@ func humanTokens(n int) string {
 		return fmt.Sprintf("%d", n)
 	}
 	if n < 100_000 {
-		if n%1_000 == 0 {
-			return fmt.Sprintf("%dk", n/1_000)
+		k := n / 1_000
+		if n == k*1_000 {
+			return fmt.Sprintf("%dk", k)
 		}
 		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
 	}

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -613,13 +613,20 @@ func aggregateTokens(results []multi.ReviewResult, mergeTokens cli.TokenUsage) i
 // summary lines. Three bands:
 //   - Below 1000:   raw integer (e.g. "456") because at small scales
 //     "0.5k" hides meaningful precision.
-//   - 1k to 99,999: "k" values with one decimal only when needed
-//     (e.g. "1k", "1.2k", "12.3k") because cost-
-//     sensitive users need the tens-of-tokens
-//     resolution here, where the gap between 4.5k and
-//     5.0k is real money on a paid tier.
+//   - 1k to 99,999: "k" values truncated to one decimal, dropping
+//     ".0" for whole thousands (e.g. "1k", "1.2k",
+//     "12.3k", "15k", "99.9k") because cost-sensitive
+//     users need tens-of-tokens resolution here, where
+//     the gap between 4.5k and 5.0k is real money on a
+//     paid tier.
 //   - 100k and up:  rounded "k" (e.g. "120k") because at six figures
 //     the decimal is just noise.
+//
+// Truncation (not rounding) in the middle band is deliberate so
+// 99,999 renders as "99.9k" rather than "100.0k" — band-crossing
+// would both look wrong (the band cap is supposed to be 99.9k)
+// and overstate usage by ~1 token at the boundary. We'd rather
+// under-report by <100 tokens than tip over.
 //
 // CodeRabbit's auto-fix proposed a simpler "always divide by 1000,
 // drop .0 for whole thousands" form. Rejected: that path renders
@@ -632,11 +639,16 @@ func humanTokens(n int) string {
 		return fmt.Sprintf("%d", n)
 	}
 	if n < 100_000 {
-		k := n / 1_000
-		if n == k*1_000 {
-			return fmt.Sprintf("%dk", k)
+		// Integer math truncates toward zero — no rounding-up across
+		// the band boundary. tenths = floor(n/100); whole = tenths/10;
+		// frac = tenths%10 ∈ [0,9].
+		tenths := n / 100
+		whole := tenths / 10
+		frac := tenths % 10
+		if frac == 0 {
+			return fmt.Sprintf("%dk", whole)
 		}
-		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
+		return fmt.Sprintf("%d.%dk", whole, frac)
 	}
 	rounded := (n + 500) / 1000
 	return fmt.Sprintf("%dk", rounded)

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -253,9 +253,9 @@ func TestParseOnlyList(t *testing.T) {
 		{"claude", []string{"claude"}},
 		{"claude,gemini", []string{"claude", "gemini"}},
 		{" claude , gemini ", []string{"claude", "gemini"}},
-		{"", nil},          // empty input → empty set, callers don't need a separate guard
-		{" ", nil},         // whitespace-only → empty set
-		{",,, ", nil},      // delimiters with no names → empty set
+		{"", nil},     // empty input → empty set, callers don't need a separate guard
+		{" ", nil},    // whitespace-only → empty set
+		{",,, ", nil}, // delimiters with no names → empty set
 		{"claude,,", []string{"claude"}},
 	}
 	for _, tc := range cases {
@@ -628,11 +628,11 @@ func TestValidateMergeWith(t *testing.T) {
 		mergeWith string
 		wantErr   bool
 	}{
-		{"", false},        // unset is fine
-		{"auto", false},    // sentinel is fine
-		{"claude", false},  // member of active set
-		{"codex", true},    // not active — typo or misconfig
-		{"claud", true},    // typo — must error, not silently fall through
+		{"", false},       // unset is fine
+		{"auto", false},   // sentinel is fine
+		{"claude", false}, // member of active set
+		{"codex", true},   // not active — typo or misconfig
+		{"claud", true},   // typo — must error, not silently fall through
 	}
 	for _, tc := range cases {
 		err := validateMergeWith(&sharedFlags{mergeWith: tc.mergeWith}, active)
@@ -651,14 +651,15 @@ func TestHumanTokens_FormatBands(t *testing.T) {
 	// the CHANGELOG showed "12.3k" but the prior implementation
 	// emitted "12k". This test fails if either drifts again.
 	cases := map[int]string{
-		0:      "0",
-		456:    "456",
-		999:    "999",
-		1_000:  "1.0k",
-		1_234:  "1.2k",
-		4_500:  "4.5k",
-		12_300: "12.3k",
-		99_999: "100.0k",  // edge of decimal band; renders as 100.0k by float-to-string
+		0:       "0",
+		456:     "456",
+		999:     "999",
+		1_000:   "1k",
+		1_234:   "1.2k",
+		4_500:   "4.5k",
+		12_300:  "12.3k",
+		99_999:  "100.0k", // edge of decimal band; renders as 100.0k by float-to-string
+		15_000:  "15k",
 		100_000: "100k",
 		120_000: "120k",
 		543_210: "543k",
@@ -678,7 +679,7 @@ func TestFormatTokenSuffix_BehaviorByShape(t *testing.T) {
 	}{
 		{"zero usage → empty (no misleading 0/0)", cli.TokenUsage{}, ""},
 		{"split shape → in/out", cli.TokenUsage{InputTokens: 12300, OutputTokens: 4500}, " · 12.3k in / 4.5k out"},
-		{"total-only (codex legacy) → total", cli.TokenUsage{InputTokens: 18000, TotalOnly: true}, " · 18.0k total"},
+		{"total-only (codex legacy) → total", cli.TokenUsage{InputTokens: 18000, TotalOnly: true}, " · 18k total"},
 		{"small split", cli.TokenUsage{InputTokens: 800, OutputTokens: 200}, " · 800 in / 200 out"},
 	}
 	for _, tc := range cases {

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -658,8 +658,14 @@ func TestHumanTokens_FormatBands(t *testing.T) {
 		1_234:   "1.2k",
 		4_500:   "4.5k",
 		12_300:  "12.3k",
-		99_999:  "100.0k", // edge of decimal band; renders as 100.0k by float-to-string
 		15_000:  "15k",
+		// Top of the decimal band must truncate, not round, so
+		// 99,999 stays at "99.9k". Rounding to "100.0k" would both
+		// overstate usage at the boundary and visually crash into
+		// the next band's "100k" form.
+		99_999:  "99.9k",
+		99_950:  "99.9k",
+		99_900:  "99.9k",
 		100_000: "100k",
 		120_000: "120k",
 		543_210: "543k",

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -641,3 +641,51 @@ func TestValidateMergeWith(t *testing.T) {
 		}
 	}
 }
+
+func TestHumanTokens_FormatBands(t *testing.T) {
+	// Three-band format documented on humanTokens:
+	//   <1k        → integer
+	//   1k-99,999  → one-decimal "k"
+	//   ≥100k      → integer "k"
+	// Pinned because review feedback flagged the docs/code drift —
+	// the CHANGELOG showed "12.3k" but the prior implementation
+	// emitted "12k". This test fails if either drifts again.
+	cases := map[int]string{
+		0:      "0",
+		456:    "456",
+		999:    "999",
+		1_000:  "1.0k",
+		1_234:  "1.2k",
+		4_500:  "4.5k",
+		12_300: "12.3k",
+		99_999: "100.0k",  // edge of decimal band; renders as 100.0k by float-to-string
+		100_000: "100k",
+		120_000: "120k",
+		543_210: "543k",
+	}
+	for n, want := range cases {
+		if got := humanTokens(n); got != want {
+			t.Errorf("humanTokens(%d) = %q, want %q", n, got, want)
+		}
+	}
+}
+
+func TestFormatTokenSuffix_BehaviorByShape(t *testing.T) {
+	cases := []struct {
+		name  string
+		usage cli.TokenUsage
+		want  string
+	}{
+		{"zero usage → empty (no misleading 0/0)", cli.TokenUsage{}, ""},
+		{"split shape → in/out", cli.TokenUsage{InputTokens: 12300, OutputTokens: 4500}, " · 12.3k in / 4.5k out"},
+		{"total-only (codex legacy) → total", cli.TokenUsage{InputTokens: 18000, TotalOnly: true}, " · 18.0k total"},
+		{"small split", cli.TokenUsage{InputTokens: 800, OutputTokens: 200}, " · 800 in / 200 out"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatTokenSuffix(tc.usage); got != tc.want {
+				t.Errorf("formatTokenSuffix(%+v) = %q, want %q", tc.usage, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -229,6 +230,14 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, T
 // graceful plain-text fall-through. The v0.6.6 CLI-version baseline
 // is documented in CHANGELOG and fails-fast rather than producing
 // token-less reviews.
+//
+// Stdout and stderr are captured separately so JSON parsing only
+// sees the structured response. Pre-fix this used CombinedOutput
+// and any stderr noise (deprecation banners, "new version available"
+// nags, Node-version warnings) interleaved into the JSON, breaking
+// json.Unmarshal and silently dropping tokens via the raw-text
+// fallback. On error we concatenate stdout+stderr for ClassifyExit
+// so the user-facing message still includes the stderr tail.
 func (g *GeminiInvoker) run(ctx context.Context, prompt string) (string, TokenUsage, error) {
 	args := []string{"-p", "Follow the instructions in stdin.", "-o", "json"}
 	if g.model != "" {
@@ -237,14 +246,14 @@ func (g *GeminiInvoker) run(ctx context.Context, prompt string) (string, TokenUs
 	cmd := exec.CommandContext(ctx, g.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Classified message includes the actionable hint inline; no
-		// "gemini review failed:" prefix because the caller's per-LLM
-		// line already names the agent.
-		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, output, "gemini"))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		combined := append(stdout.Bytes(), stderr.Bytes()...)
+		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, combined, "gemini"))
 	}
-	text, usage := parseGeminiJSON(output)
+	text, usage := parseGeminiJSON(stdout.Bytes())
 	return text, usage, nil
 }
 
@@ -280,6 +289,15 @@ func (c *ClaudeInvoker) RunPrompt(ctx context.Context, prompt string) (string, T
 // fall-through to plain text. Older CLIs are unsupported by design;
 // the documented v0.6.6 CLI-version baseline fails-fast rather than
 // silently producing token-less reviews.
+//
+// Stdout and stderr are captured separately so JSON parsing only
+// sees the structured response. Pre-fix this used CombinedOutput
+// and any stderr noise (Anthropic auth-refresh notices, npm-install
+// "new version available" banners) interleaved into the JSON,
+// breaking json.Unmarshal and silently dropping tokens via the raw-
+// text fallback. On error we concatenate stdout+stderr for
+// ClassifyExit so the user-facing message still includes the
+// stderr tail.
 func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (string, TokenUsage, error) {
 	args := []string{"--print", "--output-format", "json"}
 	if c.model != "" {
@@ -288,16 +306,17 @@ func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (strin
 	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["claude"], c.apiKey)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Classified message includes actionable hints (OOM → smaller
-		// diff, timeout → raise timeout_sec, non-zero → stderr tail).
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
 		// errLabel was the old "claude review failed:" / "claude:" prefix
 		// — the caller's per-LLM line already names the agent so the
 		// prefix would duplicate.
 		_ = errLabel
-		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, output, "claude"))
+		combined := append(stdout.Bytes(), stderr.Bytes()...)
+		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, combined, "claude"))
 	}
-	text, usage := parseClaudeJSON(output)
+	text, usage := parseClaudeJSON(stdout.Bytes())
 	return text, usage, nil
 }

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 )
 
-// Invoker runs an LLM CLI with a diff and returns the review output.
+// Invoker runs an LLM CLI with a diff and returns the review output
+// plus token-usage metadata.
 //
 // Review takes a `systemPrompt` (the language-specific prompt pack
 // content the runner has already loaded via lang.Dominant +
@@ -16,10 +17,16 @@ import (
 // severity tiering, and hard rules the single-LLM path uses. Empty
 // systemPrompt means "fall back to the agent's built-in generic
 // prompt" — useful for tests and as a defensive default.
+//
+// Returns the review text, a TokenUsage from the CLI's structured
+// output (zero values when the CLI version or invocation didn't
+// surface token counts), and any error.
 type Invoker interface {
-	Review(ctx context.Context, systemPrompt, diff string) (string, error)
-	// RunPrompt sends a raw prompt to the LLM without wrapping it in a code-review context
-	RunPrompt(ctx context.Context, prompt string) (string, error)
+	Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error)
+	// RunPrompt sends a raw prompt to the LLM without wrapping it
+	// in a code-review context. Used by the merger; tokens returned
+	// for cost-attribution symmetry with Review.
+	RunPrompt(ctx context.Context, prompt string) (string, TokenUsage, error)
 }
 
 // multiLLMOutputOverride tells the agent to respond in markdown
@@ -119,12 +126,12 @@ type CodexInvoker struct {
 	apiKey string // injected as OPENAI_API_KEY into subprocess env
 }
 
-func (c *CodexInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
+func (c *CodexInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error) {
 	prompt := buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff
 	return c.runExec(ctx, prompt, "codex review")
 }
 
-func (c *CodexInvoker) RunPrompt(ctx context.Context, prompt string) (string, error) {
+func (c *CodexInvoker) RunPrompt(ctx context.Context, prompt string) (string, TokenUsage, error) {
 	return c.runExec(ctx, prompt, "codex")
 }
 
@@ -141,10 +148,18 @@ func (c *CodexInvoker) RunPrompt(ctx context.Context, prompt string) (string, er
 // so we accept the disk I/O — one temp file per review, deleted via
 // defer — as the price of a stable contract. If codex ever ships a
 // stdout-only flag, drop the file.
-func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (string, error) {
+//
+// Token usage: codex exec doesn't have a JSON-output flag (verified
+// against `codex exec --help` on v0.128.0). We parse the same stdout
+// metadata block we already capture (for stderr tail on errors) for
+// the "tokens used" line. parseCodexStdoutTokens returns TokenUsage{}
+// when the line isn't found, so a future codex version that drops
+// the line silently degrades to "no token info" rather than failing
+// the whole review.
+func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (string, TokenUsage, error) {
 	tmp, err := os.CreateTemp("", "codex-out-*.txt")
 	if err != nil {
-		return "", fmt.Errorf("%s: create temp output file: %w", errLabel, err)
+		return "", TokenUsage{}, fmt.Errorf("%s: create temp output file: %w", errLabel, err)
 	}
 	tmpPath := tmp.Name()
 	tmp.Close()
@@ -157,7 +172,8 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["codex"], c.apiKey)
-	if combined, err := cmd.CombinedOutput(); err != nil {
+	combined, err := cmd.CombinedOutput()
+	if err != nil {
 		// ClassifyExit produces the user-facing summary with an
 		// actionable hint (smaller diff for SIGKILL, raise timeout for
 		// deadline, surface stderr tail for non-zero exit). The
@@ -165,14 +181,15 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 		// already prefixes the agent name, so prefixing it again would
 		// just produce "codex ✗ codex review failed: ..." duplication.
 		_ = errLabel
-		return "", fmt.Errorf("%s", ClassifyExit(ctx, err, combined, "codex"))
+		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, combined, "codex"))
 	}
 
 	out, err := os.ReadFile(tmpPath)
 	if err != nil {
-		return "", fmt.Errorf("%s: read codex output: %w", errLabel, err)
+		return "", TokenUsage{}, fmt.Errorf("%s: read codex output: %w", errLabel, err)
 	}
-	return string(out), nil
+	usage := parseCodexStdoutTokens(string(combined))
+	return string(out), usage, nil
 }
 
 // GeminiInvoker runs the Google Gemini CLI.
@@ -183,37 +200,29 @@ type GeminiInvoker struct {
 	apiKey string // injected as GEMINI_API_KEY into subprocess env
 }
 
-func (g *GeminiInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
-	// gemini's `-p` is appended to stdin in headless mode (per its
-	// --help). Put a marker in -p, route the full pack-prompt + diff
-	// via stdin to dodge ARG_MAX on long pack content.
-	args := []string{"-p", "Follow the instructions in stdin."}
-	if g.model != "" {
-		args = append(args, "-m", g.model)
-	}
-	cmd := exec.CommandContext(ctx, g.path, args...)
-	cmd.Stdin = strings.NewReader(buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff)
-	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Classified message includes the actionable hint inline; no
-		// "gemini review failed:" prefix because the caller's per-LLM
-		// line already names the agent.
-		return "", fmt.Errorf("%s", ClassifyExit(ctx, err, output, "gemini"))
-	}
-
-	return string(output), nil
+func (g *GeminiInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error) {
+	return g.run(ctx, buildReviewPrompt(systemPrompt)+"\n\n# Diff\n\n"+diff)
 }
 
-func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, error) {
-	// gemini's --help: "-p, --prompt: Run in non-interactive mode with
-	// the given prompt. Appended to input on stdin (if any)." So a tiny
-	// marker via -p activates headless mode and the real prompt body
-	// goes via stdin — sidestepping ARG_MAX (~256KB on macOS, ~2MB on
-	// Linux) that the previous "whole prompt via -p" implementation hit
-	// on merger prompts that aggregate multiple per-LLM reviews.
-	args := []string{"-p", "Follow the instructions in stdin."}
+func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	return g.run(ctx, prompt)
+}
+
+// run is the shared driver for Review and RunPrompt.
+//
+// gemini's --help: "-p, --prompt: Run in non-interactive mode with
+// the given prompt. Appended to input on stdin (if any)." A tiny
+// marker via -p activates headless mode; the real prompt body goes
+// via stdin — sidestepping ARG_MAX (~256KB on macOS, ~2MB on Linux)
+// the "whole prompt via -p" implementation hit on merger prompts.
+//
+// `-o json` requests structured output. The CLI returns either a
+// JSON object with token counts in usageMetadata, or — if too old —
+// plain text. parseGeminiJSON handles both: returns the parsed text
+// and tokens on success, or the raw output with TokenUsage{} on
+// failure (graceful degradation: lose tokens, keep the review).
+func (g *GeminiInvoker) run(ctx context.Context, prompt string) (string, TokenUsage, error) {
+	args := []string{"-p", "Follow the instructions in stdin.", "-o", "json"}
 	if g.model != "" {
 		args = append(args, "-m", g.model)
 	}
@@ -222,9 +231,13 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, e
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%s", ClassifyExit(ctx, err, output, "gemini"))
+		// Classified message includes the actionable hint inline; no
+		// "gemini review failed:" prefix because the caller's per-LLM
+		// line already names the agent.
+		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, output, "gemini"))
 	}
-	return string(output), nil
+	text, usage := parseGeminiJSON(output)
+	return text, usage, nil
 }
 
 // ClaudeInvoker runs the Anthropic Claude CLI.
@@ -235,19 +248,25 @@ type ClaudeInvoker struct {
 	apiKey string // injected as ANTHROPIC_API_KEY into subprocess env
 }
 
-func (c *ClaudeInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, error) {
+func (c *ClaudeInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error) {
 	prompt := buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff
 	return c.run(ctx, prompt, "claude review")
 }
 
-func (c *ClaudeInvoker) RunPrompt(ctx context.Context, prompt string) (string, error) {
+func (c *ClaudeInvoker) RunPrompt(ctx context.Context, prompt string) (string, TokenUsage, error) {
 	return c.run(ctx, prompt, "claude")
 }
 
 // run is the shared driver. Splits args into "model + stdin prompt" so
 // per-agent --claude-model overrides reach the CLI.
-func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (string, error) {
-	var args []string
+//
+// Uses `--print --output-format json` so the response is a single
+// JSON object containing both the assistant's reply and a usage
+// block we can extract token counts from. If the CLI is too old to
+// support the flag, output won't parse as JSON and we fall back to
+// treating the whole stdout as plain text with TokenUsage{}.
+func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (string, TokenUsage, error) {
+	args := []string{"--print", "--output-format", "json"}
 	if c.model != "" {
 		args = append(args, "--model", c.model)
 	}
@@ -262,7 +281,8 @@ func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (strin
 		// — the caller's per-LLM line already names the agent so the
 		// prefix would duplicate.
 		_ = errLabel
-		return "", fmt.Errorf("%s", ClassifyExit(ctx, err, output, "claude"))
+		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, output, "claude"))
 	}
-	return string(output), nil
+	text, usage := parseClaudeJSON(output)
+	return text, usage, nil
 }

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -216,11 +216,19 @@ func (g *GeminiInvoker) RunPrompt(ctx context.Context, prompt string) (string, T
 // via stdin — sidestepping ARG_MAX (~256KB on macOS, ~2MB on Linux)
 // the "whole prompt via -p" implementation hit on merger prompts.
 //
-// `-o json` requests structured output. The CLI returns either a
-// JSON object with token counts in usageMetadata, or — if too old —
-// plain text. parseGeminiJSON handles both: returns the parsed text
-// and tokens on success, or the raw output with TokenUsage{} on
-// failure (graceful degradation: lose tokens, keep the review).
+// `-o json` requests structured output. parseGeminiJSON handles two
+// shapes seen in the wild — the modern stats.models.<id>.tokens
+// structure and the older Vertex-style usageMetadata. Returns
+// TokenUsage{} when neither shape parses (e.g., a future schema
+// drift) so the review still ships even if we lose token info for
+// that run.
+//
+// Minimum gemini CLI version: v0.40 (the version where `-o json`
+// stabilised). Older CLIs without the flag exit with an unknown-
+// argument error and ClassifyExit surfaces the stderr — *not* a
+// graceful plain-text fall-through. The v0.6.6 CLI-version baseline
+// is documented in CHANGELOG and fails-fast rather than producing
+// token-less reviews.
 func (g *GeminiInvoker) run(ctx context.Context, prompt string) (string, TokenUsage, error) {
 	args := []string{"-p", "Follow the instructions in stdin.", "-o", "json"}
 	if g.model != "" {
@@ -262,9 +270,16 @@ func (c *ClaudeInvoker) RunPrompt(ctx context.Context, prompt string) (string, T
 //
 // Uses `--print --output-format json` so the response is a single
 // JSON object containing both the assistant's reply and a usage
-// block we can extract token counts from. If the CLI is too old to
-// support the flag, output won't parse as JSON and we fall back to
-// treating the whole stdout as plain text with TokenUsage{}.
+// block we can extract token counts from.
+//
+// Minimum claude CLI version: any release supporting
+// `--output-format json` (well-established since claude-code shipped
+// non-interactive mode). If the user runs a CLI old enough not to
+// recognise the flag, the subprocess exits with an "unknown flag"
+// error and ClassifyExit surfaces the stderr — *not* a graceful
+// fall-through to plain text. Older CLIs are unsupported by design;
+// the documented v0.6.6 CLI-version baseline fails-fast rather than
+// silently producing token-less reviews.
 func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (string, TokenUsage, error) {
 	args := []string{"--print", "--output-format", "json"}
 	if c.model != "" {

--- a/internal/cli/invoker_test.go
+++ b/internal/cli/invoker_test.go
@@ -67,7 +67,7 @@ func TestCodexInvoker_Review(t *testing.T) {
 	// integration testing happens in manual testing phase.
 	invoker := &CodexInvoker{path: "/nonexistent/codex"}
 
-	if _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
+	if _, _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
 		t.Error("Expected error with non-existent path, got nil")
 	}
 }
@@ -75,7 +75,7 @@ func TestCodexInvoker_Review(t *testing.T) {
 func TestGeminiInvoker_Review(t *testing.T) {
 	invoker := &GeminiInvoker{path: "/nonexistent/gemini"}
 
-	if _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
+	if _, _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
 		t.Error("Expected error with non-existent path, got nil")
 	}
 }
@@ -83,7 +83,7 @@ func TestGeminiInvoker_Review(t *testing.T) {
 func TestClaudeInvoker_Review(t *testing.T) {
 	invoker := &ClaudeInvoker{path: "/nonexistent/claude"}
 
-	if _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
+	if _, _, err := invoker.Review(context.Background(), "", "sample diff"); err == nil {
 		t.Error("Expected error with non-existent path, got nil")
 	}
 }

--- a/internal/cli/parsers.go
+++ b/internal/cli/parsers.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// parseClaudeJSON unwraps the JSON object claude --output-format json
+// returns. Anthropic's documented shape (claude-code v1+):
+//
+//	{
+//	  "type": "result",
+//	  "subtype": "success",
+//	  "result": "<the assistant's reply>",
+//	  "usage": {
+//	    "input_tokens": N,
+//	    "output_tokens": M,
+//	    "cache_read_input_tokens": ...,
+//	    "cache_creation_input_tokens": ...
+//	  },
+//	  ...
+//	}
+//
+// Falls back to the raw output as text + zero usage when:
+//   - The output isn't valid JSON (older CLI without --output-format).
+//   - The "result" field is missing (different shape).
+//
+// Cache-read/creation tokens are NOT included in the input count we
+// surface — those represent reuse, not new spend. If we're going to
+// ever expose them, it should be as a separate "cached" field in
+// TokenUsage.
+func parseClaudeJSON(output []byte) (string, TokenUsage) {
+	var resp struct {
+		Type   string `json:"type"`
+		Result string `json:"result"`
+		Usage  struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(output, &resp); err != nil || resp.Result == "" {
+		return string(output), TokenUsage{}
+	}
+	return resp.Result, TokenUsage{
+		InputTokens:  resp.Usage.InputTokens,
+		OutputTokens: resp.Usage.OutputTokens,
+	}
+}
+
+// parseGeminiJSON unwraps the JSON object gemini -o json returns.
+// Google's CLI doesn't document a stable shape across versions, so
+// we try the two shapes that have appeared in the wild:
+//
+//	Shape A (newer): {"response": "...", "stats": {"models": {"<id>": {"tokens": {"prompt": N, "candidates": M, "total": ...}}}}}
+//	Shape B (older): {"text": "...", "usageMetadata": {"promptTokenCount": N, "candidatesTokenCount": M}}
+//
+// First-match wins. If neither shape parses, fall back to raw text +
+// zero usage. The variability is the price of using a CLI Google
+// hasn't pinned to a stable contract.
+func parseGeminiJSON(output []byte) (string, TokenUsage) {
+	// Shape A: the structure recent gemini-cli uses.
+	var shapeA struct {
+		Response string `json:"response"`
+		Stats    struct {
+			Models map[string]struct {
+				Tokens struct {
+					Prompt     int `json:"prompt"`
+					Candidates int `json:"candidates"`
+				} `json:"tokens"`
+			} `json:"models"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal(output, &shapeA); err == nil && shapeA.Response != "" {
+		// Sum tokens across all models reported (typically one).
+		var in, out int
+		for _, m := range shapeA.Stats.Models {
+			in += m.Tokens.Prompt
+			out += m.Tokens.Candidates
+		}
+		return shapeA.Response, TokenUsage{InputTokens: in, OutputTokens: out}
+	}
+
+	// Shape B: older Vertex-style usageMetadata.
+	var shapeB struct {
+		Text          string `json:"text"`
+		UsageMetadata struct {
+			PromptTokenCount     int `json:"promptTokenCount"`
+			CandidatesTokenCount int `json:"candidatesTokenCount"`
+		} `json:"usageMetadata"`
+	}
+	if err := json.Unmarshal(output, &shapeB); err == nil && shapeB.Text != "" {
+		return shapeB.Text, TokenUsage{
+			InputTokens:  shapeB.UsageMetadata.PromptTokenCount,
+			OutputTokens: shapeB.UsageMetadata.CandidatesTokenCount,
+		}
+	}
+
+	// Neither shape: not valid JSON or different structure. Fall
+	// through to text — at worst the user loses token visibility
+	// for gemini, never the review itself.
+	return string(output), TokenUsage{}
+}
+
+// codexTokensRE captures the input/output token counts from the
+// session-metadata block codex exec writes to stdout (intermixed
+// with the assistant's reply, which is why we route the reply
+// through --output-last-message). The pattern handles both shapes
+// codex has used across recent versions:
+//
+//	"tokens used: <total>"            (just total, before v0.120)
+//	"tokens: <in> input, <out> output" (split, v0.128+)
+//
+// Matches case-insensitive because codex's banner capitalisation
+// has drifted historically.
+var codexTokensRE = regexp.MustCompile(`(?i)tokens(?:\s+used)?:\s*(\d[\d,]*)(?:\s+input(?:\s*,\s*(\d[\d,]*)\s+output)?)?`)
+
+// parseCodexStdoutTokens scans codex exec's combined stdout/stderr
+// for the token-usage line. Returns TokenUsage{} when no match —
+// preferable to inventing numbers when the format changes.
+//
+// The split-counts shape (v0.128+) populates both Input and Output;
+// the legacy single-total shape (older) populates only Total via
+// InputTokens — we don't have enough signal to attribute split, so
+// reporting "all input" is a deliberate under-report on the output
+// side rather than a fabricated split.
+func parseCodexStdoutTokens(combined string) TokenUsage {
+	m := codexTokensRE.FindStringSubmatch(combined)
+	if m == nil {
+		return TokenUsage{}
+	}
+	first := atoiNoCommas(m[1])
+	if len(m) >= 3 && m[2] != "" {
+		// Split shape: m[1] = input, m[2] = output.
+		return TokenUsage{InputTokens: first, OutputTokens: atoiNoCommas(m[2])}
+	}
+	// Legacy single-total shape — fold into InputTokens since we
+	// can't attribute. Underestimates output but doesn't fabricate.
+	return TokenUsage{InputTokens: first}
+}
+
+// atoiNoCommas parses an integer that may have thousand separators
+// like "12,345". Returns 0 on parse failure so callers don't have
+// to thread errors through the regex path.
+func atoiNoCommas(s string) int {
+	s = strings.ReplaceAll(s, ",", "")
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/cli/parsers.go
+++ b/internal/cli/parsers.go
@@ -83,11 +83,7 @@ func parseGeminiJSON(output []byte) (string, TokenUsage) {
 			in += m.Tokens.Prompt
 			out += m.Tokens.Candidates
 		}
-		text := ""
-		if shapeA.Response != nil {
-			text = *shapeA.Response
-		}
-		return text, TokenUsage{InputTokens: in, OutputTokens: out}
+		return *shapeA.Response, TokenUsage{InputTokens: in, OutputTokens: out}
 	}
 
 	// Shape B: older Vertex-style usageMetadata.
@@ -99,16 +95,12 @@ func parseGeminiJSON(output []byte) (string, TokenUsage) {
 		} `json:"usageMetadata"`
 	}
 	if err := json.Unmarshal(output, &shapeB); err == nil && shapeB.Text != nil {
-		text := ""
-		if shapeB.Text != nil {
-			text = *shapeB.Text
-		}
 		usage := TokenUsage{}
 		if shapeB.UsageMetadata != nil {
 			usage.InputTokens = shapeB.UsageMetadata.PromptTokenCount
 			usage.OutputTokens = shapeB.UsageMetadata.CandidatesTokenCount
 		}
-		return text, usage
+		return *shapeB.Text, usage
 	}
 
 	// Neither shape: not valid JSON or different structure. Fall

--- a/internal/cli/parsers.go
+++ b/internal/cli/parsers.go
@@ -35,20 +35,22 @@ import (
 // TokenUsage.
 func parseClaudeJSON(output []byte) (string, TokenUsage) {
 	var resp struct {
-		Type   string `json:"type"`
-		Result string `json:"result"`
-		Usage  struct {
+		Type   string  `json:"type"`
+		Result *string `json:"result"`
+		Usage  *struct {
 			InputTokens  int `json:"input_tokens"`
 			OutputTokens int `json:"output_tokens"`
 		} `json:"usage"`
 	}
-	if err := json.Unmarshal(output, &resp); err != nil || resp.Result == "" {
+	if err := json.Unmarshal(output, &resp); err != nil || resp.Result == nil {
 		return string(output), TokenUsage{}
 	}
-	return resp.Result, TokenUsage{
-		InputTokens:  resp.Usage.InputTokens,
-		OutputTokens: resp.Usage.OutputTokens,
+	usage := TokenUsage{}
+	if resp.Usage != nil {
+		usage.InputTokens = resp.Usage.InputTokens
+		usage.OutputTokens = resp.Usage.OutputTokens
 	}
+	return *resp.Result, usage
 }
 
 // parseGeminiJSON unwraps the JSON object gemini -o json returns.
@@ -64,7 +66,7 @@ func parseClaudeJSON(output []byte) (string, TokenUsage) {
 func parseGeminiJSON(output []byte) (string, TokenUsage) {
 	// Shape A: the structure recent gemini-cli uses.
 	var shapeA struct {
-		Response string `json:"response"`
+		Response *string `json:"response"`
 		Stats    struct {
 			Models map[string]struct {
 				Tokens struct {
@@ -74,29 +76,39 @@ func parseGeminiJSON(output []byte) (string, TokenUsage) {
 			} `json:"models"`
 		} `json:"stats"`
 	}
-	if err := json.Unmarshal(output, &shapeA); err == nil && shapeA.Response != "" {
+	if err := json.Unmarshal(output, &shapeA); err == nil && (shapeA.Response != nil || len(shapeA.Stats.Models) > 0) {
 		// Sum tokens across all models reported (typically one).
 		var in, out int
 		for _, m := range shapeA.Stats.Models {
 			in += m.Tokens.Prompt
 			out += m.Tokens.Candidates
 		}
-		return shapeA.Response, TokenUsage{InputTokens: in, OutputTokens: out}
+		text := ""
+		if shapeA.Response != nil {
+			text = *shapeA.Response
+		}
+		return text, TokenUsage{InputTokens: in, OutputTokens: out}
 	}
 
 	// Shape B: older Vertex-style usageMetadata.
 	var shapeB struct {
-		Text          string `json:"text"`
-		UsageMetadata struct {
+		Text          *string `json:"text"`
+		UsageMetadata *struct {
 			PromptTokenCount     int `json:"promptTokenCount"`
 			CandidatesTokenCount int `json:"candidatesTokenCount"`
 		} `json:"usageMetadata"`
 	}
-	if err := json.Unmarshal(output, &shapeB); err == nil && shapeB.Text != "" {
-		return shapeB.Text, TokenUsage{
-			InputTokens:  shapeB.UsageMetadata.PromptTokenCount,
-			OutputTokens: shapeB.UsageMetadata.CandidatesTokenCount,
+	if err := json.Unmarshal(output, &shapeB); err == nil && (shapeB.Text != nil || shapeB.UsageMetadata != nil) {
+		text := ""
+		if shapeB.Text != nil {
+			text = *shapeB.Text
 		}
+		usage := TokenUsage{}
+		if shapeB.UsageMetadata != nil {
+			usage.InputTokens = shapeB.UsageMetadata.PromptTokenCount
+			usage.OutputTokens = shapeB.UsageMetadata.CandidatesTokenCount
+		}
+		return text, usage
 	}
 
 	// Neither shape: not valid JSON or different structure. Fall

--- a/internal/cli/parsers.go
+++ b/internal/cli/parsers.go
@@ -76,7 +76,7 @@ func parseGeminiJSON(output []byte) (string, TokenUsage) {
 			} `json:"models"`
 		} `json:"stats"`
 	}
-	if err := json.Unmarshal(output, &shapeA); err == nil && (shapeA.Response != nil || len(shapeA.Stats.Models) > 0) {
+	if err := json.Unmarshal(output, &shapeA); err == nil && shapeA.Response != nil {
 		// Sum tokens across all models reported (typically one).
 		var in, out int
 		for _, m := range shapeA.Stats.Models {
@@ -98,7 +98,7 @@ func parseGeminiJSON(output []byte) (string, TokenUsage) {
 			CandidatesTokenCount int `json:"candidatesTokenCount"`
 		} `json:"usageMetadata"`
 	}
-	if err := json.Unmarshal(output, &shapeB); err == nil && (shapeB.Text != nil || shapeB.UsageMetadata != nil) {
+	if err := json.Unmarshal(output, &shapeB); err == nil && shapeB.Text != nil {
 		text := ""
 		if shapeB.Text != nil {
 			text = *shapeB.Text

--- a/internal/cli/parsers.go
+++ b/internal/cli/parsers.go
@@ -23,9 +23,11 @@ import (
 //	  ...
 //	}
 //
-// Falls back to the raw output as text + zero usage when:
-//   - The output isn't valid JSON (older CLI without --output-format).
-//   - The "result" field is missing (different shape).
+// Falls back to the raw output as text + zero usage when valid JSON
+// has an unexpected shape (e.g., a future schema or an error
+// envelope). This is NOT a path to support older CLIs lacking
+// --output-format — those exit non-zero and never reach this parser;
+// see ClaudeInvoker.run for the version-baseline rationale.
 //
 // Cache-read/creation tokens are NOT included in the input count we
 // surface — those represent reuse, not new spend. If we're going to
@@ -135,9 +137,12 @@ func parseCodexStdoutTokens(combined string) TokenUsage {
 		// Split shape: m[1] = input, m[2] = output.
 		return TokenUsage{InputTokens: first, OutputTokens: atoiNoCommas(m[2])}
 	}
-	// Legacy single-total shape — fold into InputTokens since we
-	// can't attribute. Underestimates output but doesn't fabricate.
-	return TokenUsage{InputTokens: first}
+	// Legacy single-total shape — codex pre-v0.128 doesn't split
+	// input vs output. Fold into InputTokens (so Total() math still
+	// works) and flag TotalOnly so the formatter renders "Nk total"
+	// instead of "Nk in / 0 out". The "/ 0 out" form would lie:
+	// the model produced output, we just don't know how much.
+	return TokenUsage{InputTokens: first, TotalOnly: true}
 }
 
 // atoiNoCommas parses an integer that may have thousand separators

--- a/internal/cli/parsers_test.go
+++ b/internal/cli/parsers_test.go
@@ -51,6 +51,17 @@ func TestParseClaudeJSON_FallbackOnMissingResult(t *testing.T) {
 	}
 }
 
+func TestParseClaudeJSON_EmptyResultPreservesUsage(t *testing.T) {
+	body := []byte(`{"type":"result","subtype":"success","result":"","usage":{"input_tokens":1200,"output_tokens":300}}`)
+	text, usage := parseClaudeJSON(body)
+	if text != "" {
+		t.Errorf("empty result should stay empty, got %q", text)
+	}
+	if usage.InputTokens != 1200 || usage.OutputTokens != 300 {
+		t.Errorf("usage = %+v, want {1200, 300}", usage)
+	}
+}
+
 func TestParseGeminiJSON_ShapeA(t *testing.T) {
 	// Newer gemini-cli structure with stats.models.<id>.tokens
 	body := []byte(`{"response":"# Review\n- finding","stats":{"models":{"gemini-2.5-pro":{"tokens":{"prompt":15000,"candidates":3000}}}}}`)
@@ -66,12 +77,34 @@ func TestParseGeminiJSON_ShapeA(t *testing.T) {
 	}
 }
 
+func TestParseGeminiJSON_ShapeA_EmptyResponsePreservesUsage(t *testing.T) {
+	body := []byte(`{"response":"","stats":{"models":{"gemini-2.5-pro":{"tokens":{"prompt":15000,"candidates":3000}}}}}`)
+	text, usage := parseGeminiJSON(body)
+	if text != "" {
+		t.Errorf("empty response should stay empty, got %q", text)
+	}
+	if usage.InputTokens != 15000 || usage.OutputTokens != 3000 {
+		t.Errorf("usage = %+v, want {15000, 3000}", usage)
+	}
+}
+
 func TestParseGeminiJSON_ShapeB(t *testing.T) {
 	// Older Vertex-style usageMetadata shape
 	body := []byte(`{"text":"# Review","usageMetadata":{"promptTokenCount":15000,"candidatesTokenCount":3000}}`)
 	text, usage := parseGeminiJSON(body)
 	if text != "# Review" {
 		t.Errorf("text not extracted: %q", text)
+	}
+	if usage.InputTokens != 15000 || usage.OutputTokens != 3000 {
+		t.Errorf("usage = %+v, want {15000, 3000}", usage)
+	}
+}
+
+func TestParseGeminiJSON_ShapeB_EmptyTextPreservesUsage(t *testing.T) {
+	body := []byte(`{"text":"","usageMetadata":{"promptTokenCount":15000,"candidatesTokenCount":3000}}`)
+	text, usage := parseGeminiJSON(body)
+	if text != "" {
+		t.Errorf("empty text should stay empty, got %q", text)
 	}
 	if usage.InputTokens != 15000 || usage.OutputTokens != 3000 {
 		t.Errorf("usage = %+v, want {15000, 3000}", usage)
@@ -93,7 +126,8 @@ func TestParseGeminiJSON_FallbackOnUnknownShape(t *testing.T) {
 }
 
 func TestParseGeminiJSON_FallbackOnPlainText(t *testing.T) {
-	// Older gemini-cli without -o json returns plain text
+	// If we ever see plain text instead of JSON (schema drift, wrapper,
+	// etc.), preserve the review text and just lose token visibility.
 	plain := []byte("# Review\n- finding\n")
 	text, usage := parseGeminiJSON(plain)
 	if text != string(plain) {
@@ -165,11 +199,11 @@ func TestParseCodexStdoutTokens_NoMatch(t *testing.T) {
 
 func TestAtoiNoCommas(t *testing.T) {
 	cases := map[string]int{
-		"":         0,
-		"123":      123,
-		"12,345":   12345,
+		"":          0,
+		"123":       123,
+		"12,345":    12345,
 		"1,234,567": 1234567,
-		"abc":      0, // parse failure → 0, not panic
+		"abc":       0, // parse failure → 0, not panic
 	}
 	for in, want := range cases {
 		if got := atoiNoCommas(in); got != want {

--- a/internal/cli/parsers_test.go
+++ b/internal/cli/parsers_test.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseClaudeJSON_Success(t *testing.T) {
+	// Anthropic's documented shape from `claude --output-format json`:
+	// see https://docs.anthropic.com/en/docs/claude-code/sdk
+	body := []byte(`{"type":"result","subtype":"success","result":"# Review\n## Major\n- bug","usage":{"input_tokens":12300,"output_tokens":4500,"cache_read_input_tokens":2000}}`)
+	text, usage := parseClaudeJSON(body)
+	if !strings.Contains(text, "# Review") {
+		t.Errorf("text not extracted: %q", text)
+	}
+	if usage.InputTokens != 12300 {
+		t.Errorf("InputTokens = %d, want 12300", usage.InputTokens)
+	}
+	if usage.OutputTokens != 4500 {
+		t.Errorf("OutputTokens = %d, want 4500", usage.OutputTokens)
+	}
+}
+
+func TestParseClaudeJSON_FallbackOnInvalidJSON(t *testing.T) {
+	// An older claude CLI without --output-format json returns plain
+	// text. We must not lose the review just because we couldn't get
+	// usage data — fall back to text + zero usage.
+	plain := []byte("# Review\n## Major\n- bug\n")
+	text, usage := parseClaudeJSON(plain)
+	if text != string(plain) {
+		t.Errorf("plain text not preserved: %q", text)
+	}
+	if !usage.IsZero() {
+		t.Errorf("expected zero usage on plain-text fallback, got %+v", usage)
+	}
+}
+
+func TestParseClaudeJSON_FallbackOnMissingResult(t *testing.T) {
+	// Valid JSON but unexpected shape (e.g. an error envelope or a
+	// future schema). Treat as opaque — return raw, zero usage.
+	body := []byte(`{"type":"error","message":"oops"}`)
+	text, usage := parseClaudeJSON(body)
+	if text != string(body) {
+		t.Errorf("unexpected JSON should pass through as text, got %q", text)
+	}
+	if !usage.IsZero() {
+		t.Errorf("expected zero usage on unrecognised shape, got %+v", usage)
+	}
+}
+
+func TestParseGeminiJSON_ShapeA(t *testing.T) {
+	// Newer gemini-cli structure with stats.models.<id>.tokens
+	body := []byte(`{"response":"# Review\n- finding","stats":{"models":{"gemini-2.5-pro":{"tokens":{"prompt":15000,"candidates":3000}}}}}`)
+	text, usage := parseGeminiJSON(body)
+	if !strings.Contains(text, "# Review") {
+		t.Errorf("text not extracted: %q", text)
+	}
+	if usage.InputTokens != 15000 {
+		t.Errorf("InputTokens = %d, want 15000", usage.InputTokens)
+	}
+	if usage.OutputTokens != 3000 {
+		t.Errorf("OutputTokens = %d, want 3000", usage.OutputTokens)
+	}
+}
+
+func TestParseGeminiJSON_ShapeB(t *testing.T) {
+	// Older Vertex-style usageMetadata shape
+	body := []byte(`{"text":"# Review","usageMetadata":{"promptTokenCount":15000,"candidatesTokenCount":3000}}`)
+	text, usage := parseGeminiJSON(body)
+	if text != "# Review" {
+		t.Errorf("text not extracted: %q", text)
+	}
+	if usage.InputTokens != 15000 || usage.OutputTokens != 3000 {
+		t.Errorf("usage = %+v, want {15000, 3000}", usage)
+	}
+}
+
+func TestParseGeminiJSON_FallbackOnUnknownShape(t *testing.T) {
+	// Unknown JSON shape — neither A nor B. Fall back to raw text +
+	// zero usage. The user gets the review (whatever's there); they
+	// just lose token visibility for this run.
+	body := []byte(`{"weird":"shape"}`)
+	text, usage := parseGeminiJSON(body)
+	if text != string(body) {
+		t.Errorf("unknown shape should pass through, got %q", text)
+	}
+	if !usage.IsZero() {
+		t.Errorf("expected zero usage on unknown shape, got %+v", usage)
+	}
+}
+
+func TestParseGeminiJSON_FallbackOnPlainText(t *testing.T) {
+	// Older gemini-cli without -o json returns plain text
+	plain := []byte("# Review\n- finding\n")
+	text, usage := parseGeminiJSON(plain)
+	if text != string(plain) {
+		t.Errorf("plain text not preserved: %q", text)
+	}
+	if !usage.IsZero() {
+		t.Errorf("expected zero usage on plain-text fallback, got %+v", usage)
+	}
+}
+
+func TestParseCodexStdoutTokens_SplitShape(t *testing.T) {
+	// codex v0.128+: "tokens: <in> input, <out> output"
+	stdout := `[2026-05-07T12:00:00Z] OpenAI Codex v0.128.0
+[2026-05-07T12:00:01Z] running review
+[2026-05-07T12:00:42Z] tokens: 12,345 input, 6,789 output
+[2026-05-07T12:00:42Z] session complete`
+	usage := parseCodexStdoutTokens(stdout)
+	if usage.InputTokens != 12345 {
+		t.Errorf("InputTokens = %d, want 12345", usage.InputTokens)
+	}
+	if usage.OutputTokens != 6789 {
+		t.Errorf("OutputTokens = %d, want 6789", usage.OutputTokens)
+	}
+}
+
+func TestParseCodexStdoutTokens_LegacyTotalShape(t *testing.T) {
+	// Older codex: "tokens used: <total>" (no input/output split)
+	// We attribute everything to InputTokens — under-reports output
+	// but doesn't fabricate a split.
+	stdout := `[2026-05-04T12:00:00Z] tokens used: 18000
+[2026-05-04T12:00:00Z] done`
+	usage := parseCodexStdoutTokens(stdout)
+	if usage.InputTokens != 18000 {
+		t.Errorf("InputTokens = %d, want 18000 (legacy total)", usage.InputTokens)
+	}
+	if usage.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0 (legacy can't attribute)", usage.OutputTokens)
+	}
+}
+
+func TestParseCodexStdoutTokens_NoMatch(t *testing.T) {
+	// Future codex version drops the line entirely. Better to
+	// return zero usage than to fabricate.
+	stdout := "no metadata at all"
+	usage := parseCodexStdoutTokens(stdout)
+	if !usage.IsZero() {
+		t.Errorf("expected zero on no-match, got %+v", usage)
+	}
+}
+
+func TestAtoiNoCommas(t *testing.T) {
+	cases := map[string]int{
+		"":         0,
+		"123":      123,
+		"12,345":   12345,
+		"1,234,567": 1234567,
+		"abc":      0, // parse failure → 0, not panic
+	}
+	for in, want := range cases {
+		if got := atoiNoCommas(in); got != want {
+			t.Errorf("atoiNoCommas(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestTokenUsage_IsZero(t *testing.T) {
+	cases := []struct {
+		name  string
+		usage TokenUsage
+		want  bool
+	}{
+		{"both zero", TokenUsage{0, 0}, true},
+		{"input only", TokenUsage{100, 0}, false},
+		{"output only", TokenUsage{0, 100}, false},
+		{"both nonzero", TokenUsage{100, 200}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.usage.IsZero(); got != tc.want {
+				t.Errorf("IsZero() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTokenUsage_Total(t *testing.T) {
+	u := TokenUsage{InputTokens: 100, OutputTokens: 200}
+	if got := u.Total(); got != 300 {
+		t.Errorf("Total() = %d, want 300", got)
+	}
+}

--- a/internal/cli/parsers_test.go
+++ b/internal/cli/parsers_test.go
@@ -22,9 +22,12 @@ func TestParseClaudeJSON_Success(t *testing.T) {
 }
 
 func TestParseClaudeJSON_FallbackOnInvalidJSON(t *testing.T) {
-	// An older claude CLI without --output-format json returns plain
-	// text. We must not lose the review just because we couldn't get
-	// usage data — fall back to text + zero usage.
+	// If we somehow get plain text instead of JSON (a future CLI
+	// schema change that drops --output-format json without
+	// erroring, say), don't lose the review — pass it through as
+	// text with zero usage. This is NOT a fallback path for older
+	// CLIs lacking the flag; those exit non-zero and never reach
+	// this parser. See ClaudeInvoker.run.
 	plain := []byte("# Review\n## Major\n- bug\n")
 	text, usage := parseClaudeJSON(plain)
 	if text != string(plain) {
@@ -117,17 +120,36 @@ func TestParseCodexStdoutTokens_SplitShape(t *testing.T) {
 }
 
 func TestParseCodexStdoutTokens_LegacyTotalShape(t *testing.T) {
-	// Older codex: "tokens used: <total>" (no input/output split)
-	// We attribute everything to InputTokens — under-reports output
-	// but doesn't fabricate a split.
+	// Older codex: "tokens used: <total>" (no input/output split).
+	// We fold the total into InputTokens (so Total() math works)
+	// AND set TotalOnly so the formatter renders "Nk total" rather
+	// than the misleading "Nk in / 0 out" — the model produced
+	// output, we just don't know how much.
 	stdout := `[2026-05-04T12:00:00Z] tokens used: 18000
 [2026-05-04T12:00:00Z] done`
 	usage := parseCodexStdoutTokens(stdout)
 	if usage.InputTokens != 18000 {
-		t.Errorf("InputTokens = %d, want 18000 (legacy total)", usage.InputTokens)
+		t.Errorf("InputTokens = %d, want 18000 (legacy total folded here)", usage.InputTokens)
 	}
 	if usage.OutputTokens != 0 {
 		t.Errorf("OutputTokens = %d, want 0 (legacy can't attribute)", usage.OutputTokens)
+	}
+	if !usage.TotalOnly {
+		t.Errorf("TotalOnly = false, want true so formatter renders 'total' not 'in/out'")
+	}
+	if usage.Total() != 18000 {
+		t.Errorf("Total() = %d, want 18000 (sum should still work for aggregation)", usage.Total())
+	}
+}
+
+func TestParseCodexStdoutTokens_SplitShapeNotTotalOnly(t *testing.T) {
+	// Modern codex with split shape must NOT set TotalOnly — we
+	// have real input vs output numbers and the formatter should
+	// render "Nk in / Mk out" honestly.
+	stdout := "tokens: 100 input, 50 output"
+	usage := parseCodexStdoutTokens(stdout)
+	if usage.TotalOnly {
+		t.Errorf("split-shape codex output should not set TotalOnly: got %+v", usage)
 	}
 }
 
@@ -162,10 +184,10 @@ func TestTokenUsage_IsZero(t *testing.T) {
 		usage TokenUsage
 		want  bool
 	}{
-		{"both zero", TokenUsage{0, 0}, true},
-		{"input only", TokenUsage{100, 0}, false},
-		{"output only", TokenUsage{0, 100}, false},
-		{"both nonzero", TokenUsage{100, 200}, false},
+		{"both zero", TokenUsage{InputTokens: 0, OutputTokens: 0}, true},
+		{"input only", TokenUsage{InputTokens: 100, OutputTokens: 0}, false},
+		{"output only", TokenUsage{InputTokens: 0, OutputTokens: 100}, false},
+		{"both nonzero", TokenUsage{InputTokens: 100, OutputTokens: 200}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -2,10 +2,11 @@ package cli
 
 // TokenUsage captures how many tokens a single LLM call consumed.
 // Populated by each invoker from the vendor CLI's structured output
-// (claude/gemini JSON mode) or stdout metadata (codex). Zero values
-// mean "we couldn't determine usage from this call" — either the CLI
-// version doesn't support a structured-output flag, or its output
-// shape didn't match what we expected. Callers should treat
+// (claude/gemini JSON mode) or stdout metadata (codex).
+//
+// Zero values mean "we couldn't determine usage from this call" —
+// the CLI version may not support a structured-output flag, or its
+// output shape didn't match what we expected. Callers should treat
 // `usage.IsZero()` as "unknown" rather than "no tokens used."
 type TokenUsage struct {
 	// InputTokens is what the user paid for to send (prompt + diff +
@@ -19,6 +20,17 @@ type TokenUsage struct {
 	// for receiving. Anthropic: `output_tokens`. Google:
 	// `candidatesTokenCount`. OpenAI: `completion_tokens`.
 	OutputTokens int
+
+	// TotalOnly indicates the source CLI reported a single combined
+	// total without an input/output split. Codex's pre-v0.128
+	// stdout metadata is the canonical example ("tokens used: N").
+	// When set, the total is in InputTokens (we fold it there
+	// instead of inventing a 50/50 split) and display callers
+	// should render as "Nk total" rather than "Nk in / 0 out" —
+	// the latter would mislead users into thinking the model
+	// produced no output. Tools that aggregate across calls should
+	// still use Total() for the running sum.
+	TotalOnly bool
 }
 
 // IsZero reports whether neither token count was populated. The
@@ -31,7 +43,9 @@ func (u TokenUsage) IsZero() bool {
 }
 
 // Total is the sum of input + output, useful for closing-line
-// summaries that show overall consumption across all agents.
+// summaries that show overall consumption across all agents. For
+// TotalOnly usage, InputTokens already holds the full total so the
+// math still works — OutputTokens is 0 by definition there.
 func (u TokenUsage) Total() int {
 	return u.InputTokens + u.OutputTokens
 }

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -1,0 +1,37 @@
+package cli
+
+// TokenUsage captures how many tokens a single LLM call consumed.
+// Populated by each invoker from the vendor CLI's structured output
+// (claude/gemini JSON mode) or stdout metadata (codex). Zero values
+// mean "we couldn't determine usage from this call" — either the CLI
+// version doesn't support a structured-output flag, or its output
+// shape didn't match what we expected. Callers should treat
+// `usage.IsZero()` as "unknown" rather than "no tokens used."
+type TokenUsage struct {
+	// InputTokens is what the user paid for to send (prompt + diff +
+	// any system message wrapping). Anthropic calls this
+	// `input_tokens`; Google calls it `promptTokenCount`; OpenAI
+	// calls it `prompt_tokens`. We normalise to the same field name
+	// across vendors.
+	InputTokens int
+
+	// OutputTokens is what the model generated and the user paid
+	// for receiving. Anthropic: `output_tokens`. Google:
+	// `candidatesTokenCount`. OpenAI: `completion_tokens`.
+	OutputTokens int
+}
+
+// IsZero reports whether neither token count was populated. The
+// caller uses this to decide between "show '12.3k in / 4.5k out'"
+// and "omit the token suffix entirely" on the per-LLM completion
+// line — printing "0 in / 0 out" would mislead users into thinking
+// the call was free when actually we just didn't know.
+func (u TokenUsage) IsZero() bool {
+	return u.InputTokens == 0 && u.OutputTokens == 0
+}
+
+// Total is the sum of input + output, useful for closing-line
+// summaries that show overall consumption across all agents.
+func (u TokenUsage) Total() int {
+	return u.InputTokens + u.OutputTokens
+}

--- a/internal/multi/merger.go
+++ b/internal/multi/merger.go
@@ -55,26 +55,31 @@ type ReviewContent struct {
 }
 
 // Merge consolidates multiple reviews into one using an LLM.
-func (m *Merger) Merge(ctx context.Context, input MergeInput) (string, error) {
+//
+// Returns the merged markdown report, the merge step's own token
+// usage (for cost-attribution alongside per-LLM review usage), and
+// any error. Tokens may be zero when the merge LLM's CLI doesn't
+// surface usage data.
+func (m *Merger) Merge(ctx context.Context, input MergeInput) (string, cli.TokenUsage, error) {
 	// Render the template
 	var buf bytes.Buffer
 	if err := m.template.Execute(&buf, input); err != nil {
-		return "", fmt.Errorf("execute template: %w", err)
+		return "", cli.TokenUsage{}, fmt.Errorf("execute template: %w", err)
 	}
 
 	prompt := buf.String()
 
 	// Send to LLM for merging (use RunPrompt, not Review, to avoid double-wrapping)
-	merged, err := m.invoker.RunPrompt(ctx, prompt)
+	merged, tokens, err := m.invoker.RunPrompt(ctx, prompt)
 	if err != nil {
-		return "", fmt.Errorf("merge review: %w", err)
+		return "", cli.TokenUsage{}, fmt.Errorf("merge review: %w", err)
 	}
 
 	// Some merger LLMs ignore "Return ONLY the merged markdown report"
 	// and wrap their output in a ```markdown ... ``` fence. Without
 	// this strip, every multi-LLM run prints literal triple-backticks
 	// to the terminal AND saves them to disk in <commit>_merged.md.
-	return stripFenceWrapper(merged), nil
+	return stripFenceWrapper(merged), tokens, nil
 }
 
 // fenceOpener matches the leading ```markdown / ```md / bare ```

--- a/internal/multi/metadata.go
+++ b/internal/multi/metadata.go
@@ -25,6 +25,14 @@ type ReviewMeta struct {
 	FindingsCount int    `json:"findings_count,omitempty"`
 	OutputFile    string `json:"output_file,omitempty"`
 	Error         string `json:"error,omitempty"`
+	// InputTokens / OutputTokens come from the CLI's structured
+	// output (claude / gemini JSON, codex stdout metadata) when
+	// available. Both 0 means usage was indeterminate — typically
+	// because the user is on an older CLI version that doesn't
+	// surface token counts. omitempty keeps backward-compat for
+	// readers that don't know about these fields.
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
 }
 
 // MergeMeta holds details about the merge operation.
@@ -35,6 +43,11 @@ type MergeMeta struct {
 	DeduplicationRemoved int    `json:"deduplication_removed,omitempty"`
 	DurationMs           int64  `json:"duration_ms,omitempty"`
 	Error                string `json:"error,omitempty"`
+	// InputTokens / OutputTokens for the merge step's own LLM call,
+	// same shape and semantics as ReviewMeta. Sum with each
+	// ReviewMeta to get total per-PR token spend.
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
 }
 
 // Save writes the metadata to a JSON file.

--- a/internal/multi/metadata.go
+++ b/internal/multi/metadata.go
@@ -27,12 +27,18 @@ type ReviewMeta struct {
 	Error         string `json:"error,omitempty"`
 	// InputTokens / OutputTokens come from the CLI's structured
 	// output (claude / gemini JSON, codex stdout metadata) when
-	// available. Both 0 means usage was indeterminate — typically
-	// because the user is on an older CLI version that doesn't
-	// surface token counts. omitempty keeps backward-compat for
-	// readers that don't know about these fields.
+	// available. Both 0 means usage was indeterminate. omitempty
+	// keeps backward-compat for readers that don't know about
+	// these fields.
 	InputTokens  int `json:"input_tokens,omitempty"`
 	OutputTokens int `json:"output_tokens,omitempty"`
+	// TotalOnlyTokens=true means input/output split is unknown and
+	// InputTokens holds the combined total (codex pre-v0.128 stdout
+	// shape). Aggregation tools should still sum InputTokens +
+	// OutputTokens — the total is in InputTokens, OutputTokens is 0
+	// — but display-layer tools should show "Nk total" rather than
+	// "Nk in / 0 out".
+	TotalOnlyTokens bool `json:"total_only_tokens,omitempty"`
 }
 
 // MergeMeta holds details about the merge operation.
@@ -46,8 +52,9 @@ type MergeMeta struct {
 	// InputTokens / OutputTokens for the merge step's own LLM call,
 	// same shape and semantics as ReviewMeta. Sum with each
 	// ReviewMeta to get total per-PR token spend.
-	InputTokens  int `json:"input_tokens,omitempty"`
-	OutputTokens int `json:"output_tokens,omitempty"`
+	InputTokens     int  `json:"input_tokens,omitempty"`
+	OutputTokens    int  `json:"output_tokens,omitempty"`
+	TotalOnlyTokens bool `json:"total_only_tokens,omitempty"`
 }
 
 // Save writes the metadata to a JSON file.

--- a/internal/multi/orchestrator.go
+++ b/internal/multi/orchestrator.go
@@ -25,6 +25,13 @@ func NewOrchestrator(llms []cli.LLM, storage *ReviewStorage) *Orchestrator {
 }
 
 // ReviewResult holds the result of a single LLM review.
+//
+// Tokens is populated from the CLI's structured output (claude /
+// gemini JSON, codex stdout metadata) when available. Zero values
+// mean "we couldn't determine usage" — the CLI version may be too
+// old to support a JSON flag, or the output shape didn't match
+// what we expected. Display callers should check Tokens.IsZero()
+// rather than printing "0 in / 0 out" which would mislead users.
 type ReviewResult struct {
 	LLM      string
 	Version  string
@@ -33,6 +40,7 @@ type ReviewResult struct {
 	Error    error
 	Duration time.Duration
 	FilePath string
+	Tokens   cli.TokenUsage
 }
 
 // RunParallel executes reviews concurrently for all configured LLMs.
@@ -83,8 +91,9 @@ func (o *Orchestrator) RunParallel(ctx context.Context, systemPrompt, diff, comm
 			defer cancel()
 
 			// Run review
-			output, err := invoker.Review(reviewCtx, systemPrompt, diff)
+			output, tokens, err := invoker.Review(reviewCtx, systemPrompt, diff)
 			result.Duration = time.Since(start)
+			result.Tokens = tokens
 
 			if err != nil {
 				result.Error = err


### PR DESCRIPTION
## Summary

Surfaces input/output token counts per agent on the review's completion line, aggregates a run total, and persists per-agent + per-merge counts in \`<commit>_metadata.json\`.

## Why

Paid-tier users (codex API, claude paid) currently have zero per-PR cost insight — vendor dashboards lag by a day and have no PR-level attribution. A typical 3-agent branch review spends 15K-150K tokens; surfacing the numbers means users can:

- Reality-check unexpected vendor bills
- Compare cost-vs-value per agent
- Predict the cost of running locally vs. through CI

## User-visible

\`\`\`
[1/3] claude ✓ (51.5s) · 12.3k in / 4.5k out
[2/3] gemini ✓ (102.4s) · 15k in / 3k out
[3/3] codex ✓ (85.0s) · 14k in / 4k out

Per-LLM reviews → .local-review/reviews/feat-x/

Merging reviews...
✓ Merged review (16.0s)

✓ 3/3 LLMs produced output · total 2m51s · ~54k tokens
\`\`\`

When a CLI version is too old to surface usage, the token suffix is omitted entirely rather than misleading users with "0 in / 0 out".

## Implementation per CLI

| CLI | Mechanism |
|---|---|
| **claude** | \`--print --output-format json\`; parses \`usage.{input_tokens, output_tokens}\` from the documented Anthropic shape |
| **gemini** | \`-o json\`; tries two shapes seen in the wild — modern \`stats.models.<id>.tokens\` and Vertex-style \`usageMetadata.{promptTokenCount, candidatesTokenCount}\`. First match wins. |
| **codex** | No JSON flag exists. Reuses the existing stdout capture (already needed for ClassifyExit's stderr tail) and parses the session-summary metadata block via regex. Handles both modern split-counts (\`tokens: N input, M output\`) and legacy total-only (\`tokens used: N\`) shapes. |

All three fall back to raw text + zero usage on unknown shapes — older CLIs degrade to "no token info" rather than failing the review.

## Plumbing

- \`internal/cli/usage.go\` (new): \`TokenUsage\` struct + \`IsZero()\` / \`Total()\`
- \`internal/cli/parsers.go\` (new): per-vendor JSON / regex parsers
- \`Invoker.Review\` and \`Invoker.RunPrompt\` now return \`(output, cli.TokenUsage, error)\`
- \`ReviewResult.Tokens\` and \`MergeMeta.{InputTokens, OutputTokens}\` plumb the data through
- \`aggregateTokens\` / \`humanTokens\` / \`formatTokenSuffix\` helpers in runner.go for display

## Tests

- 15 new test cases in \`parsers_test.go\` covering happy paths + fallback paths for all three vendors
- Existing \`Invoker.Review\` tests updated to the new 3-return-value signature
- All existing v0.6.5 preflight tests still pass

## CHANGELOG correction

The CHANGELOG entry for the diff-too-large preflight (PR #46) was labelled v0.7.0 but actually shipped under the v0.6.5 tag (release workflow's bump-label logic used \`patch\`, not \`minor\`). Corrected in this PR. v0.7.0 stays reserved for the bundled "preflight + tokens + live progress" minor announcement — see \`do-not-merge/ROADMAP.md\`.

## Test plan

- [ ] CI green
- [ ] CodeQL passes
- [ ] CodeRabbit / Copilot reviews surface no blockers
- [ ] After merge: confirm token suffix appears on a real \`local-review review\` run (claude+gemini+codex)
- [ ] Confirm \`<commit>_metadata.json\` includes \`input_tokens\` / \`output_tokens\` per review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage reporting for multi-LLM reviews: per-agent input/output counts and aggregated totals; merge-step usage included.
  * Token usage persisted with review and merge metadata; CLI outputs degrade gracefully to "no token info" when unavailable.

* **Tests**
  * Added comprehensive parser and invoker unit tests to validate token extraction across vendor output formats.

* **Documentation**
  * Changelog updated with new 0.6.6 release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->