### PR TITLE
docs: align with MSH org doc conventions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
 
           labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' || echo "")
 
-          # Bump labels follow strict semver — see docs/RELEASE_PROCESS.md
+          # Bump labels follow strict semver — see docs/release.md
           # "Label cheat sheet" for when each is appropriate. Quick reminder:
           #   major  = breaking changes (CLI flags removed, config schema rewrite)
           #   minor  = new user-visible feature (new pack, new command, new flag)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,21 @@ These OVERRIDE default behavior — read them before acting.
 
 ---
 
+## Docs
+
+Project docs live in `docs/`. Each is a **delta** over the org-level baseline at
+`~/Projects/MSH/docs/` (the org files hold the common rules; the project files
+add only what's local-review-specific).
+
+- [docs/code-review.md](docs/code-review.md) — review standards (drives prompt packs + contributor process).
+- [docs/release.md](docs/release.md) — how releases ship.
+- [docs/developer.md](docs/developer.md) — toolchain, hard architecture constraints, danger zone, pre-push self-review.
+- [docs/testing.md](docs/testing.md) — test commands and known gaps.
+- [docs/security.md](docs/security.md) — secret scanning, untrusted repo config, symlink-escape, supply chain.
+- [docs/prompt-packs.md](docs/prompt-packs.md) — how prompt packs work.
+
+---
+
 ## Operating rules
 
 These apply to every task in this repo. They exist because each one has cost us a review round, an incident, or a rewrite.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,3 +1,5 @@
+> Baseline: `MSH/docs/code-review.md` (org common rules). Below: local-review-specific rules.
+
 # Code Review Guidelines
 
 Best-in-class code review standards for `local-review`, synthesized from Google's Engineering Practices, *Software Engineering at Google*, Microsoft's Engineering Playbook, OWASP Top 10:2025, DORA / Cisco / SmartBear empirical research, and the canon of software-engineering literature.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,48 @@
+> Baseline: `MSH/docs/developer.md` (org common rules). Below: local-review-specific rules.
+
+# Developer
+
+local-review-specific engineering rules. The org baseline covers the general
+conventions; this file holds what's particular to this Go CLI.
+
+## Toolchain & basics
+
+- **Go 1.23+**, `git` in PATH.
+- `gofmt -s` and `go vet` must be clean before pushing.
+- New logic needs a unit test — see [testing.md](testing.md).
+
+## Hard architecture constraints
+
+These are non-negotiable; a change that violates one will be rejected in review.
+
+- **No vendor SDKs in `internal/llm/` — raw HTTP only.** Keeps the binary small
+  and removes the supply-chain attack surface of pulling in provider SDKs. See
+  [security.md](security.md).
+- **No telemetry.** Privacy first; the tool phones home to nothing.
+- **Git CLI integration only — never go-git.** All git access shells out to the
+  `git` binary (`internal/git/`).
+- **Exit codes:**
+  - `0` = no blocking findings.
+  - `2` = `major` or `critical` findings present — this is the pre-commit gate.
+  - other non-zero = tool failure (hooks ignore so commits still go through).
+
+## Danger zone
+
+`cmd/local-review/runner.go` and `cmd/local-review/doctor.go` historically
+account for ~40% of all reviewer findings. They're orchestration files where
+multiple concepts meet. Apply extra care: read before you write, and grep all
+callers of any shared helper or contract you touch.
+
+## Pre-push self-review (mandatory)
+
+Before pushing any branch with code changes, run:
+
+```sh
+./local-review review main        # multi-LLM
+./local-review review main --only claude   # if multi-LLM is too slow
+```
+
+Address every `major` / `critical` finding before pushing. We eat our own dog
+food — if the tool produces noise on this codebase, that's a bug to file or fix.
+
+Skip the self-review **only** for pure docs / website / trivial-config changes.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,3 +1,5 @@
+> Baseline: `MSH/docs/deployment.md` (org common rules). Below: local-review release specifics.
+
 # Release process
 
 How `local-review` ships releases. Read this before merging anything you want tagged.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,45 @@
+> Baseline: `MSH/docs/security.md` (org common rules). Below: local-review-specific rules.
+
+# Security
+
+local-review-specific security rules. The org baseline covers general secret
+hygiene; this file holds the threat-model specifics of this BYOK code reviewer.
+
+## Secret & personal-data scanning
+
+- A **pre-commit hook runs `gitleaks`**; CI enforces the same via
+  `.github/workflows/secret-scan.yml`.
+- The gitignored `.git-personal-denylist` backstops personal values (names,
+  emails, IPs) that aren't secrets but still must not land in history.
+- Never commit real secrets or personal data, even in fixtures or docs. Use
+  neutral examples: RFC 5737 ranges (`192.0.2.x`, `198.51.100.x`),
+  `test@example.com`, `ghp_example`.
+
+## Untrusted repo config
+
+The repo-level `.local-review.yml` is an **untrusted, attacker-controllable**
+config layer — it ships inside any repo you review (a hostile commit in CI, a
+fresh clone of someone else's code). Security-sensitive LLM fields are stripped
+from untrusted layers before merge, each with a stderr warning:
+
+- `cli_path` — would otherwise allow arbitrary command execution via
+  `exec.LookPath` + `exec.CommandContext`.
+- `base_url` — would otherwise point a provider agent at a hostile endpoint that
+  receives the diff/source (exfiltration).
+- `api_key` — secret-in-repo.
+
+The home-directory layer (`~/.local-review.yml`) is trusted; the repo layer is
+not, unless `LOCAL_REVIEW_TRUST_REPO_CONFIG=1` is set. Non-sensitive fields
+(model / timeout / enabled / prompts / review) still merge from the repo layer.
+
+## Symlink-escape protection
+
+`pathInsideDir` resolves symlinks (`EvalSymlinks`, with a deepest-existing-
+ancestor walk-up) **before** the containment check, and fails closed on resolve
+errors. A lexical-only check would admit symlink-escape paths
+(e.g. `evil-link → /etc`).
+
+## Supply chain
+
+No vendor SDKs — raw HTTP only in `internal/llm/`, keeping the dependency
+surface (and thus supply-chain risk) minimal. See [developer.md](developer.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,22 @@
+> Baseline: `MSH/docs/testing.md` (org common rules). Below: local-review-specific rules.
+
+# Testing
+
+local-review-specific testing rules. The org baseline covers general testing
+philosophy; this file holds what's particular to this Go CLI.
+
+## Running tests
+
+```sh
+go test ./...            # local
+go test -race ./...      # CI standard (run before pushing)
+```
+
+CI (`.github/workflows/ci.yml`) runs `go test -race ./...` on every push.
+
+## Known gap
+
+`internal/llm/` is intentionally **not mocked yet** — its raw-HTTP client has no
+test double, so its behavior isn't exercised in unit tests. This is a known gap,
+not an oversight. Contributions adding a mock transport (or an httptest-based
+harness) are welcome.


### PR DESCRIPTION
Aligns the project's docs with the MSH org conventions (lowercase-hyphenated topic files, each a delta over the org-level baseline). **Docs + one trivial workflow-comment change; no production code.**

## Changes
- **Rename to the org-standard names** so they match the links CLAUDE.md already uses:
  - `docs/CODE_REVIEW_GUIDELINES.md` → `docs/code-review.md`
  - `docs/RELEASE_PROCESS.md` → `docs/release.md`
- **New project-delta docs** opening with a pointer to their org baseline: `docs/developer.md`, `docs/testing.md`, `docs/security.md`.
- **CLAUDE.md**: new `## Docs` index linking the six topic files.
- **release.yml**: update a comment reference (`docs/RELEASE_PROCESS.md` → `docs/release.md`) to follow the rename.

## Verification
All six CLAUDE.md doc links resolve to files present on the branch. No code paths touched; `release.yml` change is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)