### PR TITLE
feat(cli): --preflight-timeout flag + silent-timeout hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--preflight-timeout <duration>` flag.** First-customer dogfood on the v0.10.6 build showed `claude ✗ timeout after 10s` with no vendor diagnostic — claude-code's cold-start on a loaded host can exceed the 10s probe cap before the CLI writes anything to stderr. Bumping with `--preflight-timeout 20s` rescues those runs without forcing `--no-preflight` (which loses the readiness signal entirely). Default unchanged (10s); the flag exists as the "cold-start escape hatch" — `--no-preflight` is still the "CI / scripting" escape hatch.
+
+### Changed
+
+- **Bare-timeout readiness line now includes a "no diagnostic captured" hint.** Pre-fix `claude ✗ timeout after 10s` read identically to a vendor-message-present timeout, leaving users unable to tell silent-claude apart from gemini-with-vendor-message. The readiness block now appends `(no diagnostic captured — run \`local-review doctor\`, or raise --preflight-timeout)` to bare-timeout lines, pointing at the two most common fixes. Vendor-message-present timeouts (the v0.10.6 path) are unchanged — they already surface the vendor's actual text. Also the rendered timeout now reflects the configured `--preflight-timeout` value instead of always saying "10s"; pinned by `TestFormatProbeLine/timeout_renders_configured_timeout_not_default`.
+
 ## [0.10.7] - 2026-05-26
 
 **Theme: catch the docs up to the code.**

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -98,6 +99,17 @@ type sharedFlags struct {
 	// Default is to run the probe; the flag exists as an escape
 	// hatch, not as a routine knob.
 	noPreflight bool
+
+	// v0.10.8 per-LLM probe deadline override. Zero falls back to
+	// cli.DefaultProbeTimeout (10s) — the empirical balance for a
+	// healthy CLI's startup + minimal response. Raise via
+	// `--preflight-timeout 20s` when claude-code is cold-starting
+	// on a slow disk / loaded host and consistently times out at
+	// 10s with no diagnostic captured (the silent-claude case the
+	// first-customer dogfood surfaced). 0 stays as "use the
+	// package default" rather than "infinite" — the probe always
+	// needs SOME cap or the v0.10.1 4-minute-gemini-hang regresses.
+	preflightTimeout time.Duration
 }
 
 func main() {
@@ -202,6 +214,17 @@ See README and https://mshykov.github.io/local-review/ for details.`,
 	// can't afford the ~1k probe tokens per LLM. Not a routine
 	// knob; the default-on behaviour is the recommended path.
 	root.PersistentFlags().BoolVar(&sf.noPreflight, "no-preflight", false, "skip the per-LLM readiness probe before review (default: probe enabled)")
+
+	// Per-LLM probe deadline override (v0.10.8). The 10s default
+	// is tight on purpose — too long defeats the "fast feedback"
+	// point of the probe. But some environments (corporate
+	// laptops with slow disks, cold-cache claude-code) consistently
+	// time out at 10s with NO vendor diagnostic captured because
+	// the CLI hasn't written anything to stderr yet. Letting the
+	// user bump to 15-20s rescues those runs without forcing
+	// --no-preflight (which loses the readiness signal entirely).
+	// Zero / unset falls back to cli.DefaultProbeTimeout.
+	root.PersistentFlags().DurationVar(&sf.preflightTimeout, "preflight-timeout", 0, "per-LLM probe deadline (default: 10s); raise when CLIs cold-start past the default")
 
 	// Group commands so --help reads as three sections (Review / Setup /
 	// Other) instead of one alphabetical wall. Cobra renders any command

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -231,7 +231,16 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	// want the extra ~10s + ~1k tokens per LLM. Reserved escape
 	// hatch — not the recommended path.
 	if !sf.noPreflight {
-		active = runPreflightProbe(ctx, active)
+		// Resolve the per-LLM probe timeout: explicit --preflight-
+		// timeout wins; 0/unset falls back to cli.DefaultProbeTimeout
+		// (10s). The runner — not Probe — owns this resolution so
+		// the readiness-block render can show the actual configured
+		// value, not the package default.
+		probeTimeout := sf.preflightTimeout
+		if probeTimeout <= 0 {
+			probeTimeout = cli.DefaultProbeTimeout
+		}
+		active = runPreflightProbe(ctx, active, probeTimeout)
 		// Short-circuit on user interrupt / parent context cancel.
 		// Pre-fix the runner's only check was len(active) == 0,
 		// which would surface "every active LLM failed pre-flight"
@@ -692,14 +701,19 @@ func printAgentRoster(active []cli.LLM, configDisabled []string, cfg config.Conf
 // with the per-LLM failure line.
 //
 // Goroutine + timeout posture: ProbeAll fans out internally with
-// per-LLM cli.DefaultProbeTimeout deadlines. Empirically 10s is
-// generous for a healthy CLI's startup + minimal response;
+// per-LLM deadlines bounded by `timeout`. The caller resolves
+// the actual value (--preflight-timeout flag overrides
+// cli.DefaultProbeTimeout); runPreflightProbe just receives it
+// pre-resolved so the readiness-block render can show the
+// CONFIGURED value, not a hard-coded default that would lie when
+// the user passed --preflight-timeout. Empirically the default
+// 10s is generous for a healthy CLI's startup + minimal response;
 // shortening it would catch slow but recoverable CLIs as
 // false-positive timeouts.
-func runPreflightProbe(ctx context.Context, active []cli.LLM) []cli.LLM {
+func runPreflightProbe(ctx context.Context, active []cli.LLM, timeout time.Duration) []cli.LLM {
 	fmt.Println("Pre-flight (probing auth + capacity):")
 	probeStart := time.Now()
-	results := cli.ProbeAll(ctx, active, cli.DefaultProbeTimeout)
+	results := cli.ProbeAll(ctx, active, timeout)
 	probeDuration := time.Since(probeStart)
 
 	// Build a quick name → index map so we can filter `active`
@@ -713,40 +727,10 @@ func runPreflightProbe(ctx context.Context, active []cli.LLM) []cli.LLM {
 		// a-glance UX, same as the per-LLM completion lines.
 		// printf's %-Ns padding does this in one format call.
 		name := r.LLM
-		switch r.Status {
-		case cli.ProbeReady:
-			fmt.Printf("  %-8s ✓ (%s)\n", name, r.Duration.Round(10*time.Millisecond))
+		line := formatProbeLine(r, timeout)
+		fmt.Println(line)
+		if r.Status == cli.ProbeReady {
 			readyByName[name] = true
-		case cli.ProbeTimeout:
-			// v0.10.6: if the probe captured a partial-stderr
-			// message (vendor printed its diagnostic before the
-			// hang), Probe will have populated r.Err with the
-			// vendor text in a "timeout after Ns — <vendor msg>"
-			// shape. Surface that message instead of the generic
-			// "timeout after 10s" so users see the actual cause
-			// (capacity exhausted, auth failed, etc.).
-			if r.Err != nil && strings.Contains(r.Err.Error(), "timeout after") {
-				fmt.Printf("  %-8s ✗ %s\n", name, singleLine(r.Err.Error()))
-			} else {
-				fmt.Printf("  %-8s ✗ timeout after %s\n", name, cli.DefaultProbeTimeout)
-			}
-		case cli.ProbeCanceled:
-			// Use a distinct glyph (⊘ / "canceled") so the user
-			// can tell "I pressed Ctrl+C" apart from "vendor
-			// timed out" at a glance. The runner short-circuits
-			// on ctx.Err() right after this loop returns, so this
-			// branch is mostly for the user's eyes — they see the
-			// readiness block render mid-cancel, then the run
-			// exits with the right reason.
-			fmt.Printf("  %-8s ⊘ canceled\n", name)
-		case cli.ProbeError:
-			// Surface the vendor's own error message (single line
-			// — multi-line stderr tails happen in the real-review
-			// path, not in the readiness block). Strip trailing
-			// whitespace + collapse newlines so a CLI that prints
-			// "error\n at line ..." renders as one tight line.
-			msg := singleLine(r.Err.Error())
-			fmt.Printf("  %-8s ✗ %s\n", name, msg)
 		}
 	}
 	fmt.Printf("Probed %d LLM%s in %s.\n\n", len(active), pluralS(len(active)), probeDuration.Round(10*time.Millisecond))
@@ -759,6 +743,58 @@ func runPreflightProbe(ctx context.Context, active []cli.LLM) []cli.LLM {
 		}
 	}
 	return ready
+}
+
+// formatProbeLine renders one row of the pre-flight readiness
+// block as a single string, ready for fmt.Println. Extracted from
+// the render loop so the rendering rules — especially the v0.10.8
+// "no diagnostic captured" hint and the v0.10.6 vendor-message
+// surfacing — can be unit-tested without needing to capture stdout.
+//
+// The padding width (8 chars on the agent name) matches the
+// per-LLM completion lines later in the run, so the readiness
+// block and the completion summary line up visually as a column.
+// All four ProbeStatus cases are exhaustive — unknown statuses
+// would render the empty default, which is harmless but tests
+// pin the exhaustiveness to catch a future enum addition that
+// forgets to update this function.
+func formatProbeLine(r cli.ProbeResult, timeout time.Duration) string {
+	name := r.LLM
+	switch r.Status {
+	case cli.ProbeReady:
+		return fmt.Sprintf("  %-8s ✓ (%s)", name, r.Duration.Round(10*time.Millisecond))
+	case cli.ProbeTimeout:
+		// v0.10.6: vendor message present → surface it (the
+		// "timeout after Ns — <vendor>" shape produced by
+		// Probe via probeTimeoutErr).
+		// v0.10.8: vendor message absent → append the
+		// "no diagnostic captured" hint so the user knows the
+		// difference between "vendor told us X" and "we got
+		// nothing." The hint also points at the most common
+		// fix (raise --preflight-timeout) so cold-start cases
+		// don't require digging through `doctor` output first.
+		if r.Err != nil && strings.Contains(r.Err.Error(), "timeout after") {
+			return fmt.Sprintf("  %-8s ✗ %s", name, singleLine(r.Err.Error()))
+		}
+		return fmt.Sprintf("  %-8s ✗ timeout after %s (no diagnostic captured — run `local-review doctor`, or raise --preflight-timeout)", name, timeout)
+	case cli.ProbeCanceled:
+		// Distinct glyph (⊘) so the user reads "I pressed
+		// Ctrl+C" rather than "vendor timed out" at a glance.
+		// The runner short-circuits on ctx.Err() right after
+		// the render loop, so this branch is mostly for the
+		// user's eyes mid-cancel.
+		return fmt.Sprintf("  %-8s ⊘ canceled", name)
+	case cli.ProbeError:
+		// Surface the vendor's own error message (single line
+		// — multi-line stderr tails belong in the real-review
+		// path, not the readiness block).
+		return fmt.Sprintf("  %-8s ✗ %s", name, singleLine(r.Err.Error()))
+	default:
+		// Unknown future ProbeStatus: render the agent with
+		// no glyph so the line still appears, surfacing the
+		// integer status via String() for diagnosis.
+		return fmt.Sprintf("  %-8s %s", name, r.Status)
+	}
 }
 
 // singleLine collapses any internal newline / carriage-return

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mshykov/local-review/internal/cli"
 	"github.com/mshykov/local-review/internal/config"
@@ -822,6 +824,104 @@ func TestSingleLine_CollapsesAndTrims(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := singleLine(tc.in); got != tc.want {
 				t.Errorf("singleLine(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// formatProbeLine is the rendering rule for the pre-flight
+// readiness block. v0.10.8 added two behaviours worth pinning:
+// (a) the bare-timeout case appends a "no diagnostic captured"
+// hint pointing at doctor + --preflight-timeout (so users tell
+// silent-claude apart from vendor-message-present timeouts),
+// (b) the rendered timeout uses the CONFIGURED value, not the
+// hard-coded cli.DefaultProbeTimeout (so --preflight-timeout's
+// effect is visible in the rendered line).
+func TestFormatProbeLine(t *testing.T) {
+	cases := []struct {
+		name            string
+		result          cli.ProbeResult
+		timeout         time.Duration
+		wantContains    []string
+		wantNotContains []string
+		wantStartsWith  string // exact prefix check for column-padding
+	}{
+		{
+			name:           "ready_shows_glyph_and_duration",
+			result:         cli.ProbeResult{LLM: "claude", Status: cli.ProbeReady, Duration: 1234 * time.Millisecond},
+			timeout:        10 * time.Second,
+			wantContains:   []string{"claude", "✓", "1.23s"},
+			wantStartsWith: "  claude   ",
+		},
+		{
+			name: "timeout_with_vendor_message_surfaces_inline",
+			result: cli.ProbeResult{
+				LLM:    "gemini",
+				Status: cli.ProbeTimeout,
+				Err:    errors.New("timeout after 10s — Error: You have exhausted your capacity on this model."),
+			},
+			timeout:         10 * time.Second,
+			wantContains:    []string{"gemini", "✗", "exhausted your capacity", "timeout after"},
+			wantNotContains: []string{"no diagnostic captured"},
+		},
+		{
+			name:         "timeout_without_vendor_message_appends_hint",
+			result:       cli.ProbeResult{LLM: "claude", Status: cli.ProbeTimeout, Err: context.DeadlineExceeded},
+			timeout:      10 * time.Second,
+			wantContains: []string{"claude", "✗", "timeout after 10s", "no diagnostic captured", "local-review doctor", "--preflight-timeout"},
+		},
+		{
+			// v0.10.8 second behaviour: the rendered timeout
+			// reflects the configured value, not a hard-coded
+			// default. Pin via a non-default timeout so a future
+			// regression (someone re-hard-codes
+			// cli.DefaultProbeTimeout) fails this case.
+			name:         "timeout_renders_configured_timeout_not_default",
+			result:       cli.ProbeResult{LLM: "claude", Status: cli.ProbeTimeout, Err: context.DeadlineExceeded},
+			timeout:      20 * time.Second,
+			wantContains: []string{"timeout after 20s"},
+			// 10s would be the package default — must NOT appear.
+			wantNotContains: []string{"timeout after 10s"},
+		},
+		{
+			name:         "canceled_shows_distinct_glyph",
+			result:       cli.ProbeResult{LLM: "claude", Status: cli.ProbeCanceled},
+			timeout:      10 * time.Second,
+			wantContains: []string{"claude", "⊘", "canceled"},
+		},
+		{
+			name:         "error_shows_vendor_message",
+			result:       cli.ProbeResult{LLM: "gemini", Status: cli.ProbeError, Err: errors.New("authentication failed")},
+			timeout:      10 * time.Second,
+			wantContains: []string{"gemini", "✗", "authentication failed"},
+		},
+		{
+			// Error message with embedded newlines must
+			// collapse to single line (preserves the readiness
+			// block's column alignment).
+			name:            "error_collapses_internal_newlines",
+			result:          cli.ProbeResult{LLM: "codex", Status: cli.ProbeError, Err: errors.New("error\n  at line 42\n  reason: bad")},
+			timeout:         10 * time.Second,
+			wantContains:    []string{"codex", "error at line 42"},
+			wantNotContains: []string{"\n"}, // must not contain newline; would break alignment
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatProbeLine(tc.result, tc.timeout)
+			for _, sub := range tc.wantContains {
+				if !strings.Contains(got, sub) {
+					t.Errorf("formatProbeLine = %q, want it to contain %q", got, sub)
+				}
+			}
+			for _, sub := range tc.wantNotContains {
+				if strings.Contains(got, sub) {
+					t.Errorf("formatProbeLine = %q, want it NOT to contain %q", got, sub)
+				}
+			}
+			if tc.wantStartsWith != "" && !strings.HasPrefix(got, tc.wantStartsWith) {
+				t.Errorf("formatProbeLine = %q, want prefix %q (column padding)", got, tc.wantStartsWith)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

First-customer dogfood on v0.10.7 showed two UX gaps in the readiness block:

```
claude   ✗ timeout after 10s
gemini   ✗ timeout after 10s — Warning: ... You have exhausted your capacity ...
codex    ✓ (2.9s)
```

1. **Silent claude** — no vendor diagnostic in the output line. The user can't tell whether the probe captured nothing useful (cold-start) or whether the renderer is suppressing the message. Reads identically to a vendor-message-present timeout.
2. **No way to bump the cap** — claude-code's cold start on a loaded host can exceed 10s before any stderr write. The only workarounds were `--no-preflight` (loses the readiness signal entirely) or no workaround at all.

## What changed

**A. `--preflight-timeout <duration>` flag** (root command, default `0` → falls back to `cli.DefaultProbeTimeout` 10s). Lets users bump to 15-20s for cold-starting CLIs without forcing `--no-preflight`. The runner — not Probe — resolves the actual value so the readiness-block render shows the CONFIGURED timeout, not a hard-coded default that would lie when the flag's in play.

**B. "no diagnostic captured" hint** on bare-timeout rendering. When `ProbeTimeout` has no vendor message in `r.Err`, the line now reads:

```
claude   ✗ timeout after 10s (no diagnostic captured — run `local-review doctor`, or raise --preflight-timeout)
```

Vendor-message-present timeouts (the v0.10.6 path) are unchanged — they already surface the actual text inline.

**Refactor**: pulled the readiness-block render out of `runPreflightProbe` into a `formatProbeLine(r, timeout)` helper. Print loop stays trivial; the rules — including the new hint and the configured-timeout rendering — live in one unit-testable function.

## Tests

`TestFormatProbeLine` — table-driven, 7 cases:
- `ready_shows_glyph_and_duration` — happy path with rounded duration
- `timeout_with_vendor_message_surfaces_inline` — v0.10.6 path unchanged
- **`timeout_without_vendor_message_appends_hint`** — v0.10.8 hint behaviour
- **`timeout_renders_configured_timeout_not_default`** — pin against re-hard-coding `cli.DefaultProbeTimeout` (uses 20s; asserts the rendered text contains "20s" and NOT "10s")
- `canceled_shows_distinct_glyph` — ⊘ for Ctrl+C
- `error_shows_vendor_message` — auth-failure etc.
- `error_collapses_internal_newlines` — multi-line stderr → single readiness row

## Live verification (CLAUDE.md rule 11)

3-LLM pre-push review on `2913ba7` → **APPROVE recommendation**, 0 Critical / 0 Major. Two Warning findings, both on pre-existing code outside this PR's diff:
- Probe goroutine "leak" (intentional + documented since v0.10.5/.6 — bounded by SIGKILL → kernel reap → pipe FD close → `cmd.Wait` returns)
- `strings.Contains(err.Error(), "deadline exceeded")` text-match fallback in `classifyProbeOutcome` could false-positive on a vendor error string. Pre-existing from v0.10.1; not in this PR's diff. Worth a chip but not blocking.

The `--help` output now lists `--preflight-timeout duration` next to `--no-preflight`, and the new flag is documented in CHANGELOG `[Unreleased]`.

## No release in this PR

Per user direction: merge to main, no version bump. The user-visible change ships in the next release that touches the codebase. CHANGELOG entry sits under `[Unreleased]` until then.

## Test plan

- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean (7 new sub-tests + existing suite)
- [x] Pre-push 3-LLM dogfood — APPROVE, 0 blocking findings in-diff
- [x] `--help` output verified — both `--no-preflight` and `--preflight-timeout` listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)