### PR TITLE
fix(config): --only overrides the all-LLMs-disabled validation guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Secret + personal-data guardrails (local pre-commit + CI).** A new `gitleaks`-based secret scan runs in CI (`.github/workflows/secret-scan.yml`, over full git history) and as a local pre-commit hook (`scripts/install-hooks.sh`). The hook also greps the staged *content* of changed files (not the raw diff, so a commit that *removes* a leaked value isn't blocked) against a **gitignored** `.git-personal-denylist` (seeded from `.git-personal-denylist.example`) so you can block your own IPs / hostnames / emails / names from ever being committed — those stay on your machine since CI can't hold them. `.gitleaks.toml` allowlists the repo's obviously-fake test placeholders so real secrets are still caught everywhere. Motivation: a maintainer's real Tailscale IP was committed into a test fixture in v0.13.0 — this is the backstop so it can't recur silently. (Secrets are reliably auto-detected; personal IPs/names rely on the denylist + the new CLAUDE.md rule 13, since a generic rule can't tell a real personal IP from the many legitimate example IPs in the test suite.)
 
+### Fixed
+
+- **`--only` now works with an all-disabled-LLM config.** `--only claude,codex,…` is an explicit allow-list that overrides config-level `enabled: false` for agent *selection*, but `cfg.Validate()` still hard-rejected an all-disabled config in the multi-LLM path (*"all LLMs are explicitly disabled"*), so the override didn't work end-to-end. Now `Validate` returns a sentinel `config.ErrAllLLMsDisabled` and the runner tolerates it specifically when `--only` is set. This enables a clean two-pass workflow from a **single** config (disable all LLMs + point `provider` at a local Ollama → `local-review review` runs Ollama; `local-review review --only claude,codex,copilot` runs those cloud agents). Every other config-validation failure (e.g. a bad `merge.preferred_llm`) still aborts. Surfaced by dogfooding the Ollama-then-cloud workflow.
+
 ## [0.13.0] - 2026-05-27
 
 **Theme: make the local/offline path actually work.**

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -173,7 +173,17 @@ func applyConfig(llm cli.LLM, cfg config.Config) cli.LLM {
 // to disk, and print the merged report to stdout.
 func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, active []cli.LLM, configDisabled []string, mode git.Mode, ref string) error {
 	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("invalid config: %w", err)
+		// `--only` is an explicit allow-list that overrides config-level
+		// enable/disable for agent selection (see selectAgents). So an
+		// "all LLMs disabled" config is benign here — the user named the
+		// agents to run. This is what makes the two-pass workflow work
+		// with ONE config (disable all → Ollama fallback for the default
+		// run; `--only claude,codex,...` → those cloud agents). We only
+		// swallow THIS specific error; every other Validate failure
+		// (bad merge.preferred_llm, etc.) still aborts.
+		if !(sf.only != "" && errors.Is(err, config.ErrAllLLMsDisabled)) {
+			return fmt.Errorf("invalid config: %w", err)
+		}
 	}
 	warnIgnoredFlags(sf)
 	if err := validateMergeWith(sf, active); err != nil {

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -181,7 +181,11 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 		// run; `--only claude,codex,...` → those cloud agents). We only
 		// swallow THIS specific error; every other Validate failure
 		// (bad merge.preferred_llm, etc.) still aborts.
-		if !(sf.only != "" && errors.Is(err, config.ErrAllLLMsDisabled)) {
+		// Use parseOnlyList (not a bare sf.only != "") so a whitespace-
+		// only --only value is treated as "unset" — matching how
+		// selectAgents decides whether --only is in effect.
+		onlySet := len(parseOnlyList(sf.only)) > 0
+		if !(onlySet && errors.Is(err, config.ErrAllLLMsDisabled)) {
 			return fmt.Errorf("invalid config: %w", err)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -651,28 +651,22 @@ func warnDeprecatedAPIKeys(cfg *Config) {
 // Returns an error if the config is invalid.
 // Note: This should be called explicitly by commands that need validation (e.g., multi),
 // not automatically in Load(), to avoid breaking v0-only users.
+// ErrAllLLMsDisabled is returned by Validate when every configured LLM
+// has an explicit `enabled: false`. The runner tolerates this
+// specifically when `--only` is set: `--only` is an explicit allow-list
+// that overrides config-level enable/disable for agent SELECTION, so an
+// all-disabled config is fine in that case (the user opted into the
+// named agents). Without the sentinel the runner couldn't tell this
+// benign case apart from a genuinely misconfigured default run.
+var ErrAllLLMsDisabled = errors.New("all LLMs are explicitly disabled; at least one must be enabled for multi-LLM mode")
+
 func (c *Config) Validate() error {
-	// v0.1: Check that at least one LLM is enabled
-	// Treat nil as enabled (default), only count explicit disables
-	hasEnabled := false
-	hasExplicitlyDisabled := 0
-
-	for _, llm := range c.LLMs {
-		// nil means enabled by default
-		if llm.Enabled == nil || *llm.Enabled {
-			hasEnabled = true
-		} else {
-			// Explicitly disabled
-			hasExplicitlyDisabled++
-		}
-	}
-
-	// Only error if user explicitly disabled all LLMs (not if LLMs map is empty)
-	if len(c.LLMs) > 0 && !hasEnabled && hasExplicitlyDisabled == len(c.LLMs) {
-		return fmt.Errorf("all LLMs are explicitly disabled; at least one must be enabled for multi-LLM mode")
-	}
-
-	// Validate merge config
+	// Validate merge config FIRST. ErrAllLLMsDisabled (below) is the one
+	// error the runner tolerates under --only, so it MUST be returned
+	// only when nothing else is wrong — otherwise tolerating it would
+	// mask an unrelated misconfig (e.g. a typo'd merge.preferred_llm).
+	// Checking everything else before the all-disabled short-circuit
+	// keeps the runner's "tolerate ErrAllLLMsDisabled" narrow and exact.
 	if c.Merge.PreferredLLM != "" && c.Merge.PreferredLLM != "auto" {
 		// Check that preferred LLM exists and is enabled
 		llm, ok := c.LLMs[c.Merge.PreferredLLM]
@@ -682,6 +676,24 @@ func (c *Config) Validate() error {
 		if llm.Enabled != nil && !*llm.Enabled {
 			return fmt.Errorf("merge.preferred_llm '%s' is disabled (must be enabled to use for merging)", c.Merge.PreferredLLM)
 		}
+	}
+
+	// v0.1: at least one LLM must be enabled. Treat nil as enabled
+	// (default); only count explicit disables. This check is LAST so
+	// the merge validation above is never short-circuited by it.
+	hasEnabled := false
+	hasExplicitlyDisabled := 0
+	for _, llm := range c.LLMs {
+		if llm.Enabled == nil || *llm.Enabled {
+			hasEnabled = true
+		} else {
+			hasExplicitlyDisabled++
+		}
+	}
+	// Only error if the user explicitly disabled all LLMs (not if the
+	// LLMs map is empty).
+	if len(c.LLMs) > 0 && !hasEnabled && hasExplicitlyDisabled == len(c.LLMs) {
+		return ErrAllLLMsDisabled
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -733,7 +733,7 @@ func TestValidate_NoLLMsEnabled(t *testing.T) {
 	// Must be the sentinel so the runner can errors.Is it and tolerate
 	// it specifically when --only explicitly selects agents (overriding
 	// config enable/disable). A bare fmt.Errorf string would force the
-	// runner to brittly string-match.
+	// runner to do a brittle string-match.
 	if !errors.Is(err, ErrAllLLMsDisabled) {
 		t.Errorf("expected ErrAllLLMsDisabled sentinel, got %v", err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -728,6 +729,39 @@ func TestValidate_NoLLMsEnabled(t *testing.T) {
 	err := cfg.Validate()
 	if err == nil {
 		t.Error("expected error when no LLMs enabled")
+	}
+	// Must be the sentinel so the runner can errors.Is it and tolerate
+	// it specifically when --only explicitly selects agents (overriding
+	// config enable/disable). A bare fmt.Errorf string would force the
+	// runner to brittly string-match.
+	if !errors.Is(err, ErrAllLLMsDisabled) {
+		t.Errorf("expected ErrAllLLMsDisabled sentinel, got %v", err)
+	}
+}
+
+// When all LLMs are disabled AND another config error exists (here a
+// bogus merge.preferred_llm), Validate must return the OTHER error —
+// NOT ErrAllLLMsDisabled. The runner tolerates ErrAllLLMsDisabled under
+// --only, so if the all-disabled check short-circuited ahead of the
+// merge check, a real misconfig could be silently masked. This pins the
+// "all-disabled check runs last" ordering.
+func TestValidate_AllDisabledDoesNotMaskOtherErrors(t *testing.T) {
+	cfg := Defaults()
+	for name, llm := range cfg.LLMs {
+		llm.Enabled = boolPtr(false)
+		cfg.LLMs[name] = llm
+	}
+	cfg.Merge.PreferredLLM = "nonexistent" // a real misconfig that must surface
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected an error (bad preferred_llm)")
+	}
+	if errors.Is(err, ErrAllLLMsDisabled) {
+		t.Errorf("all-disabled check masked the merge.preferred_llm error; got sentinel, want the preferred_llm error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "preferred_llm") {
+		t.Errorf("expected a merge.preferred_llm error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Surfaced by dogfooding the **Ollama-then-cloud** two-pass workflow on a real machine.

`--only claude,codex,…` is an explicit allow-list that overrides config-level `enabled: false` for agent *selection* — but `cfg.Validate()` independently hard-rejected an all-disabled config in the multi-LLM path (*"all LLMs are explicitly disabled"*), so the override didn't work end-to-end. Verified before the fix: `--only claude,codex,copilot` against an all-disabled config errored out.

**Fix:** `Validate` returns a sentinel `config.ErrAllLLMsDisabled`; `runMultiLLMReview` tolerates it **specifically when `--only` is set**. Every other validation failure still aborts.

This enables the intended **single-config, two-pass** flow:
```yaml
# .local-review.yml — disable all CLIs, point provider at local Ollama
provider: { base_url: http://<tailscale-ip>:11434/v1, model: qwen2.5-coder:7b }
llms: { claude: {enabled: false}, gemini: {enabled: false}, codex: {enabled: false}, copilot: {enabled: false} }
```
```sh
local-review review                                  # → Ollama (fallback)
local-review review --only claude,codex,copilot      # → those 3 cloud agents
```

## Self-review catch (folded in)
The 3-LLM pre-push review (Codex + Copilot consensus) caught a **masking bug**: `Validate` checked all-disabled *before* `merge.preferred_llm` and returned on the first error, so tolerating `ErrAllLLMsDisabled` under `--only` could hide a bad `preferred_llm`. Fixed by moving the all-disabled check **last**, so any real misconfig is returned first and still aborts. Pinned by `TestValidate_AllDisabledDoesNotMaskOtherErrors`. Validate call sites audited (only `runner.go:175` in prod).

## Test plan
- [x] `gofmt` / `go vet` / `go test -race ./...` clean
- [x] New tests: sentinel returned for all-disabled; masking-prevention (all-disabled + bad preferred_llm → non-sentinel error)
- [x] End-to-end on a real Tailscale Ollama + 3 cloud LLMs: stage 1 → Ollama review; stage 2 → `Reviewing main with 3 LLMs`, merged, exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `--only` flag behavior when all Language Models are disabled, enabling a two-pass workflow to run local agents first, then selectively run cloud agents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mshykov/local-review/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->