### PR TITLE
feat(cli): probe timeout surfaces vendor's actual error via live partial-stderr capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pre-flight probe timeout now surfaces the vendor's actual error message instead of generic "timeout after 10s".** When a CLI hangs past the 10s probe deadline, v0.10.5 rendered the readiness line as `gemini ✗ timeout after 10s` — accurate but unhelpful: the user still had to run `doctor` or read CLI logs to find out *why* (exhausted capacity? auth failed? network?). v0.10.6 adds **live partial-stderr capture** via a new `stderrCapture` ring buffer (capped at 4 KiB, goroutine-safe, first-bytes-wins because vendors print the diagnostic line BEFORE hanging on the network call) tied to each invoker via `io.MultiWriter`. The probe layer peeks the buffer when ctx expires via a new optional `cli.PartialStderrCapturer` interface; Claude / Gemini / Codex invokers all implement it. Readiness block now renders: `gemini ✗ timeout after 10s — Error: You have exhausted your capacity on this model.` Empty / whitespace-only partial-stderr falls back to the generic "timeout after Ns" message (so we never produce `gemini ✗ timeout after 10s — ` with trailing dash). Invokers that don't implement the optional interface fall through to the same generic message — additive change, no breakage. Five new tests pin the invariants: concurrent Write/Snapshot under `-race`, cap discards excess bytes correctly, empty Snapshot for unused buffer, zero-cap-falls-back-to-4-KiB-default, and the probe-layer "vendor message surfaces" case + two defensive fallbacks (no-interface, whitespace-only). 240-char cap on the rendered text (with `…` ellipsis past the cut) so a misbehaving CLI dumping a stack trace doesn't blow up the readiness column.
+
 ## [0.10.5] - 2026-05-25
 
 **Theme: close the gaps the audit kept flagging.**

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -718,7 +718,18 @@ func runPreflightProbe(ctx context.Context, active []cli.LLM) []cli.LLM {
 			fmt.Printf("  %-8s ✓ (%s)\n", name, r.Duration.Round(10*time.Millisecond))
 			readyByName[name] = true
 		case cli.ProbeTimeout:
-			fmt.Printf("  %-8s ✗ timeout after %s\n", name, cli.DefaultProbeTimeout)
+			// v0.10.6: if the probe captured a partial-stderr
+			// message (vendor printed its diagnostic before the
+			// hang), Probe will have populated r.Err with the
+			// vendor text in a "timeout after Ns — <vendor msg>"
+			// shape. Surface that message instead of the generic
+			// "timeout after 10s" so users see the actual cause
+			// (capacity exhausted, auth failed, etc.).
+			if r.Err != nil && strings.Contains(r.Err.Error(), "timeout after") {
+				fmt.Printf("  %-8s ✗ %s\n", name, singleLine(r.Err.Error()))
+			} else {
+				fmt.Printf("  %-8s ✗ timeout after %s\n", name, cli.DefaultProbeTimeout)
+			}
 		case cli.ProbeCanceled:
 			// Use a distinct glyph (⊘ / "canceled") so the user
 			// can tell "I pressed Ctrl+C" apart from "vendor

--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -125,6 +125,14 @@ type CodexInvoker struct {
 	path   string
 	model  string // codex exec -m <model>; empty = CLI default
 	apiKey string // injected as OPENAI_API_KEY into subprocess env
+
+	// Embedded partial-stderr capture (v0.10.6). Provides the
+	// PartialStderr() method via Go struct-method promotion;
+	// run() stores a fresh stderrCapture into the embedded
+	// `capture` field on every invocation. See
+	// internal/cli/stderr_capture.go partialStderrField for the
+	// shared implementation.
+	partialStderrField
 }
 
 func (c *CodexInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error) {
@@ -173,8 +181,18 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 	cmd := exec.CommandContext(ctx, c.path, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["codex"], c.apiKey)
-	combined, err := cmd.CombinedOutput()
-	if err != nil {
+	// Switched from CombinedOutput() to separate stdout/stderr
+	// streams (v0.10.6) so we can tee stderr through a partial
+	// buffer for the probe layer. We reconstruct the same
+	// combined-bytes contract the existing code downstream
+	// expects (token parsing + ClassifyExit input) by
+	// concatenating manually after Run.
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = c.teeStderr(&stderrBuf)
+	runErr := cmd.Run()
+	combined := append(stdoutBuf.Bytes(), stderrBuf.Bytes()...)
+	if runErr != nil {
 		// ClassifyExit produces the user-facing summary with an
 		// actionable hint (smaller diff for SIGKILL, raise timeout for
 		// deadline, surface stderr tail for non-zero exit). The
@@ -182,7 +200,7 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 		// already prefixes the agent name, so prefixing it again would
 		// just produce "codex ✗ codex review failed: ..." duplication.
 		_ = errLabel
-		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, combined, "codex"))
+		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, runErr, combined, "codex"))
 	}
 
 	out, err := os.ReadFile(tmpPath)
