### PR TITLE
Release v0.7.0: smarter, more visible reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-07
+
+**Theme: smarter, more visible reviews.**
+
+This minor bundles three features that, together, move multi-LLM runs from "black box that prints a report" to "tool that tells you what's about to happen, what's happening, and what each agent cost." Each feature shipped as a v0.6.x patch over the past two days; v0.7.0 frames them as one coherent narrative with a release announcement.
+
+### Bundled patch releases
+
+- **Diff-too-large preflight** *(v0.6.5, see entry below)* — agents whose context window can't fit the prompt + diff are skipped *before* the run starts, with a one-line hint on how to scope smaller. No more 5-minute fan-outs that fail with N opaque errors on squash-merged release branches or vendored-blob diffs.
+- **Per-LLM token visibility** *(v0.6.6, see entry below)* — every completion line shows what that agent consumed (`· 12.3k in / 4.5k out`); the closing line aggregates the run total. Same data persists in `<commit>_metadata.json` so paid-tier users can attribute spend per PR without round-tripping the vendor dashboard.
+- **Live progress streaming** *(v0.6.7, see entry below)* — per-agent lines print as each agent finishes, not all-at-once after the slowest one. A 5-min gemini run no longer looks like a hung terminal. Dropped the `[N/M]` numeric prefix from the per-LLM line — with streaming, the number would track "how many have finished" rather than roster position.
+
+### Fixed
+
+- **Timeout-error hint pointed at a non-existent config field.** When an agent timed out, the failure message read `... raise llms.<agent>.timeout_sec in .local-review.yml` — but the actual YAML key is `timeout_seconds`. Pasting the suggested fix into a config left it untouched. Hint and `classify_test.go` now reference `timeout_seconds`. Discovered during the v0.7 doc audit (`internal/cli/classify.go`).
+- **`README.md` "Codex disabled by default" landing-page claim was wrong.** Codex's `Enabled` field is `nil` (= "run if active") in `Defaults()` — same posture as claude and gemini. Landing page now reads "Enabled when authenticated."
+
+### Docs
+
+- **Doc audit pass for v0.7.0 release**: `SECURITY.md` support matrix bumped (0.7.x active, 0.6.x exception-only); `CLAUDE.md` `metadata.json` example now includes the v0.6.6 token fields (`input_tokens`, `output_tokens`, `total_only_tokens`); `README.md` adds a "What's new in v0.7" callout and corrects the "structured-JSON multi-LLM is on the v0.7 roadmap" claim (now post-v0.7); cosign-signing roadmap reference in the v0.6.0 entry corrected for the same reason.
+
 ## [0.6.7] - 2026-05-07
 
 ### Added
@@ -112,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Multi-LLM honors `review.include` / `review.exclude` globs.** Previously the multi path bypassed the filter entirely and reviewed files the user had told it to skip.
 - **`local-review review` (already in v0.5) gains `--only` strictness**: when `--only` matches no ready agents (typo, unauthed agent), the run errors out instead of silently falling back to the configured `provider:` — that fallback would have sent the diff to a different vendor than the one named, a privacy / cost footgun.
 - **Multi-LLM blocking gate has two independent signals**: the merged report AND each per-LLM Output (full, before merger truncation). Defends against a verbose reviewer pushing a Critical finding past the 8 KB merger-input cap.
-- **`install.sh` verifies SHA-256 checksums** of release tarballs. Each release now ships a `checksums.txt` manifest; the installer downloads it alongside the tarball and verifies before extracting. Defends against accidental corruption and basic CDN/MITM tampering. Cosign signing is on the v0.7 roadmap for compromised-release-key defense.
+- **`install.sh` verifies SHA-256 checksums** of release tarballs. Each release now ships a `checksums.txt` manifest; the installer downloads it alongside the tarball and verifies before extracting. Defends against accidental corruption and basic CDN/MITM tampering. Cosign signing is on the post-v0.7 roadmap for compromised-release-key defense (originally targeted v0.7; deferred — v0.7.0 ships without it).
 
 ### Changed
 - **`ParseSeverity` defaults to `major` for unknown values** (was `warning`). LLM typos (`"criticl"`, `"sev-high"`, `"BLOCKER"`) used to silently demote out of the blocking range, hiding real findings from the pre-commit hook. Now: unknown → fail-closed at major. **Heads-up:** previously-passing reviews where the LLM emitted a typo'd severity may now block; rerun with the typo corrected, or treat the new failure as the gate working correctly.
