### PR TITLE
test(llm): use a neutral CGNAT example IP, not a real personal one

### DIFF
--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -330,7 +330,7 @@ func TestIsLocalURL(t *testing.T) {
 		// widening. Tailscale tailnet IPs live here; Ollama-over-
 		// Tailscale is a common remote-Ollama setup.
 		{"http://100.64.0.1:11434/v1", true, "cgnat-lower-edge"},
-		{"http://100.107.222.78:11434/v1", true, "cgnat-tailscale-ollama"},
+		{"http://100.96.0.1:11434/v1", true, "cgnat-tailscale-ollama"},
 		{"http://100.127.255.254/v1", true, "cgnat-upper-edge-100.127"},
 		// Edges of 100.64/10 — must NOT match outside the /10 window.
 		{"http://100.63.255.254/v1", false, "100.63-just-below-cgnat"},


### PR DESCRIPTION
Swaps the maintainer's literal Tailscale IP in the `isLocalURL` CGNAT test fixture for a generic in-range example (`100.96.0.1`). A `100.64.0.0/10` address is private/non-routable (no real sensitivity), but personal values don't belong in public test code. Test-only — no behavior change, no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)