### PR TITLE
release: v0.10.3 — tighten the install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-05-25
+
+**Theme: tighten the install path.**
+
+A focused patch release closing the only remaining `warning`-severity finding from v0.10.0's first audit — `install.sh`'s env-var-only opt-out for skipping checksum verification. The fix is small (~30 lines of shell) but the surface it covers is the project's primary install path (`curl ... | sh`), so worth its own release rather than bundling into a larger v0.11. The TTY-aware probe + `if !` read guards (caught by Copilot mid-review) also harden the failure path against the ENXIO-under-`set -e` crash that would have terminated the script on some non-interactive contexts. Three-LLM review found no issues in this PR's diff; CodeRabbit caught a CHANGELOG header that I had accidentally deleted in an earlier edit. The interplay of reviewers each with their own blind spots is the trust signal.
+
 ### Security
 
 - **`install.sh`: env-var checksum bypass no longer accepts silent opt-out when a TTY is available.** v0.10.0-RC1's `audit/security.md` (single `warning` finding the LLM caught on the stale-binary dogfood) flagged that `INSTALL_REVIEW_SKIP_VERIFICATION=1` could be set silently by a compromised shell rc, parent process, or CI config — forcing an unverified install without the user's explicit awareness. Three-way resolution now: (1) env var set explicitly → proceed with a loud warning (CI's documented escape hatch is preserved); (2) `/dev/tty` available (the common case, true even for `curl | sh` because stdin is the piped script but `/dev/tty` still points to the user's terminal) → prompt `y/N` for explicit acknowledgement that no env var alone could provide; (3) no env var AND no `/dev/tty` (true non-interactive CI without explicit opt-in) → fail loud with the env-var hint, same as pre-v0.10.3. Behaviour is unchanged for users who already pass the env var; the new interactive prompt only fires on the previously-fail-loud branch when a real terminal is reachable, replacing the v0.10.2 "Sorry, can't install — set this env var" wall with a one-key acknowledgement.


### PR DESCRIPTION
## Summary

Stamps `[Unreleased]` → `[0.10.3] - 2026-05-25` with a theme paragraph for PR #84 (`install.sh` security hardening).

## What v0.10.3 ships

| PR | Headline |
|---|---|
| #84 | `fix(install.sh)`: prompt before checksum-skip when `/dev/tty` is available |

Closes the only remaining `warning`-severity finding from v0.10.0's first audit. ~30 lines of shell on the project's primary install path. Worth its own release rather than bundling into v0.11.

## Reviewer-mix note

The 3-LLM review on PR #84's diff found 0 issues IN-DIFF (it surfaced 2 findings on pre-existing code that I spawned as separate tasks — see #84's description). Copilot caught a real `set -e` + ENXIO crash bug on the `/dev/tty` gate during PR review (real bug, fixed in the same PR). CodeRabbit caught a CHANGELOG header I had accidentally deleted in an earlier edit on the same PR (real bug, fixed in the same PR).

Three reviewers, three different blind spots, three different real findings — the redundancy IS the trust signal. Worth documenting as we shape the v1.0 review story.

## Test plan

- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean
- [ ] After merge: dispatch `release.yml` with `version=v0.10.3` (workflow's manual path, same as v0.10.0/.1/.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)