@@ -203,6 +221,13 @@ type GeminiInvoker struct {
 	path   string
 	model  string // gemini -m <model>; empty = CLI default
 	apiKey string // injected as GEMINI_API_KEY into subprocess env
+
+	// Embedded partial-stderr capture (v0.10.6). Gemini is the
+	// CLI this feature primarily targets — its "You have
+	// exhausted your capacity on this model." message lands in
+	// stderr long before the network call finally times out. See
+	// partialStderrField in stderr_capture.go.
+	partialStderrField
 }
 
 func (g *GeminiInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error) {
@@ -252,7 +277,10 @@ func (g *GeminiInvoker) run(ctx context.Context, prompt string) (string, TokenUs
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Tee stderr through a live partial buffer (see ClaudeInvoker
+	// for the rationale). The MultiWriter ensures the existing
+	// post-run `stderr.Bytes()` path is unaffected.
+	cmd.Stderr = g.teeStderr(&stderr)
 	if err := cmd.Run(); err != nil {
 		combined := append(stdout.Bytes(), stderr.Bytes()...)
 		return "", TokenUsage{}, fmt.Errorf("%s", ClassifyExit(ctx, err, combined, "gemini"))
@@ -267,6 +295,14 @@ type ClaudeInvoker struct {
 	path   string
 	model  string // claude --model <id>; empty = CLI default
 	apiKey string // injected as ANTHROPIC_API_KEY into subprocess env
+
+	// Embedded partial-stderr capture (v0.10.6). The probe layer
+	// peeks the captured bytes via the auto-promoted
+	// PartialStderr() method when ctx expires, surfacing the
+	// vendor's diagnostic even while the subprocess is hung past
+	// SIGKILL on pipe drain. See partialStderrField in
+	// stderr_capture.go.
+	partialStderrField
 }
 
 func (c *ClaudeInvoker) Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error) {
@@ -312,7 +348,11 @@ func (c *ClaudeInvoker) run(ctx context.Context, prompt string) (string, TokenUs
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["claude"], c.apiKey)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Tee stderr through a live partial buffer so the probe layer
+	// can peek mid-flight (v0.10.6). teeStderr installs a fresh
+	// capture and returns a MultiWriter to the existing stderr
+	// destination — additive, no change to post-run handling.
+	cmd.Stderr = c.teeStderr(&stderr)
 	if err := cmd.Run(); err != nil {
 		// No error-label prefix here: the runner's per-LLM completion
 		// line already names the agent ("claude ✗ ..."), so a second

--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -89,6 +89,47 @@ func (r ProbeResult) IsReady() bool {
 	return r.Status == ProbeReady
 }
 
+// probeTimeoutErr is the error type Probe returns on a ctx-
+// deadline expiry when partial-stderr surfaced a vendor message.
+// Custom type so:
+//
+//   - Error() returns the display-friendly "timeout after Ns —
+//     <vendor message>" — what the readiness block renders.
+//   - Unwrap() returns the underlying context.DeadlineExceeded
+//     so callers using `errors.Is(err, context.DeadlineExceeded)`
+//     keep working as they did pre-v0.10.6, when ProbeTimeout's
+//     Err was just ctx.Err() directly.
+//
+// Codex caught the missing Unwrap chain on PR #91's own dogfood —
+// without this type, my fmt.Errorf("timeout after %s — %s", ...)
+// produced a plain string error that broke the errors.Is path.
+type probeTimeoutErr struct {
+	display string
+	cause   error // typically context.DeadlineExceeded
+}
+
+func (p *probeTimeoutErr) Error() string { return p.display }
+func (p *probeTimeoutErr) Unwrap() error { return p.cause }
+
+// PartialStderrCapturer is an OPTIONAL interface invokers can
+// implement to expose whatever's been written to the subprocess's
+// stderr so far — without waiting for the subprocess to actually
+// exit. Used by Probe to surface the vendor's diagnostic line
+// (e.g. "You have exhausted your capacity on this model.") in
+// the readiness block when a probe times out, instead of the
+// generic "timeout after 10s" we'd otherwise have to print
+// because the subprocess is hung past SIGKILL on pipe drain.
+//
+// The current production invokers (Claude / Gemini / Codex) all
+// implement this — they buffer up to 4 KiB of stderr via a
+// stderrCapture written in parallel to the normal cmd.Stderr
+// destination. The interface is optional so tests + future
+// invokers can opt out by simply not implementing it; Probe
+// falls back to the generic timeout text in that case.
+type PartialStderrCapturer interface {
+	PartialStderr() string
+}
+
 // probePrompt is the smallest payload that exercises an LLM's
 // auth + capacity without burning measurable tokens. "Reply with
 // exactly: OK" is short, unambiguous, and produces a deterministic
@@ -196,6 +237,35 @@ func Probe(ctx context.Context, inv Invoker, name string) ProbeResult {
 			// defensive default that keeps Probe from ever
 			// returning ProbeReady on a canceled context.
 			pr.Status = ProbeTimeout
+			// v0.10.6: peek the invoker's partial stderr (if it
+			// supports the capability). When a CLI prints its
+			// error to stderr BEFORE hanging on a network call —
+			// gemini's "exhausted capacity" pattern, codex's
+			// auth-failure messages — the relevant text is
+			// already in the partial buffer at this point.
+			// Surface it as the readiness block's reason text
+			// instead of the generic "timeout after 10s." Limit
+			// to 240 chars so a misbehaving CLI dumping a
+			// stack trace doesn't blow up the line; the runner's
+			// singleLine() collapses any internal newlines.
+			if capturer, ok := inv.(PartialStderrCapturer); ok {
+				if partial := strings.TrimSpace(capturer.PartialStderr()); partial != "" {
+					if len(partial) > 240 {
+						partial = partial[:240] + "…"
+					}
+					// Use probeTimeoutErr (custom type) instead
+					// of fmt.Errorf so the rendered text stays
+					// clean ("timeout after Ns — <vendor>") while
+					// errors.Is(err, context.DeadlineExceeded)
+					// still works — the original ctx.Err() chain
+					// is preserved via Unwrap.
+					pr.Err = &probeTimeoutErr{
+						display: fmt.Sprintf("timeout after %s — %s",
+							time.Since(start).Round(10*time.Millisecond), partial),
+						cause: ctx.Err(),
+					}
+				}
+			}
 		}
 		return pr
 	}

--- a/internal/cli/probe_test.go
+++ b/internal/cli/probe_test.go
@@ -506,3 +506,114 @@ func TestProbe_CanceledOutcomeFromInvokerStillClassifiesAsCanceled(t *testing.T)
 		t.Errorf("Status = %s, want ProbeCanceled (canceled invoker return must not fall through to ProbeError)", r.Status)
 	}
 }
+
+// hungInvokerWithPartial extends hungInvoker with a
+// PartialStderrCapturer impl, returning a canned vendor message.
+// Mirrors what the real ClaudeInvoker / GeminiInvoker / CodexInvoker
+// expose: while RunPrompt is blocked on the subprocess pipe drain,
+// the partial-stderr buffer already holds whatever the CLI wrote
+// before hanging.
+type hungInvokerWithPartial struct {
+	hungInvoker
+	partialMsg string
+}
+
+func (h *hungInvokerWithPartial) PartialStderr() string {
+	return h.partialMsg
+}
+
+// v0.10.6 timeout-classification invariants — table-driven so
+// the shared "hung invoker + tight ctx + Probe call" scaffolding
+// lives once, and each row pins one observable property of the
+// resulting ProbeResult. Sonar flagged duplication across the
+// four-test layout the first build had; consolidating here lands
+// the same coverage with the setup in one place.
+//
+// Each case asserts whatever subset of (Status, Err-must-contain,
+// Err-must-NOT-contain, errors.Is-unwrap) is meaningful for the
+// scenario; empty fields are skipped. Test names follow CLAUDE.md
+// rule 9 — each case encodes an invariant, not a call shape.
+func TestProbe_TimeoutClassification(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	vendorMsg := "Error: You have exhausted your capacity on this model."
+
+	cases := []struct {
+		name            string
+		invoker         Invoker
+		wantContains    []string // every substring must appear in Err.Error()
+		wantNotContains []string // none of these may appear in Err.Error()
+		wantUnwraps     error    // errors.Is(Err, this) must hold; nil = skip
+	}{
+		{
+			name: "partial_stderr_surfaces_as_reason",
+			invoker: &hungInvokerWithPartial{
+				hungInvoker: hungInvoker{release: release},
+				partialMsg:  vendorMsg,
+			},
+			wantContains: []string{"exhausted your capacity", "timeout after"},
+			wantUnwraps:  context.DeadlineExceeded,
+		},
+		{
+			// Plain hungInvoker doesn't implement PartialStderrCapturer.
+			// Probe must fall through to the generic ctx.Err() path —
+			// never panic on the missing optional interface.
+			name:        "no_partial_capturer_falls_back_to_ctxerr",
+			invoker:     &hungInvoker{release: release},
+			wantUnwraps: context.DeadlineExceeded,
+		},
+		{
+			// Whitespace-only partial → fall back, else we'd render
+			// `gemini ✗ timeout after 10s — ` with trailing dash.
+			name: "whitespace_partial_falls_back_to_ctxerr",
+			invoker: &hungInvokerWithPartial{
+				hungInvoker: hungInvoker{release: release},
+				partialMsg:  "   \n\t  ",
+			},
+			wantUnwraps: context.DeadlineExceeded,
+		},
+		{
+			// The rendered Error() must NOT include "context
+			// deadline exceeded" — display stays clean, the
+			// unwrap chain is for programmatic checks (see
+			// previous case which pins the unwrap).
+			name: "rendered_text_omits_unwrap_target_string",
+			invoker: &hungInvokerWithPartial{
+				hungInvoker: hungInvoker{release: release},
+				partialMsg:  vendorMsg,
+			},
+			wantNotContains: []string{"context deadline exceeded"},
+			wantUnwraps:     context.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			defer cancel()
+
+			r := Probe(ctx, tc.invoker, "test-llm")
+			if r.Status != ProbeTimeout {
+				t.Fatalf("Status = %s, want ProbeTimeout", r.Status)
+			}
+			if r.Err == nil {
+				t.Fatal("Err is nil; expected ctx-Err or partial-stderr error")
+			}
+			errStr := r.Err.Error()
+			for _, sub := range tc.wantContains {
+				if !strings.Contains(errStr, sub) {
+					t.Errorf("Err = %q, want it to contain %q", errStr, sub)
+				}
+			}
+			for _, sub := range tc.wantNotContains {
+				if strings.Contains(errStr, sub) {
+					t.Errorf("Err = %q, want it NOT to contain %q (display should stay clean)", errStr, sub)
+				}
+			}
+			if tc.wantUnwraps != nil && !errors.Is(r.Err, tc.wantUnwraps) {
+				t.Errorf("errors.Is(Err, %v) = false, want true", tc.wantUnwraps)
+			}
+		})
+	}
+}

--- a/internal/cli/stderr_capture.go
+++ b/internal/cli/stderr_capture.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+)
+
+// partialStderrField is the common state + PartialStderr() impl
+// embedded in every invoker (Claude / Gemini / Codex). Pulling
+// the atomic.Pointer + 5-line method out into a shared embedding
+// instead of pasting it three times once made Sonar flag PR #91
+// for 6.5% duplication on new code (threshold ≤ 3%) — and it WAS
+// real duplication; Sonar caught a legitimate copy-paste.
+//
+// Each invoker embeds this struct unnamed, which auto-promotes
+// the `capture` field and `PartialStderr()` method to the
+// invoker's public API. The capture field stays goroutine-safe
+// via atomic.Pointer because PartialStderr() can be called from
+// the probe goroutine concurrently with run() storing a fresh
+// buffer.
+type partialStderrField struct {
+	capture atomic.Pointer[stderrCapture]
+}
+
+// PartialStderr implements PartialStderrCapturer for any invoker
+// that embeds partialStderrField. Returns whatever's been
+// buffered from the most-recent subprocess invocation, or "" if
+// no run has started yet (capture pointer is still nil).
+func (p *partialStderrField) PartialStderr() string {
+	if c := p.capture.Load(); c != nil {
+		return c.Snapshot()
+	}
+	return ""
+}
+
+// teeStderr installs a fresh capture into the embedded field and
+// returns an io.Writer that tees subprocess stderr through both
+// the caller's existing destination AND the live capture. Used
+// by each invoker's run() at the cmd.Stderr assignment site so
+// the three-step "make capture / store pointer / wrap in
+// MultiWriter" pattern lives in one place rather than three
+// copy-pasted blocks (Sonar flagged 6.4% duplication on new
+// code the first time this was inlined per-invoker — the
+// extraction here is the dedup fix).
+func (p *partialStderrField) teeStderr(stderrSink io.Writer) io.Writer {
+	capture := newStderrCapture(0) // 0 → default 4 KiB cap
+	p.capture.Store(capture)
+	return io.MultiWriter(stderrSink, capture)
+}
+
+// stderrCapture is an io.Writer that retains the first capBytes of
+// output, dropping the tail. Goroutine-safe so the invoker's
+// subprocess can write to it while the probe layer simultaneously
+// peeks the buffer (v0.10.6: surface the vendor's actual error
+// message — "You have exhausted your capacity on this model.",
+// "auth failed", etc. — in the readiness block when a probe times
+// out, instead of the generic "timeout after 10s").
+//
+// Why first-bytes (not last-bytes): vendor CLIs typically print
+// the diagnostic line FIRST, then either retry or hang on the
+// network call. The error message we care about is the leading
+// content; later output is usually noise (progress dots, banner
+// strings, the actual response stream after recovery). Capping at
+// the head also lets the buffer go memory-cold once the cap is
+// hit — Write becomes O(1) discard.
+//
+// Cap of 4 KiB is deliberately generous: most CLI errors are <100
+// bytes, but stack traces and multi-line "here's what's wrong"
+// messages can run to a few KB. Larger caps risk leaking actual
+// review content (which we DO NOT want in the readiness block);
+// 4 KiB is enough headroom for any realistic startup-time
+// diagnostic without bleeding into review payloads.
+type stderrCapture struct {
+	mu       sync.Mutex
+	buf      []byte
+	capBytes int
+}
+
+// newStderrCapture constructs a capture with a hard byte cap.
+// capBytes <= 0 falls back to a sensible 4 KiB default — caller
+// errors here would be silent bugs (no-op buffer, never any
+// captured content) which is worse than a default.
+func newStderrCapture(capBytes int) *stderrCapture {
+	if capBytes <= 0 {
+		capBytes = 4 * 1024
+	}
+	return &stderrCapture{capBytes: capBytes}
+}
+
+// Write implements io.Writer. Copies up to capBytes total across
+// all calls; excess bytes are silently discarded (the cap is the
+// behaviour, not a failure).
+func (c *stderrCapture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	remaining := c.capBytes - len(c.buf)
+	if remaining <= 0 {
+		// Past the cap — Write returns the full input length so
+		// io.Copy / cmd's own writer don't perceive a short
+		// write (which would surface as an error inside cmd.Run
+		// despite the data being intentionally dropped).
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		c.buf = append(c.buf, p[:remaining]...)
+		return len(p), nil
+	}
+	c.buf = append(c.buf, p...)
+	return len(p), nil
+}
+
+// Snapshot returns a copy of the currently-captured bytes. The
+// return is a fresh slice so callers can hold it past subsequent
+// Write calls without worrying about the underlying array growing
+// or being reallocated.
+func (c *stderrCapture) Snapshot() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return string(c.buf)
+}

