### PR TITLE
docs(CLAUDE.md): tighten to rules-first, drop redundant prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,398 +1,155 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Instructions for Claude Code (and any agent) operating in this repository.
+These OVERRIDE default behavior — read them before acting.
 
-## Project Overview
+---
 
-local-review is a local, BYOK (Bring Your Own Key) AI code reviewer. It's a single Go binary that:
-- Runs against git diffs (staged changes, commits, or branches)
-- **v0.1+**: Supports multi-LLM parallel reviews (Claude, Gemini, Codex)
-- **v0**: Single-LLM via OpenAI-compatible API endpoints
-- Saves reviews to local storage and merges findings intelligently
-- Ships with language-aware prompt packs for TypeScript, Go, Python, Rust, and more
+## Operating rules
 
-Key constraints:
-- **No vendor SDK dependencies** — keeps the binary small and portable
-- **No telemetry** — privacy first
-- **Git CLI integration only** — no go-git to avoid binary bloat
-- **Hybrid CLI + API mode** — prefer free CLI tools, fallback to API if configured
+These apply to every task in this repo. They exist because each one has cost us a review round, an incident, or a rewrite.
 
-## Multi-LLM Architecture (v0.5+)
+1. **Surgical changes only.** Touch what the task requires. No drive-by formatting, comment polish, or "while I'm here" refactors. If you spot something worth fixing, surface it separately — do not bundle it.
+   *Why:* mixed-purpose diffs are the hardest to review and the easiest to revert badly.
 
-### Design Decisions
+2. **Read before you write.** Before editing a shared helper, contract, or user-visible string, grep all callers in the same pass — sibling code sites, doc comments, README, CHANGELOG, prompt templates, tests. Drift across files is the #1 reviewer-flagged defect class on this codebase. The `CountSuccessful` → `CountWithOutput` migration drifted across 5 review rounds before all sites aligned.
 
-**Multi-LLM is the default, single-LLM is the fallback**
-- Default: every authenticated LLM CLI (claude, gemini, codex) runs in
-  parallel; findings are merged into one consolidated report.
-- Fallback: when *no* LLM CLI is authenticated, hit the configured
-  `provider:` (any OpenAI-compat endpoint, including local Ollama).
-- The v0.1 plan included an "API fallback when CLI auth fails" inside
-  the multi-LLM path; that idea was abandoned with v0.5.x — `mode:
-  cli|api` was removed from the schema, see do-not-merge/v06-fully-
-  local-ollama-preset.md for the shape it would take if revived.
+3. **Doc comments and cobra `Long:` strings describe *current* behavior.** Update the comment in the same edit that changes the behavior. A stale comment is a bug.
 
-**Supported LLM CLIs**
-1. **Claude CLI** — `npm install -g @anthropic-ai/claude-code` (auth: `claude login`)
-2. **Gemini CLI** — `npm install -g @google/gemini-cli` (requires Node.js 20+)
-3. **OpenAI Codex CLI** — `npm install -g @openai/codex` (auth via `codex login` with ChatGPT Plus, or `OPENAI_API_KEY` env var pay-per-token — usually cheaper for occasional use)
+4. **Fail loud, fail closed.** Use `TrimSpace` for emptiness checks. Check `grep` exit code separately from `sha256sum`. Honor `pageInfo.hasNextPage`. Refuse on invalid input rather than silently passing it through. "Completed" is wrong if anything was skipped silently — surface what was skipped.
 
