### PR TITLE
fix(sunset): scope gate to CLI agents + unify doctor clock (pre-release QA)

### DIFF
--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -132,30 +132,39 @@ func runDoctor(out io.Writer) error {
 	}
 	llms = append(llms, cli.DetectProviders(context.Background(), providerSpecs)...)
 
+	// Capture `now` once so every clock-driven decision in this
+	// run (sunset gate on the numerator AND denominator, sunset
+	// banner rendering) sees the same instant. Pre-fix doctor
+	// called time.Now() three times across the loop and the
+	// banner; near the cutoff boundary that could produce a row
+	// that says "sunset" while the denominator still counted the
+	// agent as available, or vice versa. (v0.15 pre-release QA
+	// catch from codex.)
+	now := time.Now().UTC()
 	readyCount := 0
 	reviewCapable := 0
 	for _, llm := range llms {
-		if cli.IsReviewCapable(llm.Name) {
-			reviewCapable++
-		}
-		status, auth := classify(llm, customEnvVars[llm.Name])
 		var force bool
 		if c, ok := cfg.LLMs[llm.Name]; ok && c.ForceAfterSunset != nil {
 			force = *c.ForceAfterSunset
 		}
+		// Sunset gate applies to CLI agents only — a user-named
+		// provider entry (`llms.gemini: { base_url: ... }`) is
+		// NOT a Google CLI subprocess and must not be auto-dropped.
+		sunsetGated := llm.BaseURL == "" && cli.IsAgentSunset(llm.Name, now) && !force
+
+		if cli.IsReviewCapable(llm.Name) && !sunsetGated {
+			reviewCapable++
+		}
+		status, auth := classify(llm, customEnvVars[llm.Name])
 		// Mirror the runtime fan-out: a sunset CLI without
 		// force_after_sunset is NOT going to participate, so it
 		// must NOT count toward "N/M LLMs ready for multi-review".
-		// Pre-fix doctor said "5/5 ready" while selectAgents dropped
-		// gemini behind the scenes, giving users a false picture of
-		// available agents (codex self-review on PR 2/4).
-		if status == statusReady {
-			sunsetGated := cli.IsAgentSunset(llm.Name, time.Now().UTC()) && !force
-			if !sunsetGated {
-				readyCount++
-			}
+		// Numerator and denominator both apply the same gate now.
+		if status == statusReady && !sunsetGated {
+			readyCount++
 		}
-		printLLMRow(w, llm, status, auth, models[llm.Name], force)
+		printLLMRow(w, llm, status, auth, models[llm.Name], force, now)
 	}
 
 	fmt.Fprintln(w)
@@ -370,7 +379,7 @@ func classify(llm cli.LLM, customEnvVar string) (llmStatus, authStatus) {
 // know how to take control. For not-authed rows we still elide when
 // no model is pinned, since the row's primary signal is the auth fix
 // and the model line would be noise.
-func printLLMRow(out io.Writer, llm cli.LLM, status llmStatus, auth authStatus, configuredModel string, forceAfterSunset bool) {
+func printLLMRow(out io.Writer, llm cli.LLM, status llmStatus, auth authStatus, configuredModel string, forceAfterSunset bool, now time.Time) {
 	displayName := getDisplayName(llm.Name)
 
 	// Provider agents render an HTTP-endpoint-shaped row (no Path,
@@ -457,7 +466,7 @@ func printLLMRow(out io.Writer, llm cli.LLM, status llmStatus, auth authStatus, 
 	// the active fan-out. Remove this block once gemini support is
 	// dropped entirely in a post-cutoff release.
 	if llm.Name == "gemini" {
-		geminiSunsetBanner(out, time.Now().UTC(), forceAfterSunset)
+		geminiSunsetBanner(out, now, forceAfterSunset)
 	}
 
 	fmt.Fprintln(out)

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -138,7 +138,7 @@ func selectAgents(detected []cli.LLM, ready map[string]bool, cfg config.Config, 
 			if !ready[llm.Name] {
 				continue
 			}
-			if isSunsetAndNotForced(llm.Name, cfg, now) {
+			if isSunsetAndNotForced(llm, cfg, now) {
 				// --only is an explicit allow-list; honour the user's
 				// intent over the sunset auto-disable. Warn so they
 				// see they're past the cutoff (force_after_sunset is
@@ -162,7 +162,7 @@ func selectAgents(detected []cli.LLM, ready map[string]bool, cfg config.Config, 
 			configDisabled = append(configDisabled, llm.Name)
 			continue
 		}
-		if isSunsetAndNotForced(llm.Name, cfg, now) {
+		if isSunsetAndNotForced(llm, cfg, now) {
 			// v0.15: drop the agent from the active set once its
 			// manufacturer-announced sunset passes (today: gemini
 			// after 2026-06-18). Without this, every default-mode
@@ -183,14 +183,28 @@ func selectAgents(detected []cli.LLM, ready map[string]bool, cfg config.Config, 
 
 // isSunsetAndNotForced returns true when the agent's manufacturer
 // sunset date has passed AND the user has NOT explicitly opted
-// in via llms.<name>.force_after_sunset. Today only gemini has a
-// sunset; the predicate is no-op for everything else (returns false
-// from cli.IsAgentSunset).
-func isSunsetAndNotForced(name string, cfg config.Config, now time.Time) bool {
-	if !cli.IsAgentSunset(name, now) {
+// in via llms.<name>.force_after_sunset. Today only the Gemini CLI
+// has a sunset; the predicate is no-op for everything else.
+//
+// The CLI/provider distinction matters: a sunset is a property of
+// a *vendor binary* (Google's Gemini CLI binary stops serving on
+// 2026-06-18), NOT of a name. A user-defined provider entry that
+// happens to be called `llms.gemini:` (e.g. a self-hosted Gemini-
+// compatible service) must NOT be auto-disabled. The
+// `llm.BaseURL == ""` guard restricts the check to CLI subprocess
+// agents — provider agents short-circuit out regardless of name.
+// (v0.15 pre-release QA caught this with codex.)
+func isSunsetAndNotForced(llm cli.LLM, cfg config.Config, now time.Time) bool {
+	if llm.BaseURL != "" {
+		// Provider agent (Ollama / vLLM / OpenAI-compat HTTP). The
+		// manufacturer-sunset concept doesn't apply — the user
+		// controls the endpoint.
 		return false
 	}
-	if c, ok := cfg.LLMs[name]; ok && c.ForceAfterSunset != nil && *c.ForceAfterSunset {
+	if !cli.IsAgentSunset(llm.Name, now) {
+		return false
+	}
+	if c, ok := cfg.LLMs[llm.Name]; ok && c.ForceAfterSunset != nil && *c.ForceAfterSunset {
 		return false
 	}
 	return true

--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -986,6 +986,32 @@ func TestSelectAgents_PreSunsetGeminiStaysActive(t *testing.T) {
 	}
 }
 
+func TestSelectAgents_PostSunsetDoesNotAffectProviderNamedGemini(t *testing.T) {
+	// v0.15 pre-release QA (codex) catch: the sunset check matched
+	// on `llm.Name` alone, which would auto-drop a user-named
+	// provider entry like `llms.gemini: { base_url: http://my-llm/v1 }`
+	// post-2026-06-18 — even though the sunset only applies to
+	// Google's Gemini CLI subprocess, NOT any agent that happens
+	// to share the name. The fix gates the predicate on
+	// `llm.BaseURL == ""` (CLI only); providers short-circuit out
+	// regardless of name. This test pins that semantic so a future
+	// refactor can't quietly re-broaden it.
+	ready := map[string]bool{"gemini": true}
+	postSunset := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	// Detected as a PROVIDER named "gemini" (BaseURL set is the
+	// kind discriminator used across the codebase).
+	detected := []cli.LLM{
+		{Name: "gemini", BaseURL: "http://my-self-hosted-llm/v1", Available: true},
+	}
+	active, _, sunsetDropped := selectAgents(detected, ready, config.Config{}, &sharedFlags{}, postSunset)
+	if got, want := names(active), []string{"gemini"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("user-named provider 'gemini' must NOT be sunset-dropped (the cutoff applies to Google's CLI subprocess only), got active=%v", got)
+	}
+	if len(sunsetDropped) != 0 {
+		t.Errorf("sunsetDropped must be empty for a provider entry named 'gemini', got %v", sunsetDropped)
+	}
+}
+
 func TestSelectAgents_PostSunsetForceFalseAlsoAutoDisables(t *testing.T) {
 	// Edge case: `force_after_sunset: false` is explicitly set
 	// (distinct from the default nil). Both should auto-disable —


### PR DESCRIPTION
## Summary

Pre-release QA on `v0.14.1..main` ran a multi-agent review (claude + codex; copilot was out of quota). **Codex caught three issues** in PR 2/4's gemini-sunset hardening. Fixing them on a `qa/v015-release-readiness` branch before stamping v0.15.0.

This sits between PR 3/4 and PR 4/4 in the series — call it **PR 3.5/4**.

## Major (codex)

**Name-based sunset gate would auto-drop user-named provider entries.** `isSunsetAndNotForced(llm.Name, ...)` matched on name only. A user with `llms.gemini: { base_url: http://my-self-hosted-llm/v1 }` (e.g. a self-hosted Gemini-compatible service) would have it auto-dropped post-2026-06-18 — even though Google's sunset only applies to the CLI **subprocess**, not any agent that happens to share the name.

**Fix:** `isSunsetAndNotForced` now takes a full `cli.LLM` and short-circuits when `llm.BaseURL != ""`. Provider agents bypass the gate entirely; CLI agents still go through the normal sunset+force_after_sunset check.

## Warnings (codex)

1. **Doctor `X/Y ready` denominator drift.** `reviewCapable` counted sunset-gated gemini but `readyCount` excluded it, producing misleading "3/4 ready" when the 4th was about to be auto-dropped. Now both numerator and denominator apply the same gate.
2. **`time.Now()` called inside the doctor loop + again in the banner.** Around the 2026-06-18 boundary, a row could read "sunset" while the denominator still counted the agent. Now `now := time.Now().UTC()` is hoisted to `runDoctor`'s function scope and threaded through `printLLMRow` → `geminiSunsetBanner`.

## New test

`TestSelectAgents_PostSunsetDoesNotAffectProviderNamedGemini` — detects a provider entry named `gemini` (with `BaseURL` set), runs `selectAgents` post-2026-07-01, and asserts the agent stays in `active` and out of `sunsetDropped`. Pins the regression.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...` — 14 packages green
- [x] Smoke: doctor still shows "20 days until Gemini CLI sunset" pre-sunset

## Deterministic QA carryover

All 9 V15-* cases + 5 v0.14-carryover cases passed before this fix landed. The Major was caught only by the multi-agent review — exactly the kind of finding the pre-release pass exists to surface.

## Next

After this merges, PR 4/4 stamps `[Unreleased] → [0.15.0]` and tags the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)