### PR TITLE
ci: pin ci.yml GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+# Pin GITHUB_TOKEN to least-privilege. The CI job only checks out
+# the code, runs gofmt / vet / test / build — no API writes, no
+# artifact uploads, no PR comments. Without this block the token
+# inherits the repo / org default scopes, flagged by GitHub code
+# scanning (rule: workflow has no explicit permissions).
+# bench.yml, release.yml, and sonar.yml already pin their own;
+# this closes the gap on the last workflow.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Closes the GitHub code-scanning alert flagging `ci.yml` for missing explicit `permissions:` block.
- Adds `permissions: contents: read` at the workflow root.
- The other three workflows (`bench.yml`, `release.yml`, `sonar.yml`) already pin their own permissions; this closes the gap on the last one.

## Why `contents: read` only

The CI job runs gofmt / vet / test / build. No API writes, no artifact uploads, no PR comments — so `contents: read` (the minimum needed for `actions/checkout` and `actions/setup-go`'s module cache) is sufficient.

## Test plan

- [ ] CI green on this PR
- [ ] Code-scanning alert moves to "fixed" once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)