### PR TITLE
fix(config): silence deprecation false-positive + mask URL creds in config dump (v0.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-05-28
+
+### Fixed
+
+- **`provider:` deprecation warning fired on every invocation, even with no user config.** `Defaults()` pre-populates `Provider.BaseURL` / `Model` / `APIKeyEnv`, so post-cascade `cfg.Provider.BaseURL` was never empty — the v0.14.0 `shouldWarnDeprecatedProvider` predicate fell straight through to the "warn" branch on `doctor` / `config` / `review` / `audit` whether the user had a legacy `provider:` block or not. Now the predicate also suppresses when the resolved Provider equals `Defaults()` verbatim (no-config or tautological-config case); a user-configured non-default `provider.base_url` (e.g. Ollama at `http://localhost:11434/v1`) still triggers the migration nudge. Two new tests in `internal/config/config_test.go` pin both directions.
+- **`local-review config` leaked credentials embedded in `base_url` values.** The `api_key:` field was masked, but a basic-auth userinfo URL (`https://user:pass@host/v1`) or a query-string key (`?api_key=sk-…`) printed verbatim — a pre-existing bug, not a v0.14 regression. The config printer now runs every `base_url` (top-level `provider.base_url` AND each `llms.<name>.base_url`) through the same `SanitizeBaseURLForDisplay` helper introduced for the v0.14.0 deprecation warning. Scheme + host + path survive; userinfo, query, and fragment are dropped. The helper moves from unexported to exported in `internal/config` so both surfaces share one implementation. Five new tests in `cmd/local-review/config_test.go` pin basic-auth masking, query-string masking, and plain-URL roundtrip for both the `provider:` block and the `llms.<name>` entries.
+
 ## [0.14.0] - 2026-05-28
 
 **Theme: unified agent model.**

--- a/cmd/local-review/config.go
+++ b/cmd/local-review/config.go
@@ -47,6 +47,22 @@ which settings are being used.`,
 				}
 			}
 
+			// Strip credentials embedded in base_url values
+			// (`https://user:pass@host` or `?api_key=…`). A config dump
+			// is meant to be shareable like the masked api_key above;
+			// without this, basic-auth or query-string creds leak
+			// verbatim. Same sanitizer as the v0.14 deprecation
+			// warning so both surfaces behave identically.
+			if cfg.Provider.BaseURL != "" {
+				cfg.Provider.BaseURL = config.SanitizeBaseURLForDisplay(cfg.Provider.BaseURL)
+			}
+			for name, llmCfg := range cfg.LLMs {
+				if llmCfg.BaseURL != "" {
+					llmCfg.BaseURL = config.SanitizeBaseURLForDisplay(llmCfg.BaseURL)
+					cfg.LLMs[name] = llmCfg
+				}
+			}
+
 			enc := yaml.NewEncoder(cmd.OutOrStdout())
 			enc.SetIndent(2)
 			if err := enc.Encode(cfg); err != nil {

--- a/cmd/local-review/config_test.go
+++ b/cmd/local-review/config_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runConfigCmdIn runs the `config` cobra command after chdir'ing into
+// a temp dir seeded with the given .local-review.yml content, and
+// returns the command's stdout. Mirrors the production code path:
+// the cobra Command shares the loadConfig() entrypoint that the real
+// binary uses, so URL-masking changes can't drift between unit-test
+// and real invocation.
+func runConfigCmdIn(t *testing.T, yamlContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".local-review.yml"), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origCwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := configCmd(&sharedFlags{})
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("config command: %v", err)
+	}
+	return out.String()
+}
+
+func TestConfigCommand_MasksBasicAuthInProviderBaseURL(t *testing.T) {
+	// Credentials embedded in basic-auth userinfo (`user:pass@host`)
+	// must NOT survive a `config` dump — same standard as the api_key
+	// field, which has always been masked. Pre-fix the value was
+	// printed verbatim.
+	out := runConfigCmdIn(t, `
+provider:
+  base_url: https://leak-user:leak-pass@api.openai.com/v1
+  model: gpt-4o
+`)
+	if strings.Contains(out, "leak-user") || strings.Contains(out, "leak-pass") {
+		t.Errorf("basic-auth credentials must be stripped from config output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "api.openai.com/v1") {
+		t.Errorf("scheme+host+path must survive sanitization; got:\n%s", out)
+	}
+}
+
+func TestConfigCommand_MasksQueryStringInProviderBaseURL(t *testing.T) {
+	// Some providers accept the key as a query-string parameter.
+	// That belongs in an env var, not in a shareable config dump.
+	out := runConfigCmdIn(t, `
+provider:
+  base_url: https://api.example.test/v1?api_key=sk-LEAKED
+  model: gpt-4o
+`)
+	if strings.Contains(out, "sk-LEAKED") || strings.Contains(out, "api_key=") {
+		t.Errorf("query-string credentials must be stripped from config output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "api.example.test/v1") {
+		t.Errorf("scheme+host+path must survive sanitization; got:\n%s", out)
+	}
+}
+
+func TestConfigCommand_PlainProviderBaseURLRoundtrips(t *testing.T) {
+	// The common case: an unauthenticated URL stays exactly itself.
+	// Sanitization must not corrupt valid configs.
+	out := runConfigCmdIn(t, `
+provider:
+  base_url: http://localhost:11434/v1
+  model: qwen2.5
+`)
+	if !strings.Contains(out, "http://localhost:11434/v1") {
+		t.Errorf("plain URL must roundtrip; got:\n%s", out)
+	}
+}
+
+func TestConfigCommand_MasksCredsInLLMsBaseURL(t *testing.T) {
+	// The unified v0.14 agent model puts the same `base_url:` field
+	// under `llms.<name>:`. Masking must apply there too — the
+	// `provider:` block isn't the only leak surface.
+	out := runConfigCmdIn(t, `
+llms:
+  cloud:
+    base_url: https://creduser:credpass@api.together.xyz/v1?api_key=sk-LLM-LEAK
+    model: meta-llama/Llama-3-70b
+`)
+	for _, secret := range []string{"creduser", "credpass", "sk-LLM-LEAK", "api_key="} {
+		if strings.Contains(out, secret) {
+			t.Errorf("llms.cloud.base_url leaked %q in config output; got:\n%s", secret, out)
+		}
+	}
+	if !strings.Contains(out, "api.together.xyz/v1") {
+		t.Errorf("scheme+host+path must survive sanitization for llms entries; got:\n%s", out)
+	}
+}
+
+func TestConfigCommand_PlainLLMsBaseURLRoundtrips(t *testing.T) {
+	// Symmetric roundtrip check for the llms.<name>.base_url branch.
+	out := runConfigCmdIn(t, `
+llms:
+  ollama:
+    base_url: http://localhost:11434/v1
+    model: qwen2.5
+`)
+	if !strings.Contains(out, "http://localhost:11434/v1") {
+		t.Errorf("plain llms.ollama.base_url must roundtrip; got:\n%s", out)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -666,12 +666,33 @@ func warnDeprecatedAPIKeys(cfg *Config) {
 
 // shouldWarnDeprecatedProvider decides whether the legacy `provider:`
 // block deserves a deprecation warning. Pulled out as a pure function
-// so the suppression rule (fire ONLY when legacy is set AND no
-// `llms.*` entry already carries a `base_url`) is unit-testable
-// without capturing stderr — the warning printer below has no logic
-// worth testing once this returns true.
+// so the suppression rule is unit-testable without capturing stderr —
+// the warning printer below has no logic worth testing once this
+// returns true.
+//
+// Suppression rules:
+//
+//  1. No legacy block at all (BaseURL == "") → silent.
+//  2. Resolved Provider equals Defaults() verbatim → silent. This is
+//     the no-user-config case: `Defaults()` pre-populates BaseURL +
+//     Model + APIKeyEnv + TimeoutSec, so a post-cascade
+//     `cfg.Provider.BaseURL` is never empty even when the user has no
+//     YAML at all. v0.14.0 fired the warning on every invocation in
+//     that case (regression — see v0.14.1 CHANGELOG). The comparison
+//     is on the FULL struct (not just BaseURL/Model/APIKeyEnv) so a
+//     user who sets ONLY `provider.api_key:` or
+//     `provider.timeout_seconds:` (other legacy fields without
+//     touching base_url) still trips the warning — that user IS using
+//     the deprecated block, just on a different field. A user who
+//     explicitly wrote every default verbatim gets the same behavior
+//     either way, so silencing the tautological case is correct.
+//  3. At least one `llms.<name>.base_url` is set → already migrated;
+//     leftover legacy block is harmless.
 func shouldWarnDeprecatedProvider(cfg *Config) bool {
 	if cfg.Provider.BaseURL == "" {
+		return false
+	}
+	if cfg.Provider == Defaults().Provider {
 		return false
 	}
 	for _, llmCfg := range cfg.LLMs {
@@ -682,16 +703,17 @@ func shouldWarnDeprecatedProvider(cfg *Config) bool {
 	return true
 }
 
-// sanitizeBaseURLForDisplay strips potentially-sensitive parts of a
-// configured base_url before echoing it back into the deprecation
-// warning (which lands in stderr / terminal history / CI logs).
-// Basic-auth userinfo (`https://user:pass@host`) and the query /
-// fragment (`?api_key=…`) get dropped; scheme + host + path survive
-// because that's the part the user actually needs to copy. A URL
-// that fails to parse is replaced with a literal placeholder rather
-// than leaked verbatim — fail-closed (CLAUDE.md rule 4) and beats
-// printing garbage into a YAML stanza we're telling the user to copy.
-func sanitizeBaseURLForDisplay(raw string) string {
+// SanitizeBaseURLForDisplay strips potentially-sensitive parts of a
+// configured base_url before echoing it back into any user-facing
+// surface (stderr deprecation warning, `local-review config` dump,
+// CI logs, terminal history). Basic-auth userinfo
+// (`https://user:pass@host`) and the query / fragment
+// (`?api_key=…`) get dropped; scheme + host + path survive because
+// that's the part the user actually needs to copy. A URL that fails
+// to parse is replaced with a literal placeholder rather than leaked
+// verbatim — fail-closed (CLAUDE.md rule 4) and beats printing
+// garbage into a YAML stanza we're telling the user to copy.
+func SanitizeBaseURLForDisplay(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil || u.Host == "" {
 		return "<your-provider-url>"
@@ -710,7 +732,7 @@ func sanitizeBaseURLForDisplay(raw string) string {
 //
 // The migration snippet quotes the user's actual base_url / model /
 // api_key_env values back at them so they can paste it verbatim,
-// minus anything sensitive: see sanitizeBaseURLForDisplay above.
+// minus anything sensitive: see SanitizeBaseURLForDisplay above.
 func warnDeprecatedProviderBlock(cfg *Config) {
 	if !shouldWarnDeprecatedProvider(cfg) {
 		return
@@ -720,7 +742,7 @@ func warnDeprecatedProviderBlock(cfg *Config) {
 	fmt.Fprintln(os.Stderr, "         Example:")
 	fmt.Fprintln(os.Stderr, "           llms:")
 	fmt.Fprintln(os.Stderr, "             ollama:")
-	fmt.Fprintf(os.Stderr, "               base_url: %s\n", sanitizeBaseURLForDisplay(cfg.Provider.BaseURL))
+	fmt.Fprintf(os.Stderr, "               base_url: %s\n", SanitizeBaseURLForDisplay(cfg.Provider.BaseURL))
 	if cfg.Provider.Model != "" {
 		fmt.Fprintf(os.Stderr, "               model: %s\n", cfg.Provider.Model)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -964,11 +964,60 @@ func TestShouldWarnDeprecatedProvider_LLMsWithoutBaseURL_StillFires(t *testing.T
 	}
 }
 
+func TestShouldWarnDeprecatedProvider_DefaultsOnly_Suppresses(t *testing.T) {
+	// v0.14.1 regression guard: Defaults() pre-populates Provider with
+	// BaseURL+Model+APIKeyEnv, so a no-config invocation post-cascade
+	// has a non-empty cfg.Provider.BaseURL even though the user wrote
+	// nothing. v0.14.0 fired the deprecation warning on every doctor /
+	// config / review run in that case. Treat "resolved Provider ==
+	// Defaults()" as "user did not explicitly set this" and stay silent.
+	cfg := Defaults()
+	if shouldWarnDeprecatedProvider(&cfg) {
+		t.Error("warning must NOT fire when Provider matches Defaults() verbatim (no user config)")
+	}
+}
+
+func TestShouldWarnDeprecatedProvider_NonDefaultBaseURL_StillFires(t *testing.T) {
+	// The intended case: a real user-configured legacy provider: block
+	// pointing at something other than the default OpenAI endpoint
+	// (e.g. local Ollama). This MUST still trigger the migration nudge.
+	cfg := Defaults()
+	cfg.Provider.BaseURL = "http://localhost:11434/v1"
+	if !shouldWarnDeprecatedProvider(&cfg) {
+		t.Error("warning must fire for a non-default provider.base_url (the actual migration target)")
+	}
+}
+
+func TestShouldWarnDeprecatedProvider_APIKeyOverride_StillFires(t *testing.T) {
+	// Edge case the v0.14.1 review caught: a user writing
+	// `provider: { api_key: "..." }` is using the deprecated block
+	// even though base_url / model / api_key_env still equal defaults.
+	// Full-struct comparison must catch this; partial-field comparison
+	// would mis-suppress the warning and hide the migration nudge.
+	cfg := Defaults()
+	cfg.Provider.APIKey = "sk-user-set-this"
+	if !shouldWarnDeprecatedProvider(&cfg) {
+		t.Error("warning must fire when ONLY provider.api_key differs from defaults")
+	}
+}
+
+func TestShouldWarnDeprecatedProvider_TimeoutSecOverride_StillFires(t *testing.T) {
+	// Same shape as the api_key edge case — a user with only
+	// `provider: { timeout_seconds: 30 }` IS using the deprecated
+	// block, and the warning must fire on any Provider field that
+	// differs from Defaults(), not just base_url / model / api_key_env.
+	cfg := Defaults()
+	cfg.Provider.TimeoutSec = 30
+	if !shouldWarnDeprecatedProvider(&cfg) {
+		t.Error("warning must fire when ONLY provider.timeout_seconds differs from defaults")
+	}
+}
+
 func TestSanitizeBaseURLForDisplay_StripsBasicAuth(t *testing.T) {
 	// The whole point: a URL with embedded `user:password@` must NOT
 	// land in stderr / CI logs / terminal history. Lose userinfo;
 	// keep scheme + host + path so the suggestion is still useful.
-	got := sanitizeBaseURLForDisplay("https://user:s3cret@api.openai.com/v1")
+	got := SanitizeBaseURLForDisplay("https://user:s3cret@api.openai.com/v1")
 	if strings.Contains(got, "s3cret") || strings.Contains(got, "user") {
 		t.Errorf("basic-auth credentials must be stripped; got %q", got)
 	}
@@ -981,7 +1030,7 @@ func TestSanitizeBaseURLForDisplay_StripsQueryAndFragment(t *testing.T) {
 	// Some providers accept the key on the query string (`?api_key=…`)
 	// or a session id on the fragment. Both belong in env vars, not
 	// stderr — drop them.
-	got := sanitizeBaseURLForDisplay("https://example.test/v1?api_key=sk-leak#sid=abc")
+	got := SanitizeBaseURLForDisplay("https://example.test/v1?api_key=sk-leak#sid=abc")
 	if strings.Contains(got, "api_key") || strings.Contains(got, "sk-leak") || strings.Contains(got, "sid=") {
 		t.Errorf("query/fragment must be stripped; got %q", got)
 	}
@@ -997,7 +1046,7 @@ func TestSanitizeBaseURLForDisplay_UnparseableReturnsPlaceholder(t *testing.T) {
 	// ("refuse on invalid input rather than silently passing it
 	// through") for the display path.
 	for _, raw := range []string{"", "://bad", "not a url"} {
-		got := sanitizeBaseURLForDisplay(raw)
+		got := SanitizeBaseURLForDisplay(raw)
 		if got != "<your-provider-url>" {
 			t.Errorf("expected placeholder for unparseable %q, got %q", raw, got)
 		}
@@ -1007,7 +1056,7 @@ func TestSanitizeBaseURLForDisplay_UnparseableReturnsPlaceholder(t *testing.T) {
 func TestSanitizeBaseURLForDisplay_PlainURLRoundtrips(t *testing.T) {
 	// The common case: an unauthenticated URL stays exactly itself.
 	const in = "http://localhost:11434/v1"
-	if got := sanitizeBaseURLForDisplay(in); got != in {
+	if got := SanitizeBaseURLForDisplay(in); got != in {
 		t.Errorf("plain URL must roundtrip; got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Two regression fixes the v0.14.0 QA pass surfaced. Patch release.

### Fix 1 — `provider:` deprecation warning false-positive

**Symptom:** v0.14.0 fires the migration warning on **every** `doctor` / `config` / `review` / `audit` run, even when the user has no config file at all.

**Root cause:** `Defaults()` pre-populates `Provider.BaseURL` / `Model` / `APIKeyEnv` / `TimeoutSec`. Post-cascade `cfg.Provider.BaseURL` is never empty even for a no-config user. The v0.14.0 predicate checked only `BaseURL == ""` and fell straight through to "warn".

**Fix:** `shouldWarnDeprecatedProvider` now also suppresses when the **full resolved Provider struct equals `Defaults().Provider` verbatim**. Full-struct equality (not just BaseURL/Model/APIKeyEnv) so a user setting *only* `provider.api_key:` or `provider.timeout_seconds:` still trips the warning — they ARE using the deprecated block, just on a different field. A user who explicitly wrote every default verbatim gets the same behavior either way, so silencing the tautological case is correct.

### Fix 2 — `local-review config` leaked URL credentials

**Symptom:** Pre-existing bug, not a v0.14 regression. `api_key:` was masked to `""` in the config dump, but credentials embedded in `base_url` (`https://user:pass@host` / `?api_key=sk-…`) printed verbatim to stdout.

**Fix:** The config command now runs every `base_url` (top-level `provider:` AND each `llms.<name>:` entry) through `SanitizeBaseURLForDisplay` before yaml-encoding. The helper moves from unexported to **exported** in `internal/config` so both surfaces (deprecation warning + config dump) share one implementation — can't drift.

## Self-review fixes already folded in (2-LLM consolidated, initial commit)

The 3-LLM self-review caught a real edge case on the first attempt: my initial fix compared only `BaseURL`/`Model`/`APIKeyEnv`. A user writing only `provider: { api_key: "x" }` would have its warning incorrectly suppressed. Switched to full-struct comparison (`cfg.Provider == Defaults().Provider`) and added two new edge-case tests (`APIKeyOverride_StillFires`, `TimeoutSecOverride_StillFires`).

## Tests added (10 new)

`internal/config/config_test.go`:
- `TestShouldWarnDeprecatedProvider_DefaultsOnly_Suppresses` — the v0.14.1 regression guard
- `TestShouldWarnDeprecatedProvider_NonDefaultBaseURL_StillFires` — intended-warn case
- `TestShouldWarnDeprecatedProvider_APIKeyOverride_StillFires` — self-review edge case
- `TestShouldWarnDeprecatedProvider_TimeoutSecOverride_StillFires` — self-review edge case

`cmd/local-review/config_test.go` (NEW file):
- `TestConfigCommand_MasksBasicAuthInProviderBaseURL`
- `TestConfigCommand_MasksQueryStringInProviderBaseURL`
- `TestConfigCommand_PlainProviderBaseURLRoundtrips`
- `TestConfigCommand_MasksCredsInLLMsBaseURL`
- (+1 more) — uses temp-dir cwd + isolated `$HOME` so the user's real `~/.local-review.yml` doesn't leak in.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...` — all packages green
- [x] Smoke: `doctor` with no config file + isolated HOME → silent
- [x] Smoke: `doctor` with Ollama-shaped legacy block → still warns
- [x] Smoke: `doctor` with tautological-defaults config → silent (same behavior either way)
- [x] Smoke: `config` command with `https://l-u:l-p@host/v1?api_key=sk-LEAK` → stdout masked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecation warning for legacy `provider:` configuration now only displays when necessary, reducing unnecessary alerts
  * Credentials embedded in `base_url` values (basic-auth and API keys) are now sanitized when displaying configuration output for improved security

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mshykov/local-review/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->