### PR TITLE
refactor(multi): consolidate dual-metric gate into multi.GateDecision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Consolidated the dual-metric gate pattern in `cmd/local-review/runner.go` into a single `multi.GateDecision` type.** v0.10.0's first audit dogfood (`audit/tech-debt.md`) flagged `runner.go:156` as a `major` finding: six call sites in the runner each computed `CountSuccessful` (Error == nil) and/or `CountWithOutput` (HasMergeableOutput) independently, with load-bearing comments cataloguing two distinct historical bugs (SaveReview-failed-with-output, CLI-exited-zero-with-empty-output) where the two metrics had drifted apart. The new shape: `multi.DecideGate(results)` returns a `GateDecision` summarising both views in a single pass; the runner threads that one value through the zero-mergeable short-circuit, the run-mode classifier (renamed `classifyRunMode` → `classifyRunModeFromGate`), the merge-step framing, and the progress display lines. Error taxonomy for the zero-mergeable case moved onto the type as `GateDecision.ClassifyZero() ZeroMergeableReason` with three named cases (`ZeroMergeableAllFailed`, `ZeroMergeableAllEmpty`, `ZeroMergeableMixed`) — the runner picks the error message by switch, the categories themselves are pinned by tests in `internal/multi/orchestrator_test.go` (`TestDecideGate_*`) named for the underlying scenarios (`AllFailed`, `AllSucceededButEmpty`, `MixedFailedAndEmpty`, `SaveReviewFailedWithOutput_StillMergeable`, …) so a future regression makes the failing line readable without re-reading the body (CLAUDE.md rule 9). No user-facing behavior change — exit codes, error strings, and console output are byte-identical to v0.10.0; the change is structural, eliminating the surface area that historically drifted. `multi.CountSuccessful` and `multi.CountWithOutput` are retained as public helpers (still used in tests and stable callers), but the runner no longer uses them directly.
+
 ## [0.10.0] - 2026-05-25
 
 **Theme: reach beyond the diff.**

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -270,34 +270,40 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 		fmt.Printf("Per-LLM reviews → %s/\n\n", storageDir)
 	}
 
-	successCount := multi.CountSuccessful(results)
-	mergeable := multi.CountWithOutput(results)
-	rmode := classifyRunMode(results) // computed once here; reused in the report-path block below to avoid a second traversal
+	// Single-pass summary of the result set. Both views (Error == nil
+	// "Successful" and HasMergeableOutput "WithOutput") are derived
+	// once here and threaded through everything downstream, so the
+	// two counts can't drift across call sites the way they did pre-
+	// consolidation (audit/tech-debt.md flagged runner.go:156 as a
+	// `major` finding for exactly that pattern — six call sites
+	// observing the result set independently meant any one updating
+	// the other was a regression risk).
+	gate := multi.DecideGate(results)
+	rmode := classifyRunModeFromGate(gate) // computed once here; reused in the report-path block below to avoid a second traversal
 	metadata := buildMetadata(commit, branch, results, startTime)
 
-	// Short-circuit on "nothing for the merger to consume." Pre-fix
-	// this checked successCount (Error == nil), which let two cases
-	// slip past:
+	// Short-circuit on "nothing for the merger to consume." We branch
+	// on WithOutput (what the merger actually sees via BuildMergeInput),
+	// not Successful (Error == nil), because two cases historically
+	// slipped past a Successful-only check:
 	//
 	//   1. SaveReview-failed-with-output: Error is set but Output is
-	//      populated. successCount drops to 0 even though the merger
+	//      populated. Successful drops to 0 even though the merger
 	//      could still consolidate the in-memory output. Pre-fix we
 	//      aborted with "all N reviews failed" — wrong, the reviews
 	//      ran, only persistence failed.
 	//   2. CLI-exited-zero-with-empty-output: Error is nil but Output
-	//      is "". successCount stays positive but BuildMergeInput
-	//      drops the empty entry, so the merger ran on 0 reviews and
+	//      is "". Successful stays positive but BuildMergeInput drops
+	//      the empty entry, so the merger ran on 0 reviews and
 	//      classifyRunMode fell through to runModeMerge — both giving
 	//      the user a "Merged review" framing for what was actually
 	//      nothing.
 	//
