### PR TITLE
release: v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-05-27
+
+**Theme: workflow guardrails + the local/cloud two-pass flow.**
+
+A maintainer-facing patch: secret/PII commit guardrails (born from the v0.13.0 IP-leak incident) and a fix that lets a single config drive both a free local-Ollama pass and a cloud-LLM pass.
+
 ### Added
 
 - **Secret + personal-data guardrails (local pre-commit + CI).** A new `gitleaks`-based secret scan runs in CI (`.github/workflows/secret-scan.yml`, over full git history) and as a local pre-commit hook (`scripts/install-hooks.sh`). The hook also greps the staged *content* of changed files (not the raw diff, so a commit that *removes* a leaked value isn't blocked) against a **gitignored** `.git-personal-denylist` (seeded from `.git-personal-denylist.example`) so you can block your own IPs / hostnames / emails / names from ever being committed — those stay on your machine since CI can't hold them. `.gitleaks.toml` allowlists the repo's obviously-fake test placeholders so real secrets are still caught everywhere. Motivation: a maintainer's real Tailscale IP was committed into a test fixture in v0.13.0 — this is the backstop so it can't recur silently. (Secrets are reliably auto-detected; personal IPs/names rely on the denylist + the new CLAUDE.md rule 13, since a generic rule can't tell a real personal IP from the many legitimate example IPs in the test suite.)


### PR DESCRIPTION
Stamps CHANGELOG `[Unreleased]` → `[0.13.1]`, bundling the two changes merged since v0.13.0:
- #101 — secret/PII guardrails (gitleaks CI + pre-commit + personal denylist)
- #102 — `--only` overrides the all-LLMs-disabled config guard (enables the single-config Ollama-then-cloud workflow)

Docs-only stamp; binary built from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)