@@ -132,7 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ollama "no API key" path works.** When `base_url` points at localhost / 127.x / ::1, the empty-key check is skipped — required for the documented fully-offline workflow.
 - **Globs compile once, not per file.** Pre-fix `matchGlob` re-compiled the regex inside the per-file loop; a 500-file diff with 5 globs cost 2,500 compiles. Plus: `**/dist/**` now correctly anchors to a path-segment boundary (was matching `src/mydist/file`), and bracket character classes (`[0-9]`, `[!a-z]`) actually work.
 - **Fail-closed on all-invalid include globs.** Previously `include: ["[!]"]` (and other compile-error patterns) silently *expanded* the review to every file because the empty `includeRE` was treated as "no include filter".
-- **`Authorization` / `--json` / `--min-severity` / `--max-findings` ignored in multi-LLM** — README now states this explicitly instead of "passes them through with a warning". Multi-LLM emits a stderr warning when those flags are set but otherwise drops them; the structured-JSON multi-LLM mode is on the v0.7 roadmap.
+- **`Authorization` / `--json` / `--min-severity` / `--max-findings` ignored in multi-LLM** — README now states this explicitly instead of "passes them through with a warning". Multi-LLM emits a stderr warning when those flags are set but otherwise drops them; the structured-JSON multi-LLM mode is on the post-v0.7 roadmap (deferred from v0.7.0; unparking when the third user asks).
 - **`mergeAndPrint` truncates per-review output to 8 KB** before feeding the merger, defending against verbose reviewers blowing the merger's context window. Independent gate signal scans the full per-LLM Output to catch findings past the cutoff.
 - **Git refs are validated** — `--`-prefixed refs (e.g. `local-review commit -c`) and refs with NUL/newline are rejected to defend against `git` flag-injection.
 - **Output write errors propagate** — `WriteText` and `configCmd` no longer silently exit 0 on broken pipe / disk full.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This minor bundles three features that, together, move multi-LLM runs from "blac
 ### Fixed
 
 - **Timeout-error hint pointed at a non-existent config field.** When an agent timed out, the failure message read `... raise llms.<agent>.timeout_sec in .local-review.yml` — but the actual YAML key is `timeout_seconds`. Pasting the suggested fix into a config left it untouched. Hint and `classify_test.go` now reference `timeout_seconds`. Discovered during the v0.7 doc audit (`internal/cli/classify.go`).
