### PR TITLE
v0.6.7: stream per-LLM progress as agents finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-05-07
+
+### Added
+- **Live progress streaming for multi-LLM runs.** Per-agent completion lines now print as each agent finishes instead of all-at-once after the slowest one. Pre-fix, when one agent (commonly gemini-3.x-preview at 5+ min) dominated runtime, users saw the roster, then a blank terminal for minutes, then every result + the merge step + findings in a single burst — no way to tell whether the tool was working, hung, or stuck on a specific agent. Now:
+
+  ```
+  Reviewing feat/v0.6.7-live-progress (3016d29) with 3 LLMs...
+    • claude_claude-opus-4-7 (CLI v2.1.132) | timeout: 600s
+    • gemini_gemini-3.1-pro-preview (CLI v0.40.1) | timeout: 600s
+    • codex_gpt-5.3-codex (CLI v0.128.0) | timeout: 600s
+
+  codex ✓ (10.4s) · 14k in / 4k out         ← appears at t=10.4s
+  claude ✓ (51.5s) · 12.3k in / 4.5k out    ← appears at t=51.5s
+  gemini ✓ (287.1s) · 15k in / 3k out       ← appears at t=287.1s
+
+  Merging reviews...
+  ```
+
+  Emission order = completion order. The previous `[N/M]` numeric prefix was dropped because with streaming it would track "how many agents have finished" rather than roster position — visually the same but semantically different, and we'd rather drop the number than have it silently change meaning.
+
+### Internal
+- `Orchestrator.RunParallel` now returns `(<-chan ReviewResult, error)` instead of `([]ReviewResult, error)`. The channel is buffered to `len(llms)` so a slow consumer can't deadlock workers, and is closed after all per-agent goroutines finish so callers can `for r := range ch`. Per-agent failures still travel inside `ReviewResult.Error` (channel always emits one result per LLM, regardless of outcome). Added `Orchestrator.invokerFactory` (in-package test seam) so streaming behavior can be pinned with controlled-duration fakes — paid down a sliver of the parked `internal/multi/` test debt while we were here.
+
 ## [0.6.6] - 2026-05-07
 
 ### Added

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -1016,11 +1016,15 @@ func selectMergeLLM(results []multi.ReviewResult, available []cli.LLM, preferred
 			return &llm
 		}
 	}
-	for _, r := range results {
-		if multi.HasMergeableOutput(r) {
-			if llm, ok := eligible[r.LLM]; ok {
-				return &llm
-			}
+	// Final fallback: pick the first eligible agent in *roster* order,
+	// not results order. With v0.6.7 streaming, `results` is in
+	// completion order — iterating it for the fallback would make
+	// merge-LLM selection timing-dependent for custom-named agents
+	// (where the auto claude>codex>gemini chain doesn't match).
+	// Roster order (`available`) is deterministic across runs.
+	for _, llm := range available {
+		if l, ok := eligible[llm.Name]; ok {
+			return &l
 		}
 	}
 	return nil

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -242,6 +243,17 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 		}
 	}
 	fmt.Println()
+
+	// Sort results back to roster order before any downstream use.
+	// Display lines above already printed in completion order (the
+	// streaming UX); everything from here on (BuildMergeInput,
+	// buildMetadata, selectMergeLLM) is order-sensitive and must be
+	// deterministic across runs on identical input. Pre-fix, two
+	// identical `local-review review` runs could produce different
+	// merge prompts (reviewer #1 was "claude" in one run, "codex" in
+	// the next, depending on which finished first) — a regression
+	// from v0.6.6 that erodes trust without surfacing as an error.
+	results = sortByRoster(results, active)
 
 	// Surface the on-disk path so users know where to find raw
 	// per-LLM output — especially when one agent failed and they
@@ -980,6 +992,40 @@ func buildMetadata(commit, branch string, results []multi.ReviewResult, startTim
 		}
 	}
 	return meta