-**CLI Invocation Patterns**
-- Claude: stdin diff piped to `claude` with the review prompt
-- Gemini: short instruction prompt via `-p`, prompt body / diff via stdin (gemini's `-p` content is appended to stdin in headless mode, sidestepping argv-size limits)
-- Codex: `codex exec --output-last-message <tempfile>` with the prompt on stdin. We deliberately do NOT use `codex review --commit <sha>` (the dedicated subcommand) because it re-extracts the diff itself with codex's own settings, conflicting with the orchestrator's "extract once, fan out the same diff string to all agents" contract — that would mean codex sees a different diff than the others and consensus tags become apples-to-oranges.
+5. **Writing a v2 path next to v1? Enumerate v1's invariants explicitly and re-exercise each in v2.** Filters, severity caps, prompt-pack selection, JSON output, glob behavior — none of these carry over implicitly. The v0.5.0 multi-LLM rewrite shipped 5 separate "v2 dropped this" findings.
 
-**Version-probe failures**
-`internal/cli/detector.go` reports an LLM as `Available=false` when the `--version` probe fails (e.g., a CLI changes its banner format and our regex misses). `local-review doctor` surfaces this as the "install broken" state with the resolved binary path, but the runner currently filters silently — an upstream banner change can shrink the active agent set without an error message. Loosen the regex if a real CLI breaks this; for now the doctor row is the diagnostic.
+6. **User-visible strings drift fast.** When changing a CLI output line, error message, or warning, grep the repo for the prior wording — CHANGELOG, README, prompt templates, help text, and tests likely all need updating.
 
-**Storage Structure**
-Reviews saved to `.local-review/reviews/<sanitized-branch>/<commit>_<llm>_<version>.md`:
+7. **State assumptions, then proceed.** Auto mode prefers action over questions. When ambiguous, name the assumption out loud in one sentence and continue. Stop and ask only for irreversible or shared-state actions (push, force-push, schema change, deleting data).
+
+8. **Surface conflicts; don't average them.** If two patterns contradict, pick the more recent / more tested one, explain why in the diff or commit message, and flag the other for cleanup. Do not silently blend them.
+
+9. **Tests encode the invariant, not the call.** A test named `Test_FooReturnsErrorOnEmptyInput` is better than `Test_Foo_2`. If a test can't fail when the business rule changes, it isn't testing the rule.
+
+10. **Match the codebase's conventions even if you disagree.** Conformance > taste. If you genuinely think a convention is harmful, surface it in chat — don't fork silently.
+
+11. **Pre-push self-review is non-negotiable.** Before pushing any branch with code changes, run `./local-review review main` (or `--only claude` if multi-LLM is too slow). Address `major` / `critical` findings before pushing. Skip only for pure docs / website / trivial-config changes. We eat our own dog food; if the tool produces noise on this codebase, that's a bug to file or fix.
+
+12. **`cmd/local-review/runner.go` and `doctor.go` are the danger zone.** They historically account for ~40% of all reviewer findings. Both are orchestration files where multiple concepts meet. Apply rules 1–6 with extra care here.
+
+---
+
+## What this project is
+
+`local-review` is a local, BYOK AI code reviewer — a single Go binary that runs against git diffs (staged / commit / branch).
+
+**Two paths, picked automatically:**
+- **Multi-LLM (default)** — every authenticated LLM CLI (claude, gemini, codex) runs in parallel against the same diff; findings are merged into one consolidated report.
+- **Single-LLM fallback** — when no CLI is authenticated, hit the configured `provider:` (any OpenAI-compatible endpoint, including local Ollama).
+
+**Hard constraints:**
+- No vendor SDKs (keeps the binary small and portable).
+- No telemetry (privacy first).
+- Git CLI integration only — never go-git.
+- Exit codes: `0` = no blocking findings, `2` = `major` or `critical` present (used by pre-commit hooks), non-zero = tool failure (hooks ignore so commits go through).
+
+---
+
+## Architecture map
+
+Code is authoritative; this is just a pointer table. Read the package, don't trust the prose.
+
+| Package | Purpose |
+|---|---|
+| [cmd/local-review/](cmd/local-review/) | Cobra entrypoint, `runner.go` dispatcher, `doctor.go`, `init.go`, `bench.go` |
+| [internal/cli/](internal/cli/) | LLM CLI detection, version probe, invocation patterns per LLM |
+| [internal/multi/](internal/multi/) | Parallel orchestrator, LLM-powered merger, on-disk storage, metadata |
+| [internal/config/](internal/config/) | YAML cascade (`~/.local-review.yml` → `./.local-review.yml` → flags) |
+| [internal/llm/](internal/llm/) | SDK-free HTTP client for OpenAI-compat endpoints (single-LLM fallback) |
+| [internal/git/](internal/git/) | Shells out to `git`; `-U10` context; modes: `staged`, `commit <rev>`, `branch <base>...HEAD` |
+| [internal/lang/](internal/lang/) | Extension → language ID mapping |
+| [internal/prompts/](internal/prompts/) | `go:embed`-ed packs in `packs/*.md`; user override via `prompts.pack_dir` (v0.7+) |
+| [internal/review/](internal/review/) | Filtering (min_severity, max_findings, include/exclude globs), formatting |
+| [internal/output/](internal/output/) | Text and JSON renderers |
+| [bench/](bench/) | Regression dataset + harness; `--uplift` compares treatment vs baseline (v0.8+) |
+
+---
+
+## Multi-LLM model — non-obvious facts
+
+These are things you can't infer by reading the code in 30 seconds:
+
+- **Codex invocation uses `codex exec --output-last-message`, NOT `codex review --commit`.** The dedicated subcommand re-extracts the diff itself, breaking the orchestrator's "extract once, fan out the same diff to all agents" contract.
+- **Gemini gets a short `-p` prompt + the diff via stdin.** In headless mode, gemini appends `-p` content to stdin, sidestepping argv-size limits.
+- **Version-probe regex failures fail silently.** `internal/cli/detector.go` marks an LLM `Available=false` on probe miss; the runner filters silently. `local-review doctor` is the only diagnostic surface — loosen the regex if a real CLI breaks.
+- **Merge LLM selection priority:** `--merge-with <llm>` → `merge.preferred_llm` → auto (claude > codex > gemini).
+- **Parallel execution continues on partial failure.** Failed LLMs are noted in `metadata.json` and `merged.md`; not-installed LLMs are skipped silently.
+- **Token fields (v0.6.6+):** `input_tokens`/`output_tokens` are `omitempty`. Codex pre-v0.128 emits `total_only_tokens: true` — `input_tokens` then holds the combined total; render as "Nk total", not "Nk in / 0 out".
+- **No standalone re-merge command.** To re-merge an existing commit, re-run `local-review commit <ref>`.
+
+---
+
+## Storage
+
+Reviews land at `.local-review/reviews/<sanitized-branch>/`:
+
 ```
-.local-review/
-  reviews/
-    feature-auth-fix/              # branch name sanitized (/ → -)
-      abc123_claude_3.5.md
-      abc123_gemini_0.40.md
-      abc123_codex_0.128.md
-      abc123_merged.md             # LLM-powered merge
-      abc123_metadata.json         # run details: timestamps, exit codes
-```
-
-**Merge Strategy**
-- Use LLM to deduplicate and consolidate findings from all reviews
-- Merge LLM selection (in priority order):
-  1. User's `--merge-with <llm>` flag
-  2. User's config `merge.preferred_llm: claude`
-  3. Automatic best-available: Claude > Codex > Gemini
-- Default: automatic mode
-
-**Error Handling**
-- Parallel execution: continue if one LLM fails
-- Log failures to metadata.json
-- Include failure notes in merged.md
-- Skip not-installed LLMs silently (only log installed ones)
-
-**Configuration Schema (v0.5+)**
-```yaml
-# .local-review.yml — every field is optional; defaults are sensible.
-llms:
-  claude:
-    # enabled: true              # default; omit to use auto-detect
-    cli_path: claude             # path override; defaults to PATH lookup
-    model: claude-opus-4-7       # passed via --model
-    api_key_env: ANTHROPIC_API_KEY  # custom env var for the key
-
-  gemini:
-    cli_path: gemini
-    model: gemini-2.0-flash
-    api_key_env: GEMINI_API_KEY
-
-  codex:
-    # codex runs by default when authenticated. Set enabled: false to
-    # opt out (e.g., to keep paid-tier billing predictable).
-    cli_path: codex
-    model: gpt-4
-    api_key_env: OPENAI_API_KEY
-
-merge:
-  preferred_llm: auto            # 'auto' or specific LLM name
-  deduplicate: true
-
-storage:
-  base_path: .local-review/reviews
+abc123_claude_3.5.md      # one per active LLM
+abc123_codex_0.128.md
+abc123_gemini_0.40.md
+abc123_merged.md          # consolidated by the merge LLM
+abc123_metadata.json      # timestamps, exit codes, token counts, versions
 ```
 
-The v0.1 schema had a `mode: cli|api` field per LLM. It was never
-wired through to the runtime — the orchestrator always invoked CLIs —
-and was removed in v0.5.x. Existing configs with stray `mode:` lines
-still load (yaml.v3 silently ignores unknown fields).
+Branch sanitization: `/` → `-`. Override base path via `storage.base_path` in config.
 
-**Command Structure (v0.5+)**
+---
+
+## Commands cheat sheet
+
 ```sh
-# Review — multi-LLM by default (every authenticated CLI runs in parallel and
-# findings are merged). Falls back to single-LLM via configured provider when
-# no CLI is active.
-local-review review              # canonical: current branch vs main
-local-review staged              # what would be committed next (pre-commit)
-local-review commit [<rev>]      # one commit (default: HEAD)
-local-review branch [<base>]     # alias of `review`
-local-review review --only claude,gemini      # restrict the agent set
-local-review review --claude-model claude-opus-4-7  # override one agent's model
-local-review review --merge-with claude       # pick which agent merges
+local-review review              # canonical: current branch vs main (multi-LLM if any CLI authenticated)
+local-review staged              # pre-commit shape
+local-review commit [<rev>]      # one commit (default HEAD)
+local-review branch [<base>]     # alias of review
+local-review review --only claude,gemini       # restrict agent set
+local-review review --merge-with claude        # pick merge LLM
+local-review review --claude-model <id>        # override one agent's model
 
-# Utilities
-local-review init                # interactive setup wizard (writes .local-review.yml)
-local-review doctor              # check LLM installations, auth status
-local-review config              # print resolved config (API keys masked)
-local-review version             # print version
+local-review init                # interactive config wizard
+local-review doctor              # check installs + auth + version-probe state
+local-review config              # print resolved config (keys masked)
+local-review version
 ```
 
-There is no standalone "re-merge" command — the merge step runs as part of `local-review review`. To re-run the merge against an existing commit, re-run `local-review commit <ref>`.
+---
 
-## Development Commands
+## Development
 
-### Build and Test
 ```sh
-# Run all tests
-go test ./...
-
-# Run tests with race detection (CI standard)
-go test -race ./...
-
-# Build the binary
+go test ./...                    # unit tests
+go test -race ./...              # CI standard
 go build -o local-review ./cmd/local-review
-
-# Test the canonical review path (multi-LLM by default if any CLI is active)
-./local-review review
-
-# Test staged-only review (pre-commit shape)
-./local-review staged
-
-# Test doctor command (check LLM installations + auth)
-./local-review doctor
-
-# Test against a specific commit
-./local-review commit HEAD
+./local-review review            # smoke test
+./local-review doctor            # check LLM installs
 ```
 
-### v0.1 Development Prerequisites
-```sh
-# Install Node.js (required for LLM CLIs)
-brew install node
+Required: Go 1.23+, git in PATH. For multi-LLM testing: Node 20+ plus at least one of `@anthropic-ai/claude-code`, `@google/gemini-cli`, `@openai/codex`. For single-LLM fallback: `export LOCAL_REVIEW_API_KEY=sk-...`.
 
-# Install LLM CLIs for testing
-npm install -g @google/gemini-cli
-npm install -g @openai/codex
-npm install -g @anthropic-ai/claude-code
-```
+CI (`.github/workflows/ci.yml`) runs `go vet` + `go test -race` + build on every push. Tagging `vX.Y.Z` on main triggers cross-compiled releases (darwin/linux/windows × amd64/arm64).
 
-### Configuration Testing
-```sh
-# View resolved config
-./local-review config
-```
+---
 
-### Required Environment
-- Go 1.23+
-- Git CLI available in PATH
-- For single-LLM-fallback testing: `export LOCAL_REVIEW_API_KEY=sk-...`
-- For multi-LLM (default) testing: Node.js 20+ and npm to install at least one of the LLM CLIs
+## Adding a new language
 
-## Multi-LLM Architecture (v0.5+)
+1. Create `internal/prompts/packs/<langid>.md`.
+2. Add extension(s) to `byExt` in [internal/lang/detect.go](internal/lang/detect.go).
+3. Add a constant for the language ID (e.g., `const Rust = "rust"`).
+4. `go test ./internal/prompts/... ./internal/lang/...`.
 
-### Packages
+---
 
-**internal/cli/** — LLM CLI wrapper and detection
-- `detector.go` — Check which LLM CLIs are installed (claude, gemini, codex); `LLM` struct + `CanonicalAPIKeyEnv` map
-- `invoker.go` — Execute CLI commands with proper patterns per LLM; thread Model + APIKey + systemPrompt
-- `version.go` — Extract CLI version numbers for metadata
+## Style
 
-**internal/multi/** — Multi-LLM orchestration
-- `orchestrator.go` — Parallel execution coordinator
-- `merger.go` — LLM-powered review consolidation
-- `storage.go` — Save reviews to `.local-review/reviews/<branch>/<commit>_*.md`
-- `metadata.go` — Track run details (timestamps, exit codes, versions)
-
-**internal/config/** — Extended configuration
-- `LLMs` map with per-agent settings (cli_path, model, api_key_env, timeout)
-- `Merge` config (preferred_llm, deduplicate, consensus_threshold)
-- `Storage` config (base_path)
-
-**cmd/local-review/** — New commands
-- `runner.go` — Unified review dispatcher (multi-LLM with single-LLM fallback)
-- `doctor.go` — Check LLM installations and auth status
-
-### Review Flow (v0.5+)
-
-1. **Command: `local-review review`** (or `staged|commit|branch`)
-2. **Config Load** — Resolve cascade (~/.local-review.yml → ./.local-review.yml → flags)
-3. **Active LLM Detection** — `pickAgents()` reuses doctor's `classify()` to find every
-   LLM CLI that is installed AND authenticated. Config `enabled: false` is honored
-   as an opt-out unless `--only` overrides.
-4. **Multi-LLM path** (when ≥1 active):
-   - Print agent roster with model + CLI version
-   - Parallel `RunParallel()` over goroutines
-   - Save each per-LLM output to `.local-review/reviews/<branch>/<commit>_<llm>_<version>.md`
-   - Log metadata to `<commit>_metadata.json`
-   - Pick merge LLM (`--merge-with` → `merge.preferred_llm` → auto: claude > codex > gemini)
-   - Merge findings via the merge LLM, save `<commit>_merged.md`, print to stdout
-5. **Single-LLM fallback** (when no CLI active):
-   - Use the configured `provider:` (any OpenAI-compatible endpoint)
-   - One review pass, print findings, exit 2 on major/critical
-
-### Storage Schema
-
-```
-.local-review/
-  reviews/
-    feature-auth-fix/
-      abc123_claude_3.5.md          # Individual reviews
-      abc123_gemini_0.40.md
-      abc123_codex_0.128.md
-      abc123_merged.md              # Consolidated review
-      abc123_metadata.json          # Run metadata
-```
-
-**metadata.json structure:**
-```json
-{
-  "commit": "abc123",
-  "branch": "feature-auth-fix",
-  "timestamp": "2026-05-02T10:30:00Z",
-  "reviews": [
-    {
-      "llm": "claude",
-      "version": "3.5",
-      "mode": "cli",
-      "status": "success",
-      "duration_ms": 4500,
-      "findings_count": 12,
-      "input_tokens": 12300,
-      "output_tokens": 4500
-    },
-    {
-      "llm": "codex",
-      "version": "0.120",
-      "mode": "cli",
-      "status": "success",
-      "duration_ms": 9800,
-      "input_tokens": 18000,
-      "total_only_tokens": true
-    },
-    {
-      "llm": "gemini",
-      "version": "0.40",
-      "mode": "cli",
-      "status": "failed",
-      "error": "authentication required"
-    }
-  ],
-  "merge": {
-    "llm": "claude",
-    "status": "success",
-    "final_findings_count": 8,
-    "input_tokens": 8500,
-    "output_tokens": 2100
-  }
-}
-```
-
-Token fields shipped in v0.6.6. `input_tokens`/`output_tokens` are
-omitempty — absent on runs where the CLI version didn't surface
-usage. `total_only_tokens: true` (codex pre-v0.128) means
-`input_tokens` holds the combined total and the split is unknown;
-display layers should render "Nk total" rather than "Nk in / 0 out".
-
-## Single-LLM Fallback Path
-
-Used when no LLM CLI is authenticated. Same code path as the original
-v0 single-LLM design — kept verbatim because it's the simplest way to
-get a review running with just an API key.
-
-### Configuration Cascade (internal/config/)
-Config is loaded in order of precedence (lowest to highest):
-1. Built-in defaults (compiled in)
-2. `~/.local-review.yml` (per-user)
-3. `./.local-review.yml` (per-repo, found by walking up from cwd)
-4. CLI flags (per-invocation)
-
-Each layer shallow-merges over the previous one. Slices like `exclude` are replaced wholesale, not appended.
-
-### Core Flow (cmd/local-review/main.go → internal/review/review.go)
-1. **CLI entry** (cobra) parses command (staged/commit/branch) + flags
-2. **Config loader** resolves YAML cascade, applies flag overrides
-3. **Git wrapper** shells out to `git diff` with appropriate args for mode
-4. **Language detection** analyzes file extensions, picks dominant language
-5. **Prompt pack loader** embeds markdown files via go:embed, selects pack by language
-6. **LLM client** (internal/llm/) sends system prompt + diff to chat-completions endpoint
-7. **Parser** extracts JSON findings from LLM response (tolerates markdown fences)
-8. **Filtering** applies min_severity + max_findings
-9. **Output** formats as text or JSON
-
-Exit codes:
-- `0` — success, no blocking findings
-- `2` — major/critical findings present (blocks pre-commit hooks)
-- non-zero — tool failure (hooks ignore this and let commits through)
-
-### LLM Client (internal/llm/client.go)
-- **No SDKs** — raw HTTP POST to `/v1/chat/completions`
-- All major providers speak this API dialect (even Anthropic via their OpenAI-compat endpoint)
-- Uses `response_format: {type: "json_object"}` for structured output
-- Low temperature (0.2) for consistency
-
-### Git Integration (internal/git/diff.go)
-- Shells out to `git` CLI (not go-git library) to preserve user's repo state
-- Uses `-U10` for 10 lines of context (sweet spot for LLM reasoning vs token cost)
-- Returns structured Diffs with Hunks (path + line numbers + content)
-- Modes:
-  - `staged`: `git diff --cached`
-  - `commit`: `git show --format= <rev>`
-  - `branch`: `git diff <base>...HEAD` (three-dot: from common ancestor)
-
-### Prompt Packs (internal/prompts/)
-Embedded markdown files (packs/*.md) define language-specific review rules:
-- `default.md` — fallback for unknown languages
-- `typescript.md`, `go.md`, `python.md`, `rust.md` — language-specific packs
-
-Each pack is a system prompt with:
-1. Priority-ordered review criteria (correctness > security > perf > style)
-2. Severity tiering rules (nit/info/warning/major/critical)
-3. Hard rules (never comment outside the diff, never invent code)
-4. JSON output schema
-
-Language detection (internal/lang/detect.go) maps file extensions → language IDs → pack files.
-
-### Output Filtering (internal/review/review.go)
-Findings are:
-1. Parsed from LLM's JSON response (tolerates `\`\`\`json` fences)
-2. Filtered by min_severity (drops findings below threshold)
-3. Sorted by severity desc, then file/line asc
-4. Capped at max_findings
-5. Formatted as text (internal/output/text.go) or JSON
-
-Glob filtering (include/exclude) uses a custom `**` glob matcher (review.go:matchGlob).
-
-## Adding a New Language
-
-1. Create `internal/prompts/packs/<langid>.md` with the pack content
-2. Add extension(s) to `byExt` map in `internal/lang/detect.go`
-3. Add a constant for the language ID (e.g., `const Rust = "rust"`)
-4. Run `go test ./internal/prompts/... ./internal/lang/...`
-
-## Style Guidelines
-
-- **No vendor SDKs** — internal/llm/ stays SDK-free to keep binary size down
-- **Standard Go** — gofmt -s + go vet
-- **Comment intent, not mechanics** — explain *why*, never *what*
-- **Tests required** — new logic needs a unit test
-- **One-line doc comments** — exported functions/types only
-
-## Recurring failure patterns (review retrospective)
-
-`cmd/local-review/runner.go` + `cmd/local-review/doctor.go` account for ~40% of all reviewer findings across v0.4.0–v0.6.1. Both are orchestration files where multiple concepts meet. Following the rules below avoids re-living the same review iteration cycle.
-
-1. **Migrating a shared helper or contract? Grep all callers in the same commit.** Doc comments, sibling sites, README quotes, CHANGELOG, prompt templates. Drift across files is the #1 reviewer-flagged class of defect on this codebase (the `CountSuccessful` → `CountWithOutput` migration drifted across 5 review rounds before all sites aligned).
-2. **Doc comments and cobra `Long:` strings describe the *current* behavior, not yesterday's.** A comment claiming a function is "optional" while the function always fires is a bug. Update the comment in the same edit that changes the behavior.
-3. **Default to fail-closed.** `TrimSpace` for emptiness checks; check `grep` exit code separately from `sha256sum`; honor `pageInfo.hasNextPage`; refuse on invalid input rather than silently passing it through. When in doubt, return an error and let the caller decide.
-4. **Writing a v2 code path next to a v1 path? Enumerate v1's invariants explicitly and re-exercise each in v2.** Filters, severity caps, prompt-pack selection, JSON output, glob behavior — none of these carry over implicitly. PR #34 (v0.5.0 multi-LLM rewrite) shipped 5 separate "v2 dropped this" findings.
-5. **User-visible strings drift fast.** When changing a CLI output line, error message, or warning, grep the repo for the prior wording — CHANGELOG, README, prompt templates, help text, and tests likely all need to update with it.
-
-## Pre-push Workflow (dogfooding)
-
-**Before pushing any branch to GitHub, run a self-review with the project's own tool.**
-
-```sh
-# For a feature branch (reviews full diff vs main with every active LLM)
-./local-review review main
-
-# To restrict to one LLM (e.g., when multi-LLM is too slow):
-./local-review review main --only claude
-```
-
-Address any `major` or `critical` findings before pushing. This is non-negotiable: we eat our own dog food. If `local-review` produces a noisy, low-value review on this codebase, that's a bug — file an issue or fix the prompt pack.
-
-Skip the self-review only for: pure docs changes (`*.md`, `docs/`), website-only changes (`docs/index.html`), or trivial config tweaks where the tool would have nothing to say.
-
-## CI and Releases
-
-- `.github/workflows/ci.yml` runs `go vet` + `go test -race` + build on every push
-- Tag `vX.Y.Z` on main to trigger release workflow (cross-compiles binaries for darwin/linux/windows × amd64/arm64)
+- `gofmt -s` + `go vet` clean.
+- Comment intent (*why*), never mechanics (*what*) — well-named identifiers describe what.
+- One-line doc comments on exported symbols only.
+- New logic needs a unit test.
+- No vendor SDKs in `internal/llm/` — raw HTTP only.


### PR DESCRIPTION
## Summary

- Rewrites [CLAUDE.md](CLAUDE.md) as a rules-first instruction file with an architecture pointer table — **17.5KB → 9.4KB (-46%)**, 491 → 124 lines.
- Promotes the \"recurring failure patterns\" retrospective into 12 numbered Operating Rules at the top, with the why-it-exists scar tissue intact (CountSuccessful migration, v0.5.0 v2 drift, runner.go/doctor.go danger zone).
- Drops prose that re-narrated code (config cascade, core flow, LLM client internals, prompts/git/output sections), the duplicated \"Multi-LLM Architecture\" section, the v0.1 historical schema footnote, and the full metadata.json example.
- Adds [bench/](bench/) (v0.8 harness + ` + "`--uplift`" + `) and ` + "`prompts.pack_dir`" + ` (v0.7) to the architecture pointer table.

### Why

Every byte in CLAUDE.md is loaded into the agent's context on every turn, competing with the actual task for attention. Architecture-as-prose drifts and lies (code is authoritative); rules-with-scar-tissue don't. This pass keeps the latter and deletes the former.

### Absorbed from a 12-rule template (only the keepers)

| Added | Why kept |
|---|---|
| Surgical changes (rule 1) | Drive-by formatting is the most common bundled-PR defect on this repo |
| Surface conflicts, don't average (rule 8) | Real and concise |
| Tests encode the invariant, not the call (rule 9) | Sharpens existing test guidance |
| Match conventions even if you disagree (rule 10) | Sharpens existing style guidance |
| Fail loud (rule 12) | Merged with existing fail-closed rule |

Skipped: rules 5/6 (wrong audience — those are for codebases that *call* Claude as an API, not an agent's instruction file), rules 4/10-checkpoint (vague / output noise), rules 2/8/11 (already covered by system prompt or existing patterns).

## Test plan

- [ ] Skim the new [CLAUDE.md](CLAUDE.md) end-to-end — does anything actionable feel missing vs. the previous version?
- [ ] Spot-check the architecture pointer table — every linked package exists.
- [ ] Confirm the dogfooding pre-push rule is preserved (it is — rule 11).
- [ ] No code changes; CI ` + "`go vet` + `go test -race`" + ` should pass trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized developer documentation with emphasis on operating rules and constraints
  * Streamlined architecture reference and removed redundant content
  * Clarified development practices and contribution expectations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mshykov/local-review/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->