-- **`README.md` "Codex disabled by default" landing-page claim was wrong.** Codex's `Enabled` field is `nil` (= "run if active") in `Defaults()` — same posture as claude and gemini. Landing page now reads "Enabled when authenticated."
+- **Landing page (`docs/index.html`) "Codex disabled by default" claim was wrong.** Codex's `Enabled` field is `nil` (= "run if active") in `Defaults()` — same posture as claude and gemini. Landing page now reads "Enabled when authenticated."
 
 ### Docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ npm install -g @anthropic-ai/claude-code
     },
     {
       "llm": "codex",
-      "version": "0.128",
+      "version": "0.120",
       "mode": "cli",
       "status": "success",
       "duration_ms": 9800,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,18 @@ npm install -g @anthropic-ai/claude-code
       "mode": "cli",
       "status": "success",
       "duration_ms": 4500,
-      "findings_count": 12
+      "findings_count": 12,
+      "input_tokens": 12300,
+      "output_tokens": 4500
+    },
+    {
+      "llm": "codex",
+      "version": "0.128",
+      "mode": "cli",
+      "status": "success",
+      "duration_ms": 9800,
+      "input_tokens": 18000,
+      "total_only_tokens": true
     },
     {
       "llm": "gemini",
@@ -258,10 +269,18 @@ npm install -g @anthropic-ai/claude-code
   "merge": {
     "llm": "claude",
     "status": "success",
-    "final_findings_count": 8
+    "final_findings_count": 8,
+    "input_tokens": 8500,
+    "output_tokens": 2100
   }
 }
 ```
+
+Token fields shipped in v0.6.6. `input_tokens`/`output_tokens` are
+omitempty — absent on runs where the CLI version didn't surface
+usage. `total_only_tokens: true` (codex pre-v0.128) means
+`input_tokens` holds the combined total and the split is unknown;
+display layers should render "Nk total" rather than "Nk in / 0 out".
 
 ## Single-LLM Fallback Path
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 
 > 📋 **Looking for the human-readable code review checklist this tool implements?** See [**CHECKLIST.md**](CHECKLIST.md) — OWASP 2025-aligned, with severity tiers and concrete measurables. Use it for human reviews, or run `local-review review` to get an LLM pass against the same rules.
 
+> ✨ **New in v0.7** — *Smarter, more visible reviews.* Three changes you'll notice on your first run after upgrading:
+>
+> - **Diff-too-large preflight.** Agents whose context window can't fit the prompt + diff are skipped *before* the run starts, with a one-line hint on how to scope smaller. No more 5-minute fan-outs that fail with N opaque errors.
+> - **Per-LLM token visibility.** Each completion line shows what that agent consumed (`· 12.3k in / 4.5k out`); the closing line aggregates the run total. Same data persists in `<commit>_metadata.json` so paid-tier users can attribute spend per PR.
+> - **Live progress streaming.** Per-agent lines print as each agent finishes — no more blank terminal while the slow one grinds. See [CHANGELOG](CHANGELOG.md#070---2026-05-07) for the full notes.
+
 ---
 
 ## What it is, what it isn't
@@ -118,7 +124,7 @@ local-review review --merge-with claude
 **How it works:**
 1. Detects installed LLM CLIs and which are authenticated (`local-review doctor`)
 2. Runs every authenticated CLI in parallel
-3. Saves each review to `.local-review/reviews/<branch>/<commit>_<llm>.md`
+3. Saves each review to `.local-review/reviews/<branch>/<commit>_<llm>_<version>.md`
 4. Merges findings (dedup, consensus tagging) into one report
 5. Prints the merged report to stdout (also saved as `<commit>_merged.md`)
 
@@ -229,7 +235,7 @@ Common flags:
 | `--max-findings <n>` | Cap output (single-LLM fallback only) |
 | `--json` | Emit JSON (single-LLM fallback only — see below) |
 
-In multi-LLM mode the merger returns markdown, not structured findings, so `--json`, `--min-severity`, and `--max-findings` are **ignored**: they only take effect in the single-LLM fallback path (when no LLM CLI is authenticated and we hit the configured `provider:` directly). Multi-LLM emits a stderr warning when those flags are passed so you know they had no effect. A structured-JSON multi-LLM output mode (where the merger emits both markdown and a JSON envelope) is on the v0.7 roadmap.
+In multi-LLM mode the merger returns markdown, not structured findings, so `--json`, `--min-severity`, and `--max-findings` are **ignored**: they only take effect in the single-LLM fallback path (when no LLM CLI is authenticated and we hit the configured `provider:` directly). Multi-LLM emits a stderr warning when those flags are passed so you know they had no effect. A structured-JSON multi-LLM output mode (where the merger emits both markdown and a JSON envelope) is on the post-v0.7 roadmap — no fixed date; we'll unpark it when the third user asks for it.
 
 Config wins by default; flags override config at runtime (e.g., `--only codex` runs codex even if your config sets `codex.enabled: false`).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,17 +4,17 @@
 
 | Version | Supported                            |
 | ------- | ------------------------------------ |
-| 0.6.x   | ✅ active line — fixes shipped        |
-| 0.5.x   | ⚠️ exception-only — see policy below |
-| < 0.5   | ❌ unsupported                        |
+| 0.7.x   | ✅ active line — fixes shipped        |
+| 0.6.x   | ⚠️ exception-only — see policy below |
+| < 0.6   | ❌ unsupported                        |
 
-**Active line (0.6.x):** every reported vulnerability gets a fix in a
+**Active line (0.7.x):** every reported vulnerability gets a fix in a
 patch release; the "Security Update Process" below applies as written.
 
-**Exception-only (0.5.x):** a fix is *not* guaranteed. The maintainer
+**Exception-only (0.6.x):** a fix is *not* guaranteed. The maintainer
 may backport at their discretion when the impact is severe (remote
 code execution, credential disclosure, supply-chain compromise) AND
-the patch is small. Anything else: upgrade to 0.6.x.
+the patch is small. Anything else: upgrade to 0.7.x.
 
 **Unsupported:** report against the last active line. We won't
 investigate or patch.

--- a/docs/index.html
+++ b/docs/index.html
@@ -846,7 +846,7 @@
           <h3>Codex</h3>
           <p>ChatGPT Plus or OpenAI API key</p>
           <span class="badge badge-paid">$ OpenAI</span>
-          <p style="margin-top: 10px; font-size: 0.9em; color: #666;">Disabled by default</p>
+          <p style="margin-top: 10px; font-size: 0.9em; color: #666;">Enabled when authenticated</p>
           <p style="margin-top: 8px; font-size: 0.75em; color: #888; font-style: italic;">
             You pay OpenAI. <strong>local-review</strong> is 100% free.
           </p>

--- a/internal/cli/classify.go
+++ b/internal/cli/classify.go
@@ -28,14 +28,17 @@ const stderrTailMaxLen = 300
 // reliably triggered "delete the tool" frustration.
 //
 // agent is the LLM name ("claude", "gemini", "codex") — embedded into
-// hints that reference per-agent config (e.g. `llms.<agent>.timeout_sec`).
+// hints that reference per-agent config (e.g. `llms.<agent>.timeout_seconds`).
+// The YAML key is `timeout_seconds` (see internal/config/config.go LLMConfig
+// struct tag). A previous version of this hint said `timeout_sec` — wrong,
+// and would silently leave the user's config untouched if they pasted it.
 func ClassifyExit(ctx context.Context, err error, combinedOutput []byte, agent string) string {
 	// Context state is the most reliable signal: when the parent
 	// context expired or was cancelled, the child's exec error is
 	// often a generic "signal: killed" with no other distinguishing
 	// info, but ctx.Err() has already settled to the right reason.
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return fmt.Sprintf("timeout — try `local-review commit HEAD` for a smaller diff, or raise llms.%s.timeout_sec in .local-review.yml", agent)
+		return fmt.Sprintf("timeout — try `local-review commit HEAD` for a smaller diff, or raise llms.%s.timeout_seconds in .local-review.yml", agent)
 	}
 	if errors.Is(ctx.Err(), context.Canceled) {
 		return "cancelled"

--- a/internal/cli/classify_test.go
+++ b/internal/cli/classify_test.go
@@ -17,8 +17,11 @@ func TestClassifyExit_ContextDeadlineExceeded(t *testing.T) {
 	if !strings.Contains(got, "timeout") {
 		t.Errorf("want classification to mention 'timeout', got: %q", got)
 	}
-	if !strings.Contains(got, "llms.claude.timeout_sec") {
-		t.Errorf("want hint to reference per-agent timeout_sec config, got: %q", got)
+	// The YAML key is `timeout_seconds` (see internal/config/config.go);
+	// pin the exact substring so a future drift breaks the test instead
+	// of shipping a hint that points at a non-existent config field.
+	if !strings.Contains(got, "llms.claude.timeout_seconds") {
+		t.Errorf("want hint to reference per-agent timeout_seconds config, got: %q", got)
 	}
 	if !strings.Contains(got, "smaller diff") {
 		t.Errorf("want hint to suggest smaller diff, got: %q", got)


### PR DESCRIPTION
## Summary

v0.7.0 bundles the three v0.6.5–v0.6.7 features under one minor release + announcement narrative.

**Theme:** *Smarter, more visible reviews.*

| Feature | What it does |
|---|---|
| **Diff-too-large preflight** (v0.6.5) | Skips agents whose context window can't fit the prompt + diff *before* the run starts |
| **Per-LLM token visibility** (v0.6.6) | Each completion line shows `· 12.3k in / 4.5k out`; closing line aggregates the run total; persisted in `<commit>_metadata.json` |
| **Live progress streaming** (v0.6.7) | Per-agent lines print as each agent finishes (no more 5-min blank terminal); dropped the `[N/M]` numeric prefix |

This PR is **docs + small drift fixes** only — no new feature code. The features themselves shipped as v0.6.5/6/7 patches over the past two days.

## Doc audit findings (uncovered while preparing the release)

Two LLM agents audited every `.md` and `.html` file line-by-line. Real issues found and fixed in this PR:

- **`internal/cli/classify.go`** — timeout error hint pointed at `llms.<agent>.timeout_sec`, but the real YAML key is `timeout_seconds`. Pasting the suggested fix would have left the user's config untouched. Hint + test pin updated.
- **`docs/index.html`** — landing-page card said "Codex disabled by default." Wrong: Codex's `Enabled` field is `nil` (= "run if active") in `Defaults()`. Now reads "Enabled when authenticated."
- **`SECURITY.md`** — support matrix bumped (0.7.x active, 0.6.x exception-only).
- **`README.md`** — "structured-JSON multi-LLM is on the v0.7 roadmap" → corrected to "post-v0.7" (deferred); storage-path example was missing the version segment in the filename.
- **`CLAUDE.md`** — `metadata.json` example missed the v0.6.6 token fields (`input_tokens`, `output_tokens`, `total_only_tokens`); future AI coding sessions would have regenerated metadata without them.
- **`CHANGELOG.md`** — v0.6.0 + v0.5.x entries that pointed at "v0.7 roadmap" features (cosign signing, structured-JSON multi-LLM) corrected to "post-v0.7" since v0.7.0 ships without them.

Also added: a "✨ New in v0.7" callout near the top of the README, and the v0.7.0 framing entry in CHANGELOG.

## Self-review (dogfood pass)

Ran `./local-review review main` on `9429dcf`. Both active agents (claude + codex) returned **APPROVE with 0 findings**. The streaming worked as expected — codex appeared at t=9.3s, claude at t=42.2s (completion order, not roster order, confirming v0.6.7 is wired through). Saved to `.local-review/reviews/release-v0.7.0/9429dcf_merged.md`.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...` — all green
- [x] `./local-review version` + `./local-review doctor` smoke pass
- [x] `./local-review review main` dogfood — APPROVE, 0 findings
- [ ] CI green: test, CodeQL ×2, CodeQL aggregate, CodeRabbit
- [ ] After merge: tag `v0.7.0` auto-created by release workflow; verify binary download + brew tap update

## Release labels (required for the workflow to fire)

- `release` — triggers the release pipeline
- `minor` — bumps v0.6.7 → v0.7.0 (without this, the workflow defaults to `patch` and we'd ship as v0.6.8 — not what we want)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timeout configuration key hint in error messages
  * Fixed Codex enablement documentation to clarify authentication requirement

* **Documentation**
  * Updated release notes and user documentation for v0.7.0
  * Updated security support policy to reflect v0.7.x as active line
  * Enhanced token usage documentation with per-LLM consumption details and metadata fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->