+}
+
+// sortByRoster returns results re-ordered to match the configured
+// roster order in `available`. Used after the streaming channel
+// drains to restore determinism for downstream consumers
+// (BuildMergeInput, buildMetadata, selectMergeLLM): identical runs
+// must produce identical merge prompts and metadata files
+// regardless of which agent happened to finish first.
+//
+// Stable: agents present in `results` but absent from `available`
+// (defensive — shouldn't happen in practice since active drives
+// both) keep their relative completion-order position at the end.
+func sortByRoster(results []multi.ReviewResult, available []cli.LLM) []multi.ReviewResult {
+	rank := make(map[string]int, len(available))
+	for i, llm := range available {
+		rank[llm.Name] = i
+	}
+	sorted := make([]multi.ReviewResult, len(results))
+	copy(sorted, results)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ri, oki := rank[sorted[i].LLM]
+		rj, okj := rank[sorted[j].LLM]
+		switch {
+		case oki && okj:
+			return ri < rj
+		case oki:
+			return true
+		case okj:
+			return false
+		default:
+			return false
+		}
+	})
+	return sorted
 }
 
 // selectMergeLLM picks which agent merges findings. Priority:

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -215,22 +215,30 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	storage := multi.NewStorage(cfg.Storage.BasePath)
 	orch := multi.NewOrchestrator(active, storage)
 
-	results, err := orch.RunParallel(ctx, systemPrompt, diffStr, commit, branch)
+	resultsCh, err := orch.RunParallel(ctx, systemPrompt, diffStr, commit, branch)
 	if err != nil {
 		return fmt.Errorf("run reviews: %w", err)
 	}
 
+	// Stream per-agent completion lines as each agent finishes. The
+	// channel closes after all agents report, so the loop also serves
+	// as the synchronisation point before merge. Emission order =
+	// completion order; we dropped the [N/M] numeric prefix so the
+	// non-roster order doesn't read as a bug. Lines look like:
+	//   claude ✓ (51.5s) · 12.3k in / 4.5k out
+	//   codex ✗ timeout — try `local-review commit HEAD` for ...
+	results := make([]multi.ReviewResult, 0, len(active))
 	anyFailed := false
-	for i, r := range results {
+	for r := range resultsCh {
+		results = append(results, r)
 		if r.Error != nil {
 			anyFailed = true
 			// r.Error is the invoker's ClassifyExit output — already
 			// has the actionable hint inline. No "review failed:"
-			// prefix or "(output: )" wrapping; "[N/M] agent ✗ <msg>"
-			// reads clean.
-			fmt.Printf("[%d/%d] %s ✗ %s%s\n", i+1, len(results), r.LLM, r.Error, formatTokenSuffix(r.Tokens))
+			// prefix or "(output: )" wrapping.
+			fmt.Printf("%s ✗ %s%s\n", r.LLM, r.Error, formatTokenSuffix(r.Tokens))
 		} else {
-			fmt.Printf("[%d/%d] %s ✓ (%.1fs)%s\n", i+1, len(results), r.LLM, r.Duration.Seconds(), formatTokenSuffix(r.Tokens))
+			fmt.Printf("%s ✓ (%.1fs)%s\n", r.LLM, r.Duration.Seconds(), formatTokenSuffix(r.Tokens))
 		}
 	}
 	fmt.Println()

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -696,3 +696,62 @@ func TestFormatTokenSuffix_BehaviorByShape(t *testing.T) {
 		})
 	}
 }
