### PR TITLE
fix(docs): drop ?v=2 query string from favicon links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,8 +15,8 @@
   <meta name="twitter:description" content="Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.">
   <meta name="twitter:image" content="https://mshykov.github.io/local-review/social-preview.png">
   <link rel="canonical" href="https://mshykov.github.io/local-review/">
-  <link rel="icon" type="image/svg+xml" href="favicon.svg?v=2">
-  <link rel="alternate icon" href="favicon.ico?v=2">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="alternate icon" href="favicon.ico">
   <!-- iOS Safari uses apple-touch-icon for tab thumbnails + "Add to Home
        Screen" — without it iOS shows a generic globe (real user report).
        Reuses the existing brand logo so it shows the same artwork users


### PR DESCRIPTION
## Summary

User noticed the site still shows a generic globe in Google search results despite a correct favicon setup. The favicon links carried a `?v=2` cache-buster:

```html
<link rel="icon" type="image/svg+xml" href="favicon.svg?v=2">
<link rel="alternate icon" href="favicon.ico?v=2">
```

Google's search-result favicon fetcher (the separate "Google Favicon" crawler, not Googlebot) is historically finicky with query-string favicon URLs — several SEO reports show it skipping `favicon.svg?v=2`-style declarations. The `?v=2` already did its job when the icon last changed (browsers re-fetched), so dropping it is zero-risk.

## What this does and doesn't do

- ✅ Removes a known footgun on our side
- ❌ Does NOT guarantee the Google search favicon updates — that's gated on Google's own recrawl schedule (weeks-to-months for low-traffic sites). The real lever is Google Search Console → URL Inspection → Request Indexing on the home page, then waiting.

## Diagnostic context (everything else is already correct)

Verified against the live site:
- `favicon.svg` is 1024×1024 (well above Google's 48px-multiple minimum)
- `favicon.ico` present, HTTP 200
- `robots.txt` at the project path: `Allow: /` (nothing blocks the favicon crawler)
- All icon `<link>`s present in production `<head>`

## Test plan

- [x] Diff is 2 lines (query string removed from 2 links)
- [x] No code change, docs-only
- [ ] After merge: GH Pages re-publishes (~5 min); user requests reindex in Search Console

No release stamp (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated favicon configuration for the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->