### PR TITLE
cleanup: remove dead matchGlob, errLabel, name params (audit/tech-debt #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Dead code + dead parameters surfaced by v0.10.0's `audit/tech-debt.md`.** Three small deletions, no user-visible behavior change, opens the v0.10.2 burn-down on the audit's outstanding findings. (1) `internal/review/review.go` — removed the unused `matchGlob(path, pattern string) bool` function. It was lower-case (private), claimed in its doc comment to be "kept for back-compat with any external caller," but private functions have no external callers; production filtering goes through `compileGlobs` + `matchesAnyCompiled` (amortises regex compilation across the diff), tests go through `matchesAny`. Audit flagged it as dead code on `review.go:306-315`; the audit's framing was right. (2) `internal/cli/invoker.go` — removed the unused `errLabel string` parameter from `ClaudeInvoker.run` and its two callers (`Review`, `RunPrompt`). Pre-fix the parameter was passed in by every caller and explicitly discarded via `_ = errLabel` — a vestige of a pre-v0.7 "claude review failed:" prefix that the runner's per-LLM completion line now owns. CodexInvoker's `runExec` retains its `errLabel` parameter because it still distinguishes pre-invocation errors (temp-file creation) from post-success errors (output-file read), neither of which the runner's per-LLM line covers. (3) `internal/cli/version.go` — removed the unused `name` parameter from `detectVersion(name, path string)`. The function never read `name`; the audit's warning that "parameter suggests the function is name-aware when it's not" was accurate. Doc comment now points future maintainers at the right discriminator (`path`'s basename) if a CLI ever needs version-flag-specific branching.
+
 ## [0.10.1] - 2026-05-25
 
 **Theme: fail fast on the slow path.**

--- a/internal/cli/detector.go
+++ b/internal/cli/detector.go
@@ -112,7 +112,7 @@ func detectWithBinary(name, binaryName string) LLM {
 	}
 
 	// Extract version (may return "unknown" if version detection fails)
-	version := detectVersion(name, path)
+	version := detectVersion(path)
 
 	return LLM{
 		Name:      name,

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -271,11 +271,11 @@ type ClaudeInvoker struct {
 
 func (c *ClaudeInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error) {
 	prompt := buildReviewPrompt(systemPrompt) + "\n\n# Diff\n\n" + diff
-	return c.run(ctx, prompt, "claude review")
+	return c.run(ctx, prompt)
 }
 
 func (c *ClaudeInvoker) RunPrompt(ctx context.Context, prompt string) (string, TokenUsage, error) {
-	return c.run(ctx, prompt, "claude")
+	return c.run(ctx, prompt)
 }
 
 // run is the shared driver. Splits args into "model + stdin prompt" so
@@ -302,7 +302,7 @@ func (c *ClaudeInvoker) RunPrompt(ctx context.Context, prompt string) (string, T
 // text fallback. On error we concatenate stdout+stderr for
 // ClassifyExit so the user-facing message still includes the
 // stderr tail.
-func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (string, TokenUsage, error) {
+func (c *ClaudeInvoker) run(ctx context.Context, prompt string) (string, TokenUsage, error) {
 	args := []string{"--print", "--output-format", "json"}
 	if c.model != "" {
 		args = append(args, "--model", c.model)
@@ -314,10 +314,11 @@ func (c *ClaudeInvoker) run(ctx context.Context, prompt, errLabel string) (strin
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		// errLabel was the old "claude review failed:" / "claude:" prefix
-		// — the caller's per-LLM line already names the agent so the
-		// prefix would duplicate.
-		_ = errLabel
+		// No error-label prefix here: the runner's per-LLM completion
+		// line already names the agent ("claude ✗ ..."), so a second
+		// "claude review failed:" prefix on the message would
+		// duplicate. ClassifyExit's output is the user-facing summary;
+		// no caller-side framing needed.
 		combined := append(stdout.Bytes(), stderr.Bytes()...)
 		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, combined, "claude"))
 	}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -8,10 +8,15 @@ import (
 	"time"
 )
 
-// detectVersion runs the version command for each CLI and extracts the version number.
-// Returns "unknown" if version detection fails.
-// All supported CLIs use --version flag.
-func detectVersion(name, path string) string {
+// detectVersion runs the version command for the CLI at `path` and
+// extracts a parseable version number. Returns "unknown" if the
+// command fails or the output doesn't match any pattern.
+//
+// All supported CLIs use the `--version` flag; if a future CLI
+// diverges (e.g. `--ver`, `version` subcommand), branch here on
+// path's basename rather than the agent name — the path is what
+// determines which binary's flag format we're calling.
+func detectVersion(path string) string {
 	return runVersionCmd(path, "--version")
 }
 

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -272,16 +272,17 @@ func FilterDiffs(diffs []git.Diff, include, exclude []string) []git.Diff {
 // matching any ExcludeGlob.
 //
 // Compiles each pattern to a regex exactly once before the per-file
-// loop. Pre-fix matchGlob did regexp.Compile inside the inner loop —
-// for a 500-file repo with 5 globs that's 2,500 compiles. Now it's
-// at most len(include)+len(exclude).
+// loop. A naive "compile inside the inner loop" implementation on a
+// 500-file repo with 5 globs would do 2,500 compiles; this is at
+// most len(include)+len(exclude).
 //
 // Include semantics deliberately fail closed: if `include` was
 // non-empty but every pattern failed to compile, we drop everything.
-// The legacy matchGlob path also fail-closed (compile error → no
-// match → file excluded by the include test). Without this guard a
-// user typo'ing the only include rule would silently *expand* the
-// review to every file in the diff.
+// (compileGlobs silently skips uncompilable patterns — see its doc
+// for why; the fail-closed behaviour falls out of "no patterns
+// match" rather than being implemented separately.) Without this
+// guard a user typo'ing the only include rule would silently
+// *expand* the review to every file in the diff.
 func filter(diffs []git.Diff, include, exclude []string) []git.Diff {
 	includeRE := compileGlobs(include)
 	excludeRE := compileGlobs(exclude)
@@ -300,11 +301,11 @@ func filter(diffs []git.Diff, include, exclude []string) []git.Diff {
 }
 
 // compileGlobs converts each pattern to a regex via globToRegex.
-// Patterns that fail to compile are silently dropped (same fail-open
-// behavior as the legacy matchGlob, which returned false on compile
-// error). A failing pattern is invariably a config typo we can't fix
-// from this layer; the user-visible signal is that the glob doesn't
-// match anything.
+// Patterns that fail to compile are silently dropped — a failing
+// pattern is invariably a config typo we can't fix from this layer;
+// the user-visible signal is that the glob doesn't match anything,
+// which combines with filter()'s "include fails closed" semantics
+// to drop everything (rather than silently expand the review).
 func compileGlobs(patterns []string) []*regexp.Regexp {
 	if len(patterns) == 0 {
 		return nil
@@ -327,34 +328,13 @@ func matchesAnyCompiled(path string, res []*regexp.Regexp) bool {
 	return false
 }
 
-// matchesAny is the un-compiled variant kept for tests and any caller
-// that has a string slice handy and doesn't care about per-call regex
-// compile cost. Production filtering goes through compileGlobs +
-// matchesAnyCompiled.
+// matchesAny is the un-compiled variant kept for tests and one-off
+// callers that have a string slice handy and don't care about per-
+// call regex compile cost. Production filtering goes through
+// compileGlobs + matchesAnyCompiled. The glob dialect (anchoring,
+// `**`, character classes) is documented on globToRegex below.
 func matchesAny(path string, patterns []string) bool {
 	return matchesAnyCompiled(path, compileGlobs(patterns))
-}
-
-// matchGlob is a tiny glob matcher with `**` support. Kept for tests
-// and back-compat with any external caller; production filtering uses
-// compileGlobs + matchesAnyCompiled to amortize regex compilation
-// across all paths in a diff.
-//
-// Semantics:
-//
-//   - `*` matches any chars except '/'
-//   - `**/` matches zero or more path segments (anchored to a path
-//     boundary, so `**/dist/**` does NOT match src/mydist/file)
-//   - `**` matches any chars (including '/'); only at end of pattern
-//   - `?` matches one char except '/'
-//   - `[ab]` / `[a-z]` / `[!ab]` character classes (glob-native,
-//     `[!...]` → `[^...]`)
-func matchGlob(path, pattern string) bool {
-	re, err := regexp.Compile(globToRegex(pattern))
-	if err != nil {
-		return false
-	}
-	return re.MatchString(path)
 }
 
 func globToRegex(pattern string) string {


### PR DESCRIPTION
## Summary

First in a small series of cleanup PRs burning down `audit/tech-debt.md` findings from v0.10.0. Pure deletion / dead-parameter removal, no user-visible behavior change.

## Changes

| Finding | File:line | Action |
| --- | --- | --- |
| `major` dead code | `internal/review/review.go:338-358` | Remove `matchGlob` (private function claiming to be "kept for back-compat with external caller" — private functions have no external callers; replaced by `compileGlobs` + `matchesAnyCompiled` for production, `matchesAny` for tests). |
| `major` dead param | `internal/cli/invoker.go` | Remove `errLabel string` from `ClaudeInvoker.run` and its two callers. Pre-fix every site passed it, the function discarded it via `_ = errLabel`. CodexInvoker.runExec keeps its errLabel — it still uses it for pre-invocation (temp-file create) and post-success (output-file read) errors that the runner's per-LLM completion line doesn't cover. |
| `warning` dead param | `internal/cli/version.go:14` | Remove `name string` from `detectVersion(name, path string)`. Function never read it. Doc comment now points future maintainers at `path`'s basename as the right discriminator if a CLI needs version-flag-specific branching. |

Also updated three doc comments in `review.go` (lines 275, 281, 302-307) that referenced the now-deleted `matchGlob` per CLAUDE.md rule 3 ("doc comments describe current behavior").

## Test plan

- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean — all existing tests pass with the deletions, confirming `matchGlob` had no callers and `errLabel`/`name` had no readers
- [x] Pre-push self-review via `./local-review review main --only claude` on `c8a0d1c` — 0 blocking findings, APPROVE recommendation

## Up next in v0.10.2 burn-down

- PR #81 — extract `isBlockingMarkdown` (runner.go:478) + `writeFileWithDirs` (bench.go:195)
- PR #82 — extract `precision`/`recall`/`f1` helpers in `internal/bench/types.go` so `BaselineScore` and `CaseScore` share scoring math
- PR #83 — release v0.10.2 stamp + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Performed internal code maintenance and cleanup by removing unused code paths and function parameters identified in a technical debt audit. Updated the changelog to document these removals. These improvements enhance code quality, maintainability, and overall readability throughout the internal codebase with no impact to end-user behavior or functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mshykov/local-review/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->