+
+func TestSortByRoster_RestoresDeterministicOrder(t *testing.T) {
+	// Pin the v0.6.7 determinism contract: streaming the channel
+	// produces results in completion order, but everything
+	// downstream (BuildMergeInput, buildMetadata, selectMergeLLM)
+	// must see roster order so two identical runs produce identical
+	// merge prompts. Pre-fix, the merge prompt's "Reviewer 1"
+	// could be claude in run A and codex in run B depending on
+	// which finished first — a regression from v0.6.6's deterministic
+	// shape that erodes trust without surfacing as an error.
+	roster := []cli.LLM{
+		{Name: "claude"},
+		{Name: "gemini"},
+		{Name: "codex"},
+	}
+	// Completion order: codex (fastest) → claude → gemini (slowest).
+	// Roster order should re-sort to claude, gemini, codex.
+	completionOrder := []multi.ReviewResult{
+		{LLM: "codex", Output: "c"},
+		{LLM: "claude", Output: "a"},
+		{LLM: "gemini", Output: "b"},
+	}
+	got := sortByRoster(completionOrder, roster)
+	want := []string{"claude", "gemini", "codex"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i, name := range want {
+		if got[i].LLM != name {
+			t.Errorf("got[%d].LLM = %s, want %s (full: %v)", i, got[i].LLM, name, got)
+		}
+	}
+}
+
+func TestSortByRoster_UnknownAgentSinksStable(t *testing.T) {
+	// Defensive: an agent in `results` but absent from `available`
+	// shouldn't happen in practice (active drives both) but if it
+	// ever does — say a future feature lets the orchestrator pick
+	// up an agent that wasn't in the roster — those entries land
+	// at the end in their original (completion) order rather than
+	// crashing or duplicating.
+	roster := []cli.LLM{
+		{Name: "claude"},
+		{Name: "codex"},
+	}
+	in := []multi.ReviewResult{
+		{LLM: "ghost", Output: "g1"},
+		{LLM: "codex", Output: "c"},
+		{LLM: "phantom", Output: "p"},
+		{LLM: "claude", Output: "a"},
+	}
+	got := sortByRoster(in, roster)
+	want := []string{"claude", "codex", "ghost", "phantom"}
+	for i, name := range want {
+		if got[i].LLM != name {
+			t.Errorf("got[%d].LLM = %s, want %s", i, got[i].LLM, name)
+		}
+	}
+}

--- a/internal/multi/orchestrator.go
+++ b/internal/multi/orchestrator.go
@@ -11,16 +11,25 @@ import (
 )
 
 // Orchestrator coordinates parallel reviews from multiple LLMs.
+//
+// invokerFactory is an in-package test seam. Production code uses
+// cli.NewInvoker; orchestrator_test.go swaps in fake invokers with
+// controlled durations so the streaming contract (channel emits in
+// completion order, closes after all done) can be pinned without
+// shelling out to real CLIs. Kept unexported to avoid leaking the
+// hook into the package's public API.
 type Orchestrator struct {
-	llms    []cli.LLM
-	storage *ReviewStorage
+	llms           []cli.LLM
+	storage        *ReviewStorage
+	invokerFactory func(cli.LLM) cli.Invoker
 }
 
 // NewOrchestrator creates a new Orchestrator with the given LLMs and storage.
 func NewOrchestrator(llms []cli.LLM, storage *ReviewStorage) *Orchestrator {
 	return &Orchestrator{
-		llms:    llms,
-		storage: storage,
+		llms:           llms,
+		storage:        storage,
+		invokerFactory: cli.NewInvoker,
 	}
 }
 
@@ -43,81 +52,98 @@ type ReviewResult struct {
 	Tokens   cli.TokenUsage
 }
 
-// RunParallel executes reviews concurrently for all configured LLMs.
-// Returns results for all LLMs (including failures).
+// RunParallel executes reviews concurrently for all configured LLMs
+// and returns a channel that emits each ReviewResult as its agent
+// finishes. The channel is closed after every agent has reported,
+// so callers can range over it. Buffered to len(llms) so a slow
+// consumer can't deadlock the workers.
+//
+// Streaming (added in v0.6.7) replaced the prior "block on wg.Wait,
+// return slice" shape because users with one slow agent (gemini-3.x
+// preview at 5+ min) saw a blank terminal for the whole run with
+// zero feedback. Now each per-LLM line prints as the agent
+// completes; the runner accumulates into a slice for the merge
+// step. Emission order = completion order, not roster order — the
+// CLI dropped the [N/M] prefix in favor of bare agent names so the
+// new ordering doesn't read as misleading numbering.
 //
 // systemPrompt is the language-specific prompt pack content the
 // caller has already loaded (lang.Dominant + prompts.Get). Passed to
 // every invoker so all agents review the diff against identical
 // review-rules and severity tiering. Empty string is allowed — each
 // invoker has a generic fallback.
-func (o *Orchestrator) RunParallel(ctx context.Context, systemPrompt, diff, commit, branch string) ([]ReviewResult, error) {
-	var wg sync.WaitGroup
-	results := make([]ReviewResult, len(o.llms))
+//
+// The error return is reserved for synchronous setup failures (none
+// today; always nil). Per-agent failures travel inside ReviewResult
+// .Error so the channel still reports them and the runner can
+// surface a per-LLM failure line in completion order.
+func (o *Orchestrator) RunParallel(ctx context.Context, systemPrompt, diff, commit, branch string) (<-chan ReviewResult, error) {
+	ch := make(chan ReviewResult, len(o.llms))
+	go func() {
+		defer close(ch)
+		var wg sync.WaitGroup
+		for _, llm := range o.llms {
+			wg.Add(1)
+			go func(l cli.LLM) {
+				defer wg.Done()
+				ch <- o.runOne(ctx, l, systemPrompt, diff, commit, branch)
+			}(llm)
+		}
+		wg.Wait()
+	}()
+	return ch, nil
+}
 
-	for i, llm := range o.llms {
-		wg.Add(1)
-		go func(idx int, l cli.LLM) {
-			defer wg.Done()
-
-			start := time.Now()
-			result := ReviewResult{
-				LLM:     l.Name,
-				Version: l.Version,
-				Mode:    "cli", // TODO: pass mode from invoker once API fallback is implemented
-			}
-
-			// Create invoker
-			invoker := cli.NewInvoker(l)
-			if invoker == nil {
-				result.Error = fmt.Errorf("failed to create invoker for %s", l.Name)
-				result.Duration = time.Since(start)
-				results[idx] = result
-				return
-			}
-
-			// Create context with timeout from config; falls back to
-			// cli.DefaultTimeoutSec — same constant the runner's
-			// applyConfig fallback and the roster's display fallback
-			// use, so what the user sees ("timeout: Ns") matches
-			// what actually fires. `<= 0` (rather than `== 0`)
-			// protects against a negative `timeout_seconds: -1`
-			// typo in user config.
-			timeout := time.Duration(l.TimeoutSec) * time.Second
-			if l.TimeoutSec <= 0 {
-				timeout = time.Duration(cli.DefaultTimeoutSec) * time.Second
-			}
-			reviewCtx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-
-			// Run review
-			output, tokens, err := invoker.Review(reviewCtx, systemPrompt, diff)
-			result.Duration = time.Since(start)
-			result.Tokens = tokens
-
-			if err != nil {
-				result.Error = err
-				results[idx] = result
-				return
-			}
-
-			result.Output = output
-
-			// Save to disk
-			path, err := o.storage.SaveReview(branch, commit, l.Name, l.Version, output)
-			if err != nil {
-				result.Error = fmt.Errorf("save review: %w", err)
-				results[idx] = result
-				return
-			}
-
-			result.FilePath = path
-			results[idx] = result
-		}(i, llm)
+// runOne executes a single LLM's review and returns the result.
+// Extracted from RunParallel's per-agent goroutine so the streaming
+// wrapper stays a one-liner — the original inline body had grown to
+// the point that the channel-send pattern was hard to see.
+func (o *Orchestrator) runOne(ctx context.Context, l cli.LLM, systemPrompt, diff, commit, branch string) ReviewResult {
+	start := time.Now()
+	result := ReviewResult{
+		LLM:     l.Name,
+		Version: l.Version,
+		Mode:    "cli", // TODO: pass mode from invoker once API fallback is implemented
 	}
 
-	wg.Wait()
-	return results, nil
+	invoker := o.invokerFactory(l)
+	if invoker == nil {
+		result.Error = fmt.Errorf("failed to create invoker for %s", l.Name)
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	// Per-agent timeout from config; falls back to cli.DefaultTimeoutSec
+	// — same constant the runner's applyConfig fallback and the roster's
+	// display fallback use, so what the user sees ("timeout: Ns") matches
+	// what actually fires. `<= 0` (rather than `== 0`) protects against
+	// a negative `timeout_seconds: -1` typo in user config.
+	timeout := time.Duration(l.TimeoutSec) * time.Second
+	if l.TimeoutSec <= 0 {
+		timeout = time.Duration(cli.DefaultTimeoutSec) * time.Second
+	}
+	reviewCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	output, tokens, err := invoker.Review(reviewCtx, systemPrompt, diff)
+	result.Duration = time.Since(start)
+	result.Tokens = tokens
+
+	if err != nil {
+		result.Error = err
+		return result
+	}
+
+	result.Output = output
+
+	path, err := o.storage.SaveReview(branch, commit, l.Name, l.Version, output)
+	if err != nil {
+		result.Error = fmt.Errorf("save review: %w", err)
+		return result
+	}
+
+	result.FilePath = path
+	return result
 }
 
 // CountSuccessful returns the number of successful reviews (Error == nil); for framing decisions prefer CountWithOutput.

--- a/internal/multi/orchestrator_test.go
+++ b/internal/multi/orchestrator_test.go
@@ -21,8 +21,15 @@ type fakeInvoker struct {
 }
 
 func (f *fakeInvoker) Review(ctx context.Context, _, _ string) (string, cli.TokenUsage, error) {
+	// time.NewTimer + Stop instead of time.After: if ctx wins the
+	// select, the unstoppable time.After timer would linger until
+	// expiry — harmless in production-shape code but flagged by
+	// review for test hygiene since fakes can be invoked in tight
+	// loops.
+	timer := time.NewTimer(f.delay)
+	defer timer.Stop()
 	select {
-	case <-time.After(f.delay):
+	case <-timer.C:
 		return f.output, f.tokens, f.err
 	case <-ctx.Done():
 		return "", cli.TokenUsage{}, ctx.Err()

--- a/internal/multi/orchestrator_test.go
+++ b/internal/multi/orchestrator_test.go
@@ -1,0 +1,155 @@
+package multi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mshykov/local-review/internal/cli"
+)
+
+// fakeInvoker pretends to be an LLM CLI for streaming tests. Sleeps
+// for `delay` then returns either canned output or an error. We use
+// it to drive the orchestrator's channel without shelling out to
+// real binaries (which would make tests slow, flaky, and dependent
+// on the CI host's PATH).
+type fakeInvoker struct {
+	delay  time.Duration
+	output string
+	err    error
+	tokens cli.TokenUsage
+}
+
+func (f *fakeInvoker) Review(ctx context.Context, _, _ string) (string, cli.TokenUsage, error) {
+	select {
+	case <-time.After(f.delay):
+		return f.output, f.tokens, f.err
+	case <-ctx.Done():
+		return "", cli.TokenUsage{}, ctx.Err()
+	}
+}
+
+func (f *fakeInvoker) RunPrompt(ctx context.Context, _ string) (string, cli.TokenUsage, error) {
+	return f.Review(ctx, "", "")
+}
+
+func TestRunParallel_StreamsCompletionOrder(t *testing.T) {
+	// Seed three agents with very different durations so completion
+	// order is deterministic: codex finishes first (10ms), claude
+	// second (50ms), gemini last (150ms). The roster order
+	// (claude, gemini, codex) deliberately differs so we know the
+	// channel is yielding in completion order, not roster order.
+	delays := map[string]time.Duration{
+		"claude": 50 * time.Millisecond,
+		"gemini": 150 * time.Millisecond,
+		"codex":  10 * time.Millisecond,
+	}
+	llms := []cli.LLM{
+		{Name: "claude", Path: "fake", Version: "test", TimeoutSec: 30},
+		{Name: "gemini", Path: "fake", Version: "test", TimeoutSec: 30},
+		{Name: "codex", Path: "fake", Version: "test", TimeoutSec: 30},
+	}
+	storage := NewStorage(t.TempDir())
+	orch := NewOrchestrator(llms, storage)
+	orch.invokerFactory = func(l cli.LLM) cli.Invoker {
+		return &fakeInvoker{delay: delays[l.Name], output: "## Major\n- a finding\n"}
+	}
+
+	ch, err := orch.RunParallel(context.Background(), "", "diff", "abc123", "main")
+	if err != nil {
+		t.Fatalf("RunParallel returned err: %v", err)
+	}
+
+	var order []string
+	for r := range ch {
+		order = append(order, r.LLM)
+		if r.Error != nil {
+			t.Errorf("agent %s failed: %v", r.LLM, r.Error)
+		}
+	}
+
+	want := []string{"codex", "claude", "gemini"}
+	if len(order) != len(want) {
+		t.Fatalf("got %d results, want %d", len(order), len(want))
+	}
+	for i, name := range want {
+		if order[i] != name {
+			t.Errorf("emission[%d] = %s, want %s (full order: %v)", i, order[i], name, order)
+		}
+	}
+}
+
+func TestRunParallel_ChannelClosesAfterAll(t *testing.T) {
+	// The streaming pattern only works if the channel reliably closes
+	// — otherwise `for r := range ch` in the runner hangs forever.
+	// Pin the close-after-wg.Wait contract: a five-agent run, all
+	// finish, range loop exits.
+	llms := make([]cli.LLM, 5)
+	for i := range llms {
+		llms[i] = cli.LLM{Name: "fake", Path: "fake", Version: "test", TimeoutSec: 30}
+	}
+	storage := NewStorage(t.TempDir())
+	orch := NewOrchestrator(llms, storage)
+	orch.invokerFactory = func(cli.LLM) cli.Invoker {
+		return &fakeInvoker{delay: time.Millisecond, output: "x"}
+	}
+
+	ch, err := orch.RunParallel(context.Background(), "", "diff", "abc", "main")
+	if err != nil {
+		t.Fatalf("RunParallel: %v", err)
+	}
+	count := 0
+	done := make(chan struct{})
+	go func() {
+		for range ch {
+			count++
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Channel closed cleanly.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("channel never closed; got %d results before timing out", count)
+	}
+	if count != 5 {
+		t.Errorf("got %d results, want 5", count)
+	}
+}
+
+func TestRunParallel_FastFailErrorsStillStream(t *testing.T) {
+	// A per-agent failure (invoker returns err, or save fails, or the
+	// invoker factory returns nil for an unknown name) must still
+	// emit on the channel — the runner relies on getting one
+	// ReviewResult per LLM regardless of outcome. Pre-streaming,
+	// failures lived in the result slice; with streaming a missing
+	// emission would silently shrink the agent count and make the
+	// "X/N produced output" line lie.
+	llms := []cli.LLM{
+		{Name: "claude", Path: "fake", Version: "test", TimeoutSec: 30},
+		{Name: "broken", Path: "fake", Version: "test", TimeoutSec: 30},
+	}
+	storage := NewStorage(t.TempDir())
+	orch := NewOrchestrator(llms, storage)
+	orch.invokerFactory = func(l cli.LLM) cli.Invoker {
+		if l.Name == "broken" {
+			return nil // simulates cli.NewInvoker on unknown name
+		}
+		return &fakeInvoker{delay: time.Millisecond, output: "ok"}
+	}
+
+	ch, _ := orch.RunParallel(context.Background(), "", "diff", "abc", "main")
+	results := make(map[string]ReviewResult)
+	for r := range ch {
+		results[r.LLM] = r
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d emissions, want 2", len(results))
+	}
+	if results["broken"].Error == nil {
+		t.Errorf("broken agent should have Error set")
+	}
+	if results["claude"].Error != nil {
+		t.Errorf("claude agent should have succeeded, got: %v", results["claude"].Error)
+	}
+}

--- a/internal/multi/orchestrator_test.go
+++ b/internal/multi/orchestrator_test.go
@@ -92,9 +92,20 @@ func TestRunParallel_StreamsCompletionOrder(t *testing.T) {
 			t.Fatalf("timed out waiting for %s emission", name)
 		}
 	}
-	// Channel should now be closed.
-	if _, ok := <-ch; ok {
-		t.Errorf("channel still has results after all agents released")
+	// Channel should now be closed. Use a timeout-bounded select
+	// instead of a bare `<-ch`: the orchestrator's outer goroutine
+	// closes the channel only after wg.Wait() returns, which races
+	// in microseconds with the last worker's wg.Done(). Normally
+	// imperceptible, but under heavy CI load a bare receive could
+	// hang briefly and turn this assertion into a flaky timeout.
+	// 2s matches the rest of this file's "test never hangs" budget.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Errorf("channel still has results after all agents released")
+		}
+	case <-time.After(2 * time.Second):
+		t.Errorf("channel never closed within 2s after all agents released")
 	}
 }
 

--- a/internal/multi/orchestrator_test.go
+++ b/internal/multi/orchestrator_test.go
@@ -2,34 +2,35 @@ package multi
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/mshykov/local-review/internal/cli"
 )
 
-// fakeInvoker pretends to be an LLM CLI for streaming tests. Sleeps
-// for `delay` then returns either canned output or an error. We use
-// it to drive the orchestrator's channel without shelling out to
-// real binaries (which would make tests slow, flaky, and dependent
-// on the CI host's PATH).
+// fakeInvoker pretends to be an LLM CLI for streaming tests. Blocks
+// on `release` (a per-agent gate channel the test owns) before
+// returning canned output, so the test drives completion order
+// deterministically — no sleep deltas to invert under CI scheduler
+// jitter. Real binaries would make tests slow, flaky, and dependent
+// on the CI host's PATH; this fake sidesteps all three.
+//
+// release == nil means "respond immediately" — convenient for the
+// fast-fail/close tests where order doesn't matter.
 type fakeInvoker struct {
-	delay  time.Duration
-	output string
-	err    error
-	tokens cli.TokenUsage
+	release <-chan struct{}
+	output  string
+	err     error
+	tokens  cli.TokenUsage
 }
 
 func (f *fakeInvoker) Review(ctx context.Context, _, _ string) (string, cli.TokenUsage, error) {
-	// time.NewTimer + Stop instead of time.After: if ctx wins the
-	// select, the unstoppable time.After timer would linger until
-	// expiry — harmless in production-shape code but flagged by
-	// review for test hygiene since fakes can be invoked in tight
-	// loops.
-	timer := time.NewTimer(f.delay)
-	defer timer.Stop()
+	if f.release == nil {
+		return f.output, f.tokens, f.err
+	}
 	select {
-	case <-timer.C:
+	case <-f.release:
 		return f.output, f.tokens, f.err
 	case <-ctx.Done():
 		return "", cli.TokenUsage{}, ctx.Err()
@@ -41,15 +42,17 @@ func (f *fakeInvoker) RunPrompt(ctx context.Context, _ string) (string, cli.Toke
 }
 
 func TestRunParallel_StreamsCompletionOrder(t *testing.T) {
-	// Seed three agents with very different durations so completion
-	// order is deterministic: codex finishes first (10ms), claude
-	// second (50ms), gemini last (150ms). The roster order
-	// (claude, gemini, codex) deliberately differs so we know the
-	// channel is yielding in completion order, not roster order.
-	delays := map[string]time.Duration{
-		"claude": 50 * time.Millisecond,
-		"gemini": 150 * time.Millisecond,
-		"codex":  10 * time.Millisecond,
+	// Drive completion order with explicit release gates instead of
+	// sleep deltas. Pre-fix used 10/50/150ms — small enough that a
+	// loaded CI runner's goroutine scheduler could invert the first
+	// two and make this test flaky. Now the test closes gates in
+	// the desired order: codex first, then claude, then gemini.
+	// Roster order (claude, gemini, codex) deliberately differs so
+	// we know the channel yields in completion order, not roster.
+	gates := map[string]chan struct{}{
+		"claude": make(chan struct{}),
+		"gemini": make(chan struct{}),
+		"codex":  make(chan struct{}),
 	}
 	llms := []cli.LLM{
 		{Name: "claude", Path: "fake", Version: "test", TimeoutSec: 30},
@@ -59,7 +62,7 @@ func TestRunParallel_StreamsCompletionOrder(t *testing.T) {
 	storage := NewStorage(t.TempDir())
 	orch := NewOrchestrator(llms, storage)
 	orch.invokerFactory = func(l cli.LLM) cli.Invoker {
-		return &fakeInvoker{delay: delays[l.Name], output: "## Major\n- a finding\n"}
+		return &fakeInvoker{release: gates[l.Name], output: "## Major\n- a finding\n"}
 	}
 
 	ch, err := orch.RunParallel(context.Background(), "", "diff", "abc123", "main")
@@ -67,22 +70,31 @@ func TestRunParallel_StreamsCompletionOrder(t *testing.T) {
 		t.Fatalf("RunParallel returned err: %v", err)
 	}
 
-	var order []string
-	for r := range ch {
-		order = append(order, r.LLM)
-		if r.Error != nil {
-			t.Errorf("agent %s failed: %v", r.LLM, r.Error)
-		}
-	}
-
+	// Release in desired completion order. We read each result
+	// immediately after releasing its gate so the next gate-close
+	// can't race ahead and let two agents finish "simultaneously"
+	// from the channel's perspective.
 	want := []string{"codex", "claude", "gemini"}
-	if len(order) != len(want) {
-		t.Fatalf("got %d results, want %d", len(order), len(want))
-	}
 	for i, name := range want {
-		if order[i] != name {
-			t.Errorf("emission[%d] = %s, want %s (full order: %v)", i, order[i], name, order)
+		close(gates[name])
+		select {
+		case r, ok := <-ch:
+			if !ok {
+				t.Fatalf("channel closed early at i=%d (want %s)", i, name)
+			}
+			if r.LLM != name {
+				t.Errorf("emission[%d] = %s, want %s", i, r.LLM, name)
+			}
+			if r.Error != nil {
+				t.Errorf("agent %s failed: %v", r.LLM, r.Error)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %s emission", name)
 		}
+	}
+	// Channel should now be closed.
+	if _, ok := <-ch; ok {
+		t.Errorf("channel still has results after all agents released")
 	}
 }
 
@@ -91,36 +103,60 @@ func TestRunParallel_ChannelClosesAfterAll(t *testing.T) {
 	// — otherwise `for r := range ch` in the runner hangs forever.
 	// Pin the close-after-wg.Wait contract: a five-agent run, all
 	// finish, range loop exits.
-	llms := make([]cli.LLM, 5)
+	//
+	// Pre-fix used 5 agents all named "fake" → all wrote to the same
+	// SaveReview path concurrently, racing on disk and masking errors
+	// (the test ignored r.Error). Now: unique names per agent + we
+	// fail the test on any per-agent error so a SaveReview regression
+	// would surface here instead of hiding behind a passing count.
+	const n = 5
+	llms := make([]cli.LLM, n)
 	for i := range llms {
-		llms[i] = cli.LLM{Name: "fake", Path: "fake", Version: "test", TimeoutSec: 30}
+		llms[i] = cli.LLM{Name: fmt.Sprintf("fake-%d", i), Path: "fake", Version: "test", TimeoutSec: 30}
 	}
 	storage := NewStorage(t.TempDir())
 	orch := NewOrchestrator(llms, storage)
 	orch.invokerFactory = func(cli.LLM) cli.Invoker {
-		return &fakeInvoker{delay: time.Millisecond, output: "x"}
+		return &fakeInvoker{output: "x"}
 	}
 
 	ch, err := orch.RunParallel(context.Background(), "", "diff", "abc", "main")
 	if err != nil {
 		t.Fatalf("RunParallel: %v", err)
 	}
-	count := 0
-	done := make(chan struct{})
-	go func() {
-		for range ch {
-			count++
-		}
-		close(done)
-	}()
-	select {
-	case <-done:
-		// Channel closed cleanly.
-	case <-time.After(2 * time.Second):
-		t.Fatalf("channel never closed; got %d results before timing out", count)
+
+	// Drain on a goroutine and report the final count via a channel
+	// so the main goroutine never reads `count` while the consumer
+	// is still writing it. Pre-fix had the consumer write `count`
+	// and the timeout arm read it; race-detector latent under the
+	// regression case (channel never closes) which is exactly when
+	// you don't want a second alarm masking the real bug.
+	type drain struct {
+		count   int
+		errs    []error
 	}
-	if count != 5 {
-		t.Errorf("got %d results, want 5", count)
+	doneCh := make(chan drain, 1)
+	go func() {
+		var d drain
+		for r := range ch {
+			d.count++
+			if r.Error != nil {
+				d.errs = append(d.errs, r.Error)
+			}
+		}
+		doneCh <- d
+	}()
+
+	select {
+	case d := <-doneCh:
+		if d.count != n {
+			t.Errorf("got %d results, want %d", d.count, n)
+		}
+		if len(d.errs) > 0 {
+			t.Errorf("per-agent errors (test storage path race?): %v", d.errs)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("channel never closed within 2s")
 	}
 }
 
@@ -142,7 +178,7 @@ func TestRunParallel_FastFailErrorsStillStream(t *testing.T) {
 		if l.Name == "broken" {
 			return nil // simulates cli.NewInvoker on unknown name
 		}
-		return &fakeInvoker{delay: time.Millisecond, output: "ok"}
+		return &fakeInvoker{output: "ok"}
 	}
 
 	ch, _ := orch.RunParallel(context.Background(), "", "diff", "abc", "main")


### PR DESCRIPTION
## Summary

- **Streaming per-agent completion lines.** `Orchestrator.RunParallel` now returns `(<-chan ReviewResult, error)` instead of `([]ReviewResult, error)`. Each per-LLM line prints as the agent finishes — no more 5-min blank terminal while gemini grinds.
- **Format change**: dropped the `[N/M]` numeric prefix. With streaming, the number would track "how many have finished" rather than roster position; rather than silently change semantics, we ship the bare agent name.
- **Coverage debt**: added `internal/multi/orchestrator_test.go` with three streaming-contract tests (completion-order emission, channel-close after wg.Wait, fast-fail still emits). Pays down a sliver of the parked `internal/multi/` test debt.

## What it looks like

```
Reviewing feat/v0.6.7-live-progress (3016d29) with 3 LLMs...
  • claude_claude-opus-4-7 (CLI v2.1.132) | timeout: 600s
  • gemini_gemini-3.1-pro-preview (CLI v0.40.1) | timeout: 600s
  • codex_gpt-5.3-codex (CLI v0.128.0) | timeout: 600s

codex ✓ (10.4s) · 14k in / 4k out         ← appears at t=10.4s
claude ✓ (51.5s) · 12.3k in / 4.5k out    ← appears at t=51.5s
gemini ✓ (287.1s) · 15k in / 3k out       ← appears at t=287.1s
```

## Self-review (dogfood pass)

Ran `./local-review review main` against `aa789e4`. Codex caught one real bug + one test-hygiene warning, both fixed in `b8d6178`:

1. **`selectMergeLLM` fallback was nondeterministic.** With v0.6.7 streaming, `results` is in completion order; iterating it for the final merge-LLM fallback (when no `--merge-with`, no `merge.preferred_llm`, and no claude/codex/gemini match) made selection timing-dependent for custom-named agents. Fix: iterate `available` (roster order) instead.
2. **`fakeInvoker.Review` used `time.After` in a cancelable select.** Replaced with `NewTimer + Stop`. Test-hygiene only.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...` — all green, including the three new streaming tests
- [x] `./local-review review main` self-review passed (single-source codex due to claude binary path issue locally; codex's findings addressed)
- [ ] Wait for CI: test, CodeQL ×2, CodeRabbit
- [ ] Manual: confirm the live-progress visual in a multi-agent run on someone else's machine before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live progress streaming for multi-LLM runs, displaying results as they complete.

* **Improvements**
  * Per-agent completion lines now printed in completion order rather than roster order.
  * Removed numeric roster prefixes from output for cleaner formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->