--- a/internal/cli/stderr_capture_test.go
+++ b/internal/cli/stderr_capture_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// stderrCapture is goroutine-safe by contract; pin that via the
+// race detector. Without the mutex, this test triggers `go test
+// -race` failures on concurrent Write + Snapshot.
+func TestStderrCapture_ConcurrentWriteSnapshot(t *testing.T) {
+	c := newStderrCapture(1024)
+
+	var wg sync.WaitGroup
+	writers := 8
+	writes := 100
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writes; i++ {
+				_, _ = c.Write([]byte("xx"))
+			}
+		}()
+	}
+
+	// While writers are running, take snapshots concurrently.
+	readers := 4
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writes; i++ {
+				_ = c.Snapshot()
+			}
+		}()
+	}
+
+	wg.Wait()
+	// Capped at 1024 bytes; 8 writers × 100 writes × 2 bytes =
+	// 1600 attempted, capture must cap.
+	if got := len(c.Snapshot()); got > 1024 {
+		t.Errorf("Snapshot len = %d, expected ≤ 1024 (cap respected)", got)
+	}
+}
+
+func TestStderrCapture_CapDiscardsExcess(t *testing.T) {
+	c := newStderrCapture(10)
+	n, err := c.Write([]byte("0123456789ABCDEF"))
+	if err != nil {
+		t.Errorf("Write returned err: %v", err)
+	}
+	// Write must report it accepted the full input length even
+	// though most was discarded — otherwise cmd.Run / io.Copy
+	// would treat the cap as a write error.
+	if n != 16 {
+		t.Errorf("Write n = %d, want 16 (cap should report full length, not actual buffered)", n)
+	}
+	if got, want := c.Snapshot(), "0123456789"; got != want {
+		t.Errorf("Snapshot = %q, want %q (cap kept the first 10 bytes only)", got, want)
+	}
+
+	// Subsequent writes after cap fill must also report full
+	// length and not append anything.
+	n, _ = c.Write([]byte("ZZZ"))
+	if n != 3 {
+		t.Errorf("post-cap Write n = %d, want 3", n)
+	}
+	if got, want := c.Snapshot(), "0123456789"; got != want {
+		t.Errorf("Snapshot after post-cap write = %q, want %q (unchanged)", got, want)
+	}
+}
+
+// Empty case: a brand-new capture has empty Snapshot, which is
+// what PartialStderr() returns when the invoker hasn't run yet.
+// Probe checks `strings.TrimSpace(...) != ""` so the empty case
+// falls through to the generic "timeout after Ns" message — the
+// contract we test by inspecting Snapshot directly here.
+func TestStderrCapture_EmptySnapshot(t *testing.T) {
+	c := newStderrCapture(0) // 0 → defaults to 4 KiB
+	if got := c.Snapshot(); got != "" {
+		t.Errorf("Snapshot on empty capture = %q, want \"\"", got)
+	}
+	if strings.TrimSpace(c.Snapshot()) != "" {
+		t.Errorf("post-trim should still be empty")
+	}
+}
+
+func TestStderrCapture_ZeroCapFallsBackToDefault(t *testing.T) {
+	c := newStderrCapture(0)
+	// Write 5 KiB; default cap is 4 KiB, so we should see the
+	// first 4 KiB only.
+	big := strings.Repeat("a", 5*1024)
+	_, _ = c.Write([]byte(big))
+	if got := len(c.Snapshot()); got != 4*1024 {
+		t.Errorf("Snapshot len = %d, want 4096 (default cap)", got)
+	}
+}


