### PR TITLE
fix(docs): theme-color meta + PWA manifest for Android Chrome polish

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,16 @@
        see in the README + GitHub avatar. -->
   <link rel="apple-touch-icon" href="logo.png">
   <meta name="apple-mobile-web-app-title" content="local-review">
+  <!-- theme-color: mobile browser address bar + PWA standalone-mode
+       chrome match the site's primary brand color (the lighter end of
+       the #667eea → #764ba2 hero gradient — picks up well on both
+       light and dark UI variants). -->
+  <meta name="theme-color" content="#667eea">
+  <!-- PWA manifest: Android Chrome "Add to Home Screen" uses this to
+       install a standalone-app-shaped bookmark (icon + name + theme)
+       instead of a plain browser-tab shortcut. iOS Safari falls back
+       to apple-touch-icon above; both surfaces now have a real icon. -->
+  <link rel="manifest" href="manifest.json">
   <link rel="preload" href="fonts/Inter-Regular.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="fonts/Inter-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="fonts/Inter-Bold.woff2" as="font" type="font/woff2" crossorigin>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "local-review",
+  "short_name": "local-review",
+  "description": "Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.",
+  "start_url": "/local-review/",
+  "scope": "/local-review/",
+  "display": "minimal-ui",
+  "background_color": "#ffffff",
+  "theme_color": "#667eea",
+  "icons": [
+    {
+      "src": "logo.png",
+      "sizes": "any",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the last two web-icon gaps after PR #117's iOS apple-touch-icon fix.

1. `<meta name="theme-color" content="#667eea">` — mobile browser address bar tints to the primary brand color (lighter end of the existing #667eea → #764ba2 hero gradient) on Chrome Android, Edge, Samsung Internet, modern Safari.
2. New `docs/manifest.json` + `<link rel="manifest">` — Android Chrome "Add to Home Screen" now installs a proper standalone-app-shaped bookmark with icon + name + theme color, not a plain browser-tab shortcut. iOS continues to use the apple-touch-icon from #117.

## Implementation notes

- **`start_url` + `scope` pinned to `/local-review/`** — GitHub Pages serves the site at `https://mshykov.github.io/local-review/` (project subpath, not org root). A bare `"/"` would fail manifest scope validation on Android.
- `display: "minimal-ui"` — appropriate for a marketing site (keeps a back button); we'd use `"standalone"` for installable apps.
- Icons reuse the existing `logo.png` (81 KB) and `logo.svg` (3.8 KB) — no new image assets shipped.

## Cross-project follow-up

The recipe applied here lives in **`~/.claude/CLAUDE.md`** (user-global, applies to every project) as a paste-ready checklist so future projects don't have to learn this lesson again. Covers all 6 `<head>` declarations, the companion `manifest.json` template, GitHub-Pages-subpath gotcha, and what NOT to bother with (Windows tile pinning, Safari mask-icon).

## Test plan

- [x] Manifest validates as JSON
- [x] Single-LLM (claude) self-review — APPROVE, 0 findings; explicitly verified all 6 head elements + subpath correctness
- [x] No release stamp (docs-only, no binary change)
- [ ] Post-merge: GitHub Pages re-publishes in ~5 min; user verifies Android Chrome "Add to Home Screen" + iOS Safari private-mode tab thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)