### PR TITLE
ci(release): retry PR lookup to absorb GitHub API indexing lag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,15 @@ jobs:
     outputs:
       should_release: ${{ steps.gate.outputs.should_release }}
       version: ${{ steps.bump.outputs.version }}
+      # pr_number is exported so downstream steps in this job and
+      # in later jobs can reuse the gate's already-resolved value
+      # instead of re-querying /commits/<sha>/pulls. CodeRabbit
+      # caught the second lookup in `Determine version` racing
+      # against the same indexing-lag window the gate retries
+      # past — a fresh empty-result there would silently downgrade
+      # a `minor` release to `patch` because label detection
+      # would see an empty label set.
+      pr_number: ${{ steps.gate.outputs.pr_number }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -123,6 +132,9 @@ jobs:
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Export pr_number so downstream steps and jobs reuse this
+          # already-resolved value instead of re-querying the API.
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
           labels=$(gh pr view "$pr_number" --json labels --jq '.labels[].name' || echo "")
           if echo "$labels" | grep -qxF "release"; then
@@ -139,8 +151,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           MANUAL_VERSION: ${{ inputs.version }}
-          COMMIT_SHA: ${{ github.sha }}
-          REPO: ${{ github.repository }}
+          # Reuse the gate's already-resolved pr_number rather than
+          # hitting /commits/<sha>/pulls again. Two reasons:
+          #   1. Correctness — the second lookup races against the
+          #      same indexing-lag window the gate retries past.
+          #      Pre-fix, an empty result here silently downgraded
+          #      a `minor` release to `patch` because label
+          #      detection saw an empty label set. CodeRabbit
+          #      caught this on PR #61 review.
+          #   2. Avoids a redundant API call that's already paid
+          #      its consistency-tax up in the gate.
+          PR_NUMBER: ${{ steps.gate.outputs.pr_number }}
         run: |
           if [ -n "$MANUAL_VERSION" ]; then
             echo "version=$MANUAL_VERSION" >> "$GITHUB_OUTPUT"
@@ -151,9 +172,7 @@ jobs:
           version="${latest_tag#v}"
           IFS='.' read -r major minor patch <<< "$version"
 
-          pr_number=$(gh api "/repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
-            --jq '.[0].number' 2>/dev/null || echo "")
-          labels=$(gh pr view "$pr_number" --json labels --jq '.labels[].name' || echo "")
+          labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' || echo "")
 
           # Bump labels follow strict semver — see docs/RELEASE_PROCESS.md
           # "Label cheat sheet" for when each is appropriate. Quick reminder:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,38 @@ jobs:
           # Look up the PR via the GitHub API using the commit SHA. This works
           # for all merge strategies (squash, merge commit, rebase) — unlike
           # parsing the commit subject which only works for merge commits.
-          pr_number=$(gh api "/repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
-            --jq '.[0].number' 2>/dev/null || echo "")
-          if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
-            echo "No PR found for commit ${COMMIT_SHA} — skipping release"
+          #
+          # Retry with exponential backoff: GitHub's
+          # /commits/<sha>/pulls endpoint has a few-seconds indexing
+          # lag after a merge. The release workflow typically fires
+          # within ~5–10s of the merge event, hitting that window.
+          # Real example (v0.8.0 / PR #60): workflow ran 7s after
+          # merge, the lookup returned empty, the gate skipped
+          # release, and the maintainer had to fall back to manual
+          # workflow_dispatch.
+          #
+          # Total retry budget: ~75s (5 attempts at 0s, 5s, 10s,
+          # 20s, 40s). Plenty for a release workflow whose own
+          # build job costs minutes; cheap insurance against a
+          # silent skip.
+          pr_number=""
+          for delay in 0 5 10 20 40; do
+            if [ "$delay" -gt 0 ]; then
+              echo "PR lookup empty — retrying in ${delay}s (API consistency lag)"
+              sleep "$delay"
+            fi
+            pr_number=$(gh api "/repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
+              --jq '.[0].number' 2>/dev/null || echo "")
+            if [ -n "$pr_number" ] && [ "$pr_number" != "null" ]; then
+              break
+            fi
+            pr_number=""
+          done
+          if [ -z "$pr_number" ]; then
+            echo "No PR found for commit ${COMMIT_SHA} after retries — skipping release"
+            echo "(If this was a release-labeled merge, GitHub's commit-to-PR index"
+            echo " may be unusually slow today. Re-run the workflow, or use"
+            echo " workflow_dispatch with an explicit version to ship now.)"
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Why

`v0.8.0` (PR #60) didn't auto-release. The workflow ran but the gate logged **"No PR found for commit 3532c5e... — skipping release"** and exited cleanly. Diagnosed: the gate's `gh api /commits/<sha>/pulls` call ran **7 seconds after merge**, faster than GitHub's commit-to-PR index updated. Same lookup right now returns the PR correctly.

The gate behaved correctly (defaulting to "skip" beats "release on a mystery commit"), but a `success` exit on a skip gave no alert. Maintainer had to fall back to manual `workflow_dispatch` to ship v0.8.0.

## What

Retry the PR lookup with exponential backoff before giving up:

- 5 attempts: 0s, 5s, 10s, 20s, 40s — cumulative budget ~75s.
- Cheap relative to the build matrix (multi-platform Go cross-compile, minutes).
- Manual `workflow_dispatch` path is unaffected — it short-circuits the lookup.
- Skip message expanded to mention both recovery paths (re-run vs `workflow_dispatch`) so a future maintainer hitting the same window doesn't have to dig through workflow source.

## Test plan

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Standalone `bash -n` of the new retry block
- [ ] CI: `Analyze (actions)` workflow re-validates the YAML
- [ ] First merge after this lands exercises the new path on a normal release. (Or: trigger an irrelevant push to main to verify the retry doesn't break the "really no PR" case — but that's destructive churn; CI's syntax check is sufficient.)

## What this doesn't fix

The Copilot-review verification step at line ~150 also calls `/commits/<sha>/pulls`, but it only runs after the gate has already succeeded — the API has settled by then. Untouched here; can be DRY'd later by passing `pr_number` as a step output if it ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process reliability with improved PR number resolution during release preparation, including better handling of potential indexing delays and more descriptive logging when releases are skipped.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mshykov/local-review/pull/61)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->