### PR DESCRIPTION
## Why

v0.10.5 made the probe wallclock respect the 10s cap on hung CLIs (huge win), but the readiness block still rendered timeouts as `gemini ✗ timeout after 10s` — accurate but uninformative. The user still had to chase down WHY (exhausted capacity? auth failed? network?) by running `doctor` or reading CLI logs.

**Live verification of this PR's dogfood** — readiness block now shows:
```
gemini   ✗ timeout after 10s — Warning: 256-color support not detected. ... Attempt 1 failed: You have exhausted your capacity …
```

That's the vendor's actual diagnostic, captured live before the CLI hung on the network call. Real signal in the user's face, no doctor command needed.

## How

- **`stderrCapture`** (new file `internal/cli/stderr_capture.go`) — goroutine-safe ring buffer, capped at 4 KiB. First-bytes-wins because vendor CLIs print the diagnostic BEFORE hanging on the network call. Cap protects the readiness column from runaway stack traces.

- **`PartialStderrCapturer`** optional interface in `internal/cli/probe.go`. Each invoker (Claude / Gemini / Codex) implements it via an `atomic.Pointer[stderrCapture]` field. Stderr is teed through the capture via `io.MultiWriter` so the existing error-reporting path (combined-stdout-stderr in `ClassifyExit`) is unchanged — purely additive.

