### PR TITLE
feat(docs): SoftwareApplication JSON-LD + og:image:alt (SEO starter guide)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,7 @@
   <meta property="og:title" content="local-review — Privacy-First Multi-LLM Code Reviews">
   <meta property="og:description" content="Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.">
   <meta property="og:image" content="https://mshykov.github.io/local-review/social-preview.png">
+  <meta property="og:image:alt" content="local-review — privacy-first AI code review CLI">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="local-review — Privacy-First Multi-LLM Code Reviews">
   <meta name="twitter:description" content="Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.">
@@ -922,6 +923,39 @@
       pre { font-size: 0.82em; padding: 14px 40px 14px 14px; }
     }
   </style>
+
+  <!-- Structured data (JSON-LD) — SoftwareApplication schema makes the
+       page eligible for richer search-result treatment per Google's
+       SEO Starter Guide. Mirrors the visible facts (free, cross-platform
+       developer tool, open source); no marketing claims the page doesn't
+       already make. aggregateRating is deliberately OMITTED — Google
+       requires it to reflect genuine user reviews, and we don't collect
+       any, so asserting one would be a structured-data spam violation. -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "local-review",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS, Linux, Windows",
+    "description": "Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.",
+    "url": "https://mshykov.github.io/local-review/",
+    "downloadUrl": "https://github.com/mshykov/local-review/releases",
+    "softwareVersion": "0.15.1",
+    "license": "https://github.com/mshykov/local-review/blob/main/LICENSE",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Maksym Shykov",
+      "url": "https://github.com/mshykov"
+    }
+  }
+  </script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary

Audited `docs/index.html` against [Google's SEO Starter Guide](https://developers.google.com/search/docs/fundamentals/seo-starter-guide). The page already followed **nearly the entire guide** — this PR closes the two genuine gaps.

## Audit scorecard

| Guide item | Status |
|---|---|
| Unique descriptive `<title>` | ✅ already |
| Short compelling meta description | ✅ already |
| One `<h1>`, ordered h2/h3 | ✅ already |
| Real images have descriptive `alt` | ✅ already |
| No `meta keywords` | ✅ already |
| Canonical URL | ✅ already |
| `<html lang>` + descriptive URL | ✅ already |
| **Structured data (JSON-LD)** | ❌ → **added** |
| `og:image:alt` | ⚠️ → **added** |

## What changed

1. **`SoftwareApplication` JSON-LD** — the guide's one explicit "do this for rich-result eligibility" item we were missing. Mirrors the visible facts: free, cross-platform dev tool, open source, with download/license/author.
   - **`aggregateRating` deliberately omitted** — Google requires it to reflect genuinely collected user reviews; we collect none, so asserting a rating would be a structured-data spam-policy violation (which gets a page demoted, not promoted). Valid partial data > invalid "rich" data.
   - `softwareVersion` pinned to `0.15.1`.
2. **`og:image:alt`** — social-card accessibility text next to the existing `og:image`.

## Ruled out during audit (no change needed)

- Two "`<img>` without alt" grep hits are example markup **inside HTML comments**, not real elements.
- The `h2 → h4` "jump" is inside an `aria-hidden` decorative mock-screenshot block — correctly absent from the accessibility tree.

## Test plan

- [x] JSON-LD parses via `json.loads`; no `aggregateRating` key present
- [x] Diff is +34 lines, docs-only, no code change
- [ ] After merge + GH Pages republish: paste URL into [Rich Results Test](https://search.google.com/test/rich-results) to confirm `SoftwareApplication` is detected

No release stamp (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)