-	// CountWithOutput matches what the merger actually consumes, so
-	// "0 mergeable" is the correct threshold for "stop here." When
-	// successCount disagrees (case 1: 0 successCount but mergeable),
-	// the merge proceeds and the gate runs. When mergeable is 0 we
-	// pick the right error message based on whether anyone "succeeded"
-	// in the loose Error == nil sense.
-	if mergeable == 0 {
+	// HasMergeable() is the gate predicate; ClassifyZero() picks the
+	// right error message when the gate trips. The error taxonomy is
+	// owned by the GateDecision type, not duplicated inline here —
+	// see internal/multi/orchestrator.go ZeroMergeableReason.
+	if !gate.HasMergeable() {
 		metadata.Merge.Status = "skipped"
 		if _, err := storage.SaveMetadata(branch, commit, metadata); err != nil {
 			// Best-effort: per-LLM markdown saves either succeeded or
@@ -308,23 +314,21 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 			// code, not for metadata.json.
 			fmt.Fprintf(os.Stderr, "Warning: failed to save metadata.json (review markdown still on disk): %v\n", err)
 		}
-		failed := len(results) - successCount
-		empty := successCount // succeeded (Error nil) but no Output; classifier already counted these as non-mergeable
-		switch {
-		case failed == len(results):
-			return fmt.Errorf("all %d LLM reviews failed", len(results))
-		case empty == len(results):
-			return fmt.Errorf("all %d LLM reviews returned empty output (no findings to merge)", len(results))
-		default:
+		switch gate.ClassifyZero() {
+		case multi.ZeroMergeableAllFailed:
+			return fmt.Errorf("all %d LLM reviews failed", gate.Total)
+		case multi.ZeroMergeableAllEmpty:
+			return fmt.Errorf("all %d LLM reviews returned empty output (no findings to merge)", gate.Total)
+		default: // ZeroMergeableMixed
 			// Mixed: some agents crashed, others exited zero with blank
 			// output. Pre-fix this case printed "all returned empty
 			// output" which misled users into debugging the wrong
 			// problem (an empty-output bug vs a crash).
-			return fmt.Errorf("no LLM produced output: %d failed, %d returned empty (nothing to merge)", failed, empty)
+			return fmt.Errorf("no LLM produced output: %d failed, %d returned empty (nothing to merge)", gate.Failed(), gate.Successful)
 		}
 	}
 
-	mergedPath, mergedContent, mergeTokens := mergeAndPrint(ctx, cfg, sf, active, results, storage, commit, branch, metadata)
+	mergedPath, mergedContent, mergeTokens := mergeAndPrint(ctx, cfg, sf, active, results, gate, storage, commit, branch, metadata)
 	if _, err := storage.SaveMetadata(branch, commit, metadata); err != nil {
 		// Same posture as the no-mergeable-output branch above: review
 		// markdown files are already on disk, the gate's exit code is
@@ -350,17 +354,18 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	// mislead users into thinking the call was free.
 	totalTokens := aggregateTokens(results, mergeTokens)
 	if totalTokens > 0 {
-		fmt.Printf("✓ %d/%d LLMs produced output · total %s · ~%s tokens\n", mergeable, len(results), time.Since(startTime).Round(time.Second), humanTokens(totalTokens))
+		fmt.Printf("✓ %d/%d LLMs produced output · total %s · ~%s tokens\n", gate.WithOutput, gate.Total, time.Since(startTime).Round(time.Second), humanTokens(totalTokens))
 	} else {
-		fmt.Printf("✓ %d/%d LLMs produced output · total %s\n", mergeable, len(results), time.Since(startTime).Round(time.Second))
+		fmt.Printf("✓ %d/%d LLMs produced output · total %s\n", gate.WithOutput, gate.Total, time.Since(startTime).Round(time.Second))
 	}
 	if mergedPath != "" {
-		// Report-path label uses `rmode` (computed above alongside `mergeable`)
-		// so we don't call CountWithOutput a second time. Degraded/solo runs
-		// use distinct labels so users can tell single-source from consensus.
+		// Report-path label uses `rmode` (computed above from the same
+		// gate) so we don't traverse `results` again. Degraded/solo
+		// runs use distinct labels so users can tell single-source
+		// from consensus.
 		switch rmode {
 		case runModeDegraded:
-			fmt.Printf("Single-LLM report (%d of %d agents produced no output): %s\n", len(results)-mergeable, len(results), mergedPath)
+			fmt.Printf("Single-LLM report (%d of %d agents produced no output): %s\n", gate.Total-gate.WithOutput, gate.Total, mergedPath)
 		case runModeSolo:
 			fmt.Printf("Report: %s\n", mergedPath)
 		default:
@@ -772,28 +777,31 @@ const (
 	runModeSolo                    // exactly 1 output out of 1 agent; user chose --only, expected
 )
 
-// classifyRunMode picks the framing for the merge step based on how
-// many agents produced output the merger will actually see. We count
-// non-blank Output (matching BuildMergeInput's filter, which uses
-// strings.TrimSpace), not Error == nil:
+// classifyRunModeFromGate picks the framing for the merge step based
+// on how many agents produced output the merger will actually see —
+// derived from a GateDecision so we don't traverse the result set a
+// second time after DecideGate already walked it once. Counts non-
+// blank Output (gate.WithOutput, matching BuildMergeInput's filter
+// via HasMergeableOutput), not Error == nil:
 // a run where the LLM succeeded but SaveReview failed has Error != nil
 // yet Output != "", and the merger will still consume that review, so
-// the framing should reflect that. Pre-fix we used CountSuccessful and
-// would mis-flag such a run as "Degraded, only 1 of 3 succeeded" while
-// the merger was happily consolidating all 3 outputs.
+// the framing should reflect that. Pre-consolidation classifyRunMode
+// derived `mergeable` itself via a fresh CountWithOutput call — the
+// extra walk wasn't a correctness bug but did make the dual-metric
+// pattern that audit/tech-debt.md flagged on runner.go:156 harder to
+// audit (each call site computed counts itself, each had to be kept
+// consistent independently).
 //
 // The merger still runs in every case (it's what produces the structured
 // Recommendation line the gate reads), but the user-facing language is
 // different so nobody mistakes a single-LLM fallback for cross-model
 // consensus. Zero-output runs never reach here — the caller short-
 // circuits with an "all LLMs failed" error.
-func classifyRunMode(results []multi.ReviewResult) runMode {
-	mergeable := multi.CountWithOutput(results)
-	total := len(results)
+func classifyRunModeFromGate(g multi.GateDecision) runMode {
 	switch {
-	case mergeable == 1 && total > 1:
+	case g.WithOutput == 1 && g.Total > 1:
 		return runModeDegraded
-	case mergeable == 1 && total == 1:
+	case g.WithOutput == 1 && g.Total == 1:
 		return runModeSolo
 	default:
 		return runModeMerge
@@ -805,12 +813,19 @@ func classifyRunMode(results []multi.ReviewResult) runMode {
 // the saved path and the merged content; both are "" on skip/failure.
 // The content is returned so the caller can run the blocking-finding
 // gate without re-reading from disk.
-func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, active []cli.LLM, results []multi.ReviewResult, storage *multi.ReviewStorage, commit, branch string, metadata *multi.Metadata) (mergedPath, mergedContent string, mergeTokens cli.TokenUsage) {
-	mode := classifyRunMode(results)
+//
+// Takes the caller's GateDecision rather than recomputing — pre-
+// consolidation this function called classifyRunMode(results) and
+// CountWithOutput(results) independently, each walking the slice
+// again. Same metrics, same intent, two extra walks per invocation
+// and (more importantly) two extra independent observers of the
+// result set the dual-metric-drift bugs were about.
+func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, active []cli.LLM, results []multi.ReviewResult, gate multi.GateDecision, storage *multi.ReviewStorage, commit, branch string, metadata *multi.Metadata) (mergedPath, mergedContent string, mergeTokens cli.TokenUsage) {
+	mode := classifyRunModeFromGate(gate)
 
 	switch mode {
 	case runModeDegraded:
-		fmt.Fprintf(os.Stderr, "⚠ Only %d of %d LLMs produced output — review is single-source, no cross-model consensus.\n", multi.CountWithOutput(results), len(results))
+		fmt.Fprintf(os.Stderr, "⚠ Only %d of %d LLMs produced output — review is single-source, no cross-model consensus.\n", gate.WithOutput, gate.Total)
 		fmt.Println("Reformatting single review...")
 	case runModeSolo:
 		fmt.Println("Formatting review...")

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -525,7 +525,13 @@ func TestClassifyRunMode(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := classifyRunMode(tc.results); got != tc.want {
+			// classifyRunModeFromGate consumes a pre-computed
+			// GateDecision instead of walking results itself, but
+			// the cases here are written in terms of the underlying
+			// result sets so the test data stays readable. Compute
+			// the gate locally to bridge.
+			gate := multi.DecideGate(tc.results)
+			if got := classifyRunModeFromGate(gate); got != tc.want {
 				t.Errorf("got %d, want %d", got, tc.want)
 			}
 		})

--- a/internal/multi/orchestrator.go
+++ b/internal/multi/orchestrator.go
@@ -173,6 +173,111 @@ func HasMergeableOutput(r ReviewResult) bool {
 	return strings.TrimSpace(r.Output) != ""
 }
 
+// ZeroMergeableReason classifies *why* a result set has no mergeable
+// output. Only meaningful when GateDecision.WithOutput == 0.
+type ZeroMergeableReason int
+
+const (
+	// ZeroMergeableAllFailed: every review's Error is non-nil. The
+	// LLMs crashed or the CLI invocation errored.
+	ZeroMergeableAllFailed ZeroMergeableReason = iota
+
+	// ZeroMergeableAllEmpty: every review's Error is nil, but no
+	// review produced non-blank Output. The CLI exited zero with
+	// empty stdout — historically a real bug (CodeRabbit caught a
+	// case where this slipped past the gate with "all succeeded"
+	// framing). Distinct from AllFailed because "succeeded with
+	// empty output" is an LLM-emitter pathology, not a crash.
+	ZeroMergeableAllEmpty
+
+	// ZeroMergeableMixed: a mix of failures (Error != nil) and
+	// successes-with-empty-output. Pre-consolidation the runner
+	// would print "all returned empty output" here, misleading
+	// users into debugging the wrong problem.
+	ZeroMergeableMixed
+)
+
+// GateDecision is a single-pass summary of a result set, capturing
+// both the "Error == nil" view (Successful) and the "has mergeable
+// output" view (WithOutput). These two views CAN diverge and
+// historically did, producing two distinct bugs:
+//
+//  1. SaveReview-failed-with-output: Error != nil but Output != "".
+//     Counted in WithOutput, not Successful — the merger can still
+//     consolidate the in-memory output even though persistence failed.
+//
+//  2. CLI-exited-zero-with-empty-output: Error == nil but Output == "".
+//     Counted in Successful, not WithOutput — the merger has nothing
+//     to consume even though the per-LLM call "succeeded."
+//
+// Pre-fix the runner threaded both counts through six call sites; this
+// type is the single source so the metrics can't drift again
+// (audit/tech-debt.md "## cmd/local-review [part 2/3]" major finding
+// on runner.go:156, surfaced by `local-review audit --topic tech-debt`).
+type GateDecision struct {
+	Total      int // len(results)
+	Successful int // Error == nil (regardless of Output)
+	WithOutput int // HasMergeableOutput == true (regardless of Error)
+}
+
+// DecideGate computes a GateDecision from a result set in a single pass.
+// The intent: derive both counts at the call site that needs them once,
+// then thread the GateDecision through everything downstream — no second
+// traversal, no possibility of the two metrics observing different
+// snapshots of `results` (results is a slice, so the underlying array
+// won't change, but the historical concern was call-site drift, not
+// data-race drift).
+func DecideGate(results []ReviewResult) GateDecision {
+	g := GateDecision{Total: len(results)}
+	for _, r := range results {
+		if r.Error == nil {
+			g.Successful++
+		}
+		if HasMergeableOutput(r) {
+			g.WithOutput++
+		}
+	}
+	return g
+}
+
+// HasMergeable reports whether at least one review has mergeable output.
+// Use this instead of `WithOutput > 0` at gate sites — the named
+// predicate documents intent ("is there anything for the merger to
+// consume?") instead of leaving the reader to infer it from the count.
+func (g GateDecision) HasMergeable() bool {
+	return g.WithOutput > 0
+}
+
+// Failed returns the count of reviews where Error != nil (regardless
+// of Output). Symmetric with Successful = Total - Failed.
+func (g GateDecision) Failed() int {
+	return g.Total - g.Successful
+}
+
+// ClassifyZero categorises why a result set produced nothing
+// mergeable. Only meaningful when HasMergeable() is false; the runner
+// uses it to pick the right error message ("all N failed" vs "all N
+// returned empty output" vs the mixed-mode case).
+//
+// When HasMergeable() is true the result is meaningless — guard at
+// the call site with `if !g.HasMergeable() { ... ClassifyZero() ... }`.
+//
+// Implementation note: when WithOutput == 0, every Successful entry
+// is by definition "succeeded but produced no output" (no entry can
+// be in WithOutput, so the intersection of Successful and WithOutput
+// is empty). That's why the AllEmpty case compares Successful to
+// Total — it's exact in the only state ClassifyZero is consulted in.
+func (g GateDecision) ClassifyZero() ZeroMergeableReason {
+	switch {
+	case g.Failed() == g.Total:
+		return ZeroMergeableAllFailed
+	case g.Successful == g.Total:
+		return ZeroMergeableAllEmpty
+	default:
+		return ZeroMergeableMixed
+	}
+}
+
 // GetSuccessful returns only successful review results.
 func GetSuccessful(results []ReviewResult) []ReviewResult {
 	var successful []ReviewResult

--- a/internal/multi/orchestrator_test.go
+++ b/internal/multi/orchestrator_test.go
@@ -2,6 +2,7 @@ package multi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -205,5 +206,142 @@ func TestRunParallel_FastFailErrorsStillStream(t *testing.T) {
 	}
 	if results["claude"].Error != nil {
 		t.Errorf("claude agent should have succeeded, got: %v", results["claude"].Error)
+	}
+}
+
+// --- GateDecision tests ----------------------------------------------------
+//
+// These tests pin the *meaning* of the gate (per CLAUDE.md rule 9: tests
+// encode the invariant, not the call). The dual-metric pattern that
+// preceded GateDecision drifted across 5 review rounds historically
+// (`CountSuccessful` → `CountWithOutput` migration); naming each case
+// for the underlying scenario makes a regression obvious from the
+// failure line, not from re-reading the body.
+
+func TestDecideGate_AllSuccessful(t *testing.T) {
+	results := []ReviewResult{
+		{LLM: "claude", Output: "finding"},
+		{LLM: "gemini", Output: "finding"},
+		{LLM: "codex", Output: "finding"},
+	}
+	g := DecideGate(results)
+	if g.Total != 3 || g.Successful != 3 || g.WithOutput != 3 {
+		t.Errorf("Total/Successful/WithOutput = %d/%d/%d, want 3/3/3", g.Total, g.Successful, g.WithOutput)
+	}
+	if !g.HasMergeable() {
+		t.Error("HasMergeable() = false, want true (3 reviews with output)")
+	}
+	if got := g.Failed(); got != 0 {
+		t.Errorf("Failed() = %d, want 0", got)
+	}
+}
+
+func TestDecideGate_AllFailed(t *testing.T) {
+	agentFailed := errors.New("agent failed")
+	results := []ReviewResult{
+		{LLM: "claude", Error: agentFailed},
+		{LLM: "gemini", Error: agentFailed},
+	}
+	g := DecideGate(results)
+	if g.Total != 2 || g.Successful != 0 || g.WithOutput != 0 {
+		t.Errorf("counts = %d/%d/%d, want 2/0/0", g.Total, g.Successful, g.WithOutput)
+	}
+	if g.HasMergeable() {
+		t.Error("HasMergeable() = true, want false (no output)")
+	}
+	if got := g.ClassifyZero(); got != ZeroMergeableAllFailed {
+		t.Errorf("ClassifyZero() = %v, want ZeroMergeableAllFailed", got)
+	}
+}
+
+// "Succeeded but empty" is a real LLM-emitter pathology — the CLI exits
+// 0 with blank stdout. Pre-consolidation this slipped past a Successful-
+// only gate check and reached the merger with nothing to consume.
+func TestDecideGate_AllSucceededButEmpty(t *testing.T) {
+	results := []ReviewResult{
+		{LLM: "claude", Output: ""},
+		{LLM: "gemini", Output: "   \n\t"},
+	}
+	g := DecideGate(results)
+	if g.Total != 2 || g.Successful != 2 || g.WithOutput != 0 {
+		t.Errorf("counts = %d/%d/%d, want 2/2/0", g.Total, g.Successful, g.WithOutput)
+	}
+	if g.HasMergeable() {
+		t.Error("HasMergeable() = true, want false (whitespace-only output is not mergeable)")
+	}
+	if got := g.ClassifyZero(); got != ZeroMergeableAllEmpty {
+		t.Errorf("ClassifyZero() = %v, want ZeroMergeableAllEmpty (every Error nil, no Output)", got)
+	}
+}
+
+func TestDecideGate_MixedFailedAndEmpty(t *testing.T) {
+	agentFailed := errors.New("agent failed")
+	results := []ReviewResult{
+		{LLM: "claude", Error: agentFailed},
+		{LLM: "gemini", Output: ""}, // succeeded with no output
+	}
+	g := DecideGate(results)
+	if g.Total != 2 || g.Successful != 1 || g.WithOutput != 0 {
+		t.Errorf("counts = %d/%d/%d, want 2/1/0", g.Total, g.Successful, g.WithOutput)
+	}
+	if g.HasMergeable() {
+		t.Error("HasMergeable() = true, want false")
+	}
+	if got := g.ClassifyZero(); got != ZeroMergeableMixed {
+		t.Errorf("ClassifyZero() = %v, want ZeroMergeableMixed (one failed, one succeeded with no output)", got)
+	}
+}
+
+// SaveReview-failed-with-output: Error is set but Output is populated.
+// The merger CAN still consume the in-memory output. Pre-consolidation
+// a Successful-only check would abort the merge here ("all failed")
+// even though the merger would have produced a valid consolidated
+// report. GateDecision must count this as mergeable.
+func TestDecideGate_SaveReviewFailedWithOutput_StillMergeable(t *testing.T) {
+	saveErr := errors.New("save review: disk full")
+	results := []ReviewResult{
+		{LLM: "claude", Output: "finding", Error: saveErr},
+		{LLM: "gemini", Output: "finding", Error: saveErr},
+	}
+	g := DecideGate(results)
+	if g.Total != 2 || g.Successful != 0 || g.WithOutput != 2 {
+		t.Errorf("counts = %d/%d/%d, want 2/0/2 (both save-failed but both have output)", g.Total, g.Successful, g.WithOutput)
+	}
+	if !g.HasMergeable() {
+		t.Error("HasMergeable() = false, want true (save failure does not erase in-memory Output)")
+	}
+}
+
+// Mixed real-world shape that surfaces both views diverging at once.
+// One succeeded with output, one save-failed with output, one crashed:
+// Successful=1 (only the clean one), WithOutput=2 (the two with output),
+// Failed=2 (save-fail counts as failed in the Error sense).
+func TestDecideGate_MixedShapeBothViewsDiverge(t *testing.T) {
+	saveErr := errors.New("save review: disk full")
+	hardErr := errors.New("claude review failed: signal: killed")
+	results := []ReviewResult{
+		{LLM: "claude", Output: "finding"},
+		{LLM: "gemini", Output: "finding", Error: saveErr},
+		{LLM: "codex", Error: hardErr},
+	}
+	g := DecideGate(results)
+	if g.Total != 3 || g.Successful != 1 || g.WithOutput != 2 {
+		t.Errorf("counts = %d/%d/%d, want 3/1/2", g.Total, g.Successful, g.WithOutput)
+	}
+	if got := g.Failed(); got != 2 {
+		t.Errorf("Failed() = %d, want 2", got)
+	}
+	if !g.HasMergeable() {
+		t.Error("HasMergeable() = false, want true (2 with output)")
+	}
+}
+
+func TestDecideGate_Empty(t *testing.T) {
+	g := DecideGate(nil)
+	if g.Total != 0 || g.Successful != 0 || g.WithOutput != 0 {
+		t.Errorf("counts = %d/%d/%d, want all zero for nil input", g.Total, g.Successful, g.WithOutput)
+	}
+	if g.HasMergeable() {
+		t.Error("HasMergeable() = true on empty set, want false")
 	}
 }


### PR DESCRIPTION
## Summary

Closes a `major` finding from v0.10.0's first audit dogfood (`audit/tech-debt.md` → `cmd/local-review [part 2/3]` → `runner.go:156`).

Six call sites in `cmd/local-review/runner.go` each computed `CountSuccessful` (Error == nil) and `CountWithOutput` (HasMergeableOutput) independently. Load-bearing comments catalogued two real historical bugs (SaveReview-failed-with-output and CLI-exited-zero-with-empty-output) where the two metrics drifted apart. The audit's framing was right: "load-bearing documentation masking an architectural smell."

## What changed

- New `multi.GateDecision` type (`internal/multi/orchestrator.go`) — single-pass summary capturing both views (`Total`, `Successful`, `WithOutput`) plus named predicates `HasMergeable()`, `Failed()`, and `ClassifyZero() ZeroMergeableReason`.
- `multi.DecideGate(results)` constructor — one walk, both counts.
- `classifyRunMode(results)` → `classifyRunModeFromGate(g GateDecision)`.
- `mergeAndPrint(...)` now takes the gate, eliminating two additional `CountWithOutput` walks (and two additional independent observers of the result set, which was the audit's core concern).
- Zero-mergeable error message classification owned by `ZeroMergeableReason` (AllFailed / AllEmpty / Mixed) instead of inline arithmetic.

## What did NOT change

- **No user-facing behavior change.** Exit codes, error strings, progress lines, and merged-report framing are byte-identical to v0.10.0. The refactor is structural.
- `multi.CountSuccessful` and `multi.CountWithOutput` are retained as public helpers — `internal/multi/merger_test.go` still consumes them and external callers may exist. The runner no longer uses them directly.

## Tests

`TestDecideGate_*` in `internal/multi/orchestrator_test.go` pin the meaning of each gate outcome per CLAUDE.md rule 9 ("tests encode the invariant, not the call"):
- `AllSuccessful` — 3 reviews, 3 outputs, HasMergeable, Failed=0
- `AllFailed` — every Error non-nil, ClassifyZero = AllFailed
- `AllSucceededButEmpty` — every Error nil but no Output, ClassifyZero = AllEmpty (the historical bug-2 case)
- `MixedFailedAndEmpty` — one crashed, one empty, ClassifyZero = Mixed
- `SaveReviewFailedWithOutput_StillMergeable` — Error != nil but Output != "", HasMergeable=true (the historical bug-1 case)
- `MixedShapeBothViewsDiverge` — Successful=1, WithOutput=2, both views genuinely diverge
- `Empty` — nil input handled

## Test plan

- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean
- [x] Pre-push self-review via `./local-review review main --only claude` — 0 blocking findings on `5156359`

🤖 Generated with [Claude Code](https://claude.com/claude-code)