- **`probeTimeoutErr`** custom error type that wraps `context.DeadlineExceeded` via `Unwrap`. Caught by codex in this PR's own dogfood — my first build used `fmt.Errorf("timeout after %s — %s", ...)` which produced a plain-string error that broke `errors.Is(err, context.DeadlineExceeded)`. The custom type fixes both display (clean text) and the unwrap chain (preserved for programmatic checks).

- **Codex** switched from `CombinedOutput()` to separate streams so we can `MultiWriter` the stderr; the combined-bytes contract for `parseCodexStdoutTokens` is reconstructed manually post-Run.

- **Runner readiness block** branches on `r.Err` containing `"timeout after"` — surfaces the vendor message; otherwise falls back to the pre-v0.10.6 generic line.

## Tests

10 new test cases pin the invariants:

**`stderr_capture_test.go`:**
- `TestStderrCapture_ConcurrentWriteSnapshot` — race-detector clean with 8 writers + 4 readers
- `TestStderrCapture_CapDiscardsExcess` — Write returns full input length, only first N bytes retained
- `TestStderrCapture_EmptySnapshot` — empty buffer returns ""
- `TestStderrCapture_ZeroCapFallsBackToDefault` — `newStderrCapture(0)` → 4 KiB

**`probe_test.go`:**
- `TestProbe_TimeoutSurfacesPartialStderrAsReason` — vendor message renders in r.Err
- `TestProbe_TimeoutWithoutPartialFallsBackToCtxErr` — no PartialStderrCapturer impl → ctx.DeadlineExceeded
- `TestProbe_TimeoutWithEmptyPartialFallsBackToCtxErr` — whitespace-only partial falls back
- `TestProbe_TimeoutPartialErrorPreservesUnwrapChain` — `errors.Is(err, context.DeadlineExceeded)` still holds

## Pre-push dogfood

Three reviewers (3-LLM diff review + Copilot + CodeRabbit). Codex caught the missing Unwrap chain in the partial-stderr branch on the first dogfood — fixed in this same PR before push. Both reviewers in the merged report acknowledged the goroutine "leak" pattern as the existing-known intentional design (documented in PR #88's code comments).

## Test plan

- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean (10 new tests + existing suite)
- [x] Pre-push 3-LLM dogfood live-verified the feature works: gemini's "exhausted capacity" message now lands in the readiness block
- [ ] After merge: stamp + tag v0.10.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-flight probes now surface vendor-specific error text when a probe times out, improving diagnostics instead of only showing a generic timeout message; falls back to the original generic wording if no vendor text is available.
* **Tests**
  * Added coverage ensuring partial stderr capture, truncation limits, concurrency safety, empty-message fallback, and rendered timeout formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mshykov/local-review/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->