### PR TITLE
chore: gitignore scratch dirs + make config tests hermetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,13 @@
 /coverage.html
 *.bak*
 .local-review/reviews/
-do-not-merge/
+
+# Local scratch / working notes that must never be committed. `_do-not-commit/`
+# holds planning + business docs (and is named to say so); `local-review-doc/`
+# holds ad-hoc audit/report output. Previously only the typo'd `do-not-merge/`
+# was listed, so a stray `git add -A` could have committed either dir.
+_do-not-commit/
+local-review-doc/
 
 # Claude Code per-repo harness scratch — scheduled task locks, local
 # settings overrides, worktrees. The harness owns these; nothing in

--- a/cmd/local-review/config_test.go
+++ b/cmd/local-review/config_test.go
@@ -22,6 +22,13 @@ func runConfigCmdIn(t *testing.T, yamlContent string) string {
 	// (see config.Load), so opt this synthetic repo into trust — masking
 	// only matters for a value that's actually honored.
 	t.Setenv("LOCAL_REVIEW_TRUST_REPO_CONFIG", "1")
+	// Hermetic: point the user-home lookup at an empty temp dir so the
+	// dump reflects only the synthetic repo config, not the developer's
+	// real ~/.local-review.yml. os.UserHomeDir() reads $HOME (Unix) /
+	// %USERPROFILE% (Windows).
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".local-review.yml"), []byte(yamlContent), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates the user-home lookup for the whole package so config
+// tests never read the developer's real ~/.local-review.yml. Pre-fix, every
+// test that called Load() merged in whatever the developer had at home,
+// making results non-deterministic and (observed) leaking a real provider
+// endpoint into `config`-dump test output. os.UserHomeDir() reads $HOME on
+// Unix and %USERPROFILE% on Windows, so both are pointed at an empty temp
+// dir. Individual tests that need a specific home still override via
+// t.Setenv (which restores to this temp dir afterwards).
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "lr-config-home")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", home)
+	os.Setenv("USERPROFILE", home)
+	code := m.Run()
+	_ = os.RemoveAll(home)
+	os.Exit(code)
+}


### PR DESCRIPTION
Two repo-hygiene fixes surfaced during PR #122. **No production code changes.**

## 1. `.gitignore` — actually ignore the local scratch dirs
The ignore list contained the typo'd `do-not-merge/`, while the real scratch dirs (`_do-not-commit/` — planning/business docs; `local-review-doc/` — ad-hoc audit/report output) were **never ignored**. A stray `git add -A` could have committed them (it nearly did during #122). Replaced the dead entry with the two real dirs.

## 2. Config tests are now hermetic
`internal/config` and `cmd/local-review` config tests called `config.Load()` without isolating the home dir, so they merged in the developer's real `~/.local-review.yml` — non-deterministic, and a real provider endpoint leaked into `config`-dump test output.

- `internal/config`: new `TestMain` points `HOME` + `USERPROFILE` (Unix / Windows) at an empty temp dir for the whole package.
- `cmd/local-review`: `runConfigCmdIn` helper does the same.

Closes the test-hermeticity follow-up flagged in #122.

## Verification
`gofmt -s` clean · `go vet` clean · `go test ./...` all pass. `git check-ignore` confirms both scratch dirs are now ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)