### PR TITLE
docs: make project docs self-contained for OSS contributors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,13 @@ These OVERRIDE default behavior — read them before acting.
 
 ## Docs
 
-Project docs live in `docs/`. Each is a **delta** over the org-level baseline at
-`~/Projects/MSH/docs/` (the org files hold the common rules; the project files
-add only what's local-review-specific).
+Project docs live in `docs/` and are **self-contained** — each reads top to bottom
+for the full picture, no external references required.
 
 - [docs/code-review.md](docs/code-review.md) — review standards (drives prompt packs + contributor process).
 - [docs/release.md](docs/release.md) — how releases ship.
-- [docs/developer.md](docs/developer.md) — toolchain, hard architecture constraints, danger zone, pre-push self-review.
-- [docs/testing.md](docs/testing.md) — test commands and known gaps.
+- [docs/developer.md](docs/developer.md) — engineering principles, toolchain, hard architecture constraints, danger zone, pre-push self-review.
+- [docs/testing.md](docs/testing.md) — test strategy, commands, and known gaps.
 - [docs/security.md](docs/security.md) — secret scanning, untrusted repo config, symlink-escape, supply chain.
 - [docs/prompt-packs.md](docs/prompt-packs.md) — how prompt packs work.
 

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,5 +1,3 @@
-> Baseline: `MSH/docs/code-review.md` (org common rules). Below: local-review-specific rules.
-
 # Code Review Guidelines
 
 Best-in-class code review standards for `local-review`, synthesized from Google's Engineering Practices, *Software Engineering at Google*, Microsoft's Engineering Playbook, OWASP Top 10:2025, DORA / Cisco / SmartBear empirical research, and the canon of software-engineering literature.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -8,7 +8,7 @@ CLI. Read this top to bottom before your first change.
 These apply to every change, and they're what the project's own reviewer (and human
 reviewers) hold contributions to:
 
-- **Surgical changes only.** Touch only what the task requires — no drive-by
+- **Surgical changes only.** Touch what the task requires — no drive-by
   formatting, comment polish, or "while I'm here" refactors. Spotted something else
   worth fixing? Surface it separately.
 - **Read before you write.** Before changing a shared helper, contract, or

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,9 +1,34 @@
-> Baseline: `MSH/docs/developer.md` (org common rules). Below: local-review-specific rules.
-
 # Developer
 
-local-review-specific engineering rules. The org baseline covers the general
-conventions; this file holds what's particular to this Go CLI.
+Engineering conventions for contributing to `local-review` — a single-binary Go
+CLI. Read this top to bottom before your first change.
+
+## General engineering principles
+
+These apply to every change, and they're what the project's own reviewer (and human
+reviewers) hold contributions to:
+
+- **Surgical changes only.** Touch only what the task requires — no drive-by
+  formatting, comment polish, or "while I'm here" refactors. Spotted something else
+  worth fixing? Surface it separately.
+- **Read before you write.** Before changing a shared helper, contract, or
+  user-visible string, grep **all** callers in the same pass — sibling code, doc
+  comments, README/CHANGELOG, prompt templates, tests. Cross-file drift is the most
+  common review finding here.
+- **Keep comments and doc strings current.** A comment describing behavior you just
+  changed is a bug — update it in the same edit. Comment the *why* (intent,
+  constraints, trade-offs), never restate the *what*. One-line doc comments on
+  exported symbols only.
+- **Fail loud, fail closed.** Refuse invalid input rather than silently passing it
+  through; check error / exit codes explicitly; `TrimSpace` before emptiness checks.
+  "Completed" is wrong if anything was skipped silently.
+- **Match the codebase's conventions even if you disagree.** Conformance > taste. If
+  a convention seems harmful, raise it in the PR — don't fork silently.
+- **Surface conflicts; don't average them.** When two patterns contradict, pick the
+  more recent / more tested one, explain why, and flag the other for cleanup.
+- **Writing a v2 next to a v1?** Enumerate v1's invariants explicitly and re-exercise
+  each in v2 — filters, caps, output formats, glob / edge behavior don't carry over
+  for free.
 
 ## Toolchain & basics
 
@@ -46,3 +71,12 @@ Address every `major` / `critical` finding before pushing. We eat our own dog
 food — if the tool produces noise on this codebase, that's a bug to file or fix.
 
 Skip the self-review **only** for pure docs / website / trivial-config changes.
+
+## Definition of done
+
+- Builds clean (`go build ./...`), `gofmt -s` + `go vet` clean, `go test -race ./...`
+  passes.
+- No secrets or personal data committed (see [security.md](security.md)).
+- Docs and comments updated in the same change as the behavior they describe.
+- If you skipped a test, deferred a check, or made an assumption — **say so** in the
+  PR description. "Done except X" beats "done" with a silent gap.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,3 @@
-> Baseline: `MSH/docs/deployment.md` (org common rules). Below: local-review release specifics.
-
 # Release process
 
 How `local-review` ships releases. Read this before merging anything you want tagged.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,9 +1,7 @@
-> Baseline: `MSH/docs/security.md` (org common rules). Below: local-review-specific rules.
-
 # Security
 
-local-review-specific security rules. The org baseline covers general secret
-hygiene; this file holds the threat-model specifics of this BYOK code reviewer.
+Security model and rules for `local-review` — a local BYOK code reviewer that, by
+design, handles untrusted input (the diffs and repositories it reviews).
 
 ## Secret & personal-data scanning
 
@@ -27,6 +25,8 @@ from untrusted layers before merge, each with a stderr warning:
 - `base_url` — would otherwise point a provider agent at a hostile endpoint that
   receives the diff/source (exfiltration).
 - `api_key` — secret-in-repo.
+- `api_key_env` — would otherwise let a repo redirect which env var is read as an
+  agent's credential, exfiltrating an arbitrary env var as that agent's auth token.
 
 The home-directory layer (`~/.local-review.yml`) is trusted; the repo layer is
 not, unless `LOCAL_REVIEW_TRUST_REPO_CONFIG=1` is set. Non-sensitive fields
@@ -39,7 +39,27 @@ ancestor walk-up) **before** the containment check, and fails closed on resolve
 errors. A lexical-only check would admit symlink-escape paths
 (e.g. `evil-link → /etc`).
 
+## Logging & error hygiene
+
+- Never log sensitive auth data — API keys, tokens, session material. Auth-miss
+  errors name the *configured env var* (e.g. `api_key_env: OPENAI_API_KEY`), never the
+  key value.
+- Don't surface raw internal errors that might embed a secret; map to an actionable
+  message instead.
+
+## Handling untrusted input
+
+The diff and source under review are attacker-controllable — treat them as data, not
+instructions:
+
+- Validate untrusted input at the boundary; reject malformed config rather than
+  coercing it.
+- Validate URL protocols on any user-supplied endpoint — only `http(s)`.
+- Where a reviewer CLI exposes agentic tools (e.g. Copilot), it is invoked with tools
+  disabled, so a prompt-injecting diff can't drive its shell / file / network tools.
+
 ## Supply chain
 
-No vendor SDKs — raw HTTP only in `internal/llm/`, keeping the dependency
-surface (and thus supply-chain risk) minimal. See [developer.md](developer.md).
+No vendor SDKs — raw HTTP only in `internal/llm/`, keeping the dependency surface (and
+thus supply-chain risk) minimal. See [developer.md](developer.md). Dependencies are
+kept current: Dependabot opens update PRs and `gitleaks` runs in CI on every push.

--- a/docs/security.md
+++ b/docs/security.md
@@ -62,4 +62,5 @@ instructions:
 
 No vendor SDKs — raw HTTP only in `internal/llm/`, keeping the dependency surface (and
 thus supply-chain risk) minimal. See [developer.md](developer.md). Dependencies are
-kept current: Dependabot opens update PRs and `gitleaks` runs in CI on every push.
+kept current: Dependabot opens update PRs and `gitleaks` runs in CI on pull requests
+and pushes to `main`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,9 +1,22 @@
-> Baseline: `MSH/docs/testing.md` (org common rules). Below: local-review-specific rules.
-
 # Testing
 
-local-review-specific testing rules. The org baseline covers general testing
-philosophy; this file holds what's particular to this Go CLI.
+How testing works for `local-review`.
+
+## Strategy
+
+- **Unit tests are the bulk of coverage** — fast, isolated, table-driven.
+- **Bug fixes ship with a regression test** that would have caught the bug.
+- **Test behavior, not implementation.** A refactor that preserves behavior must not
+  break the test; if a test can't fail when the business rule changes, it isn't
+  testing the rule. Name tests as scenarios (`Test_FooReturnsErrorOnEmptyInput`), not
+  `Test_Foo_2`.
+- **Deterministic.** No real network, time, or randomness in unit tests; no `sleep()`.
+  A flaky test is fixed or quarantined, never ignored. Tests that read host state
+  (e.g. `$HOME`) isolate it to a temp dir.
+- **Mock at the boundary** (the LLM CLI invoker / HTTP client), never hit a real LLM
+  or paid API in a unit test.
+- New logic needs a test; coverage shouldn't decrease. Green `-race` is required
+  before merge.
 
 ## Running tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,9 +8,9 @@ How testing works for `local-review`.
 - **Bug fixes ship with a regression test** that would have caught the bug.
 - **Test behavior, not implementation.** A refactor that preserves behavior must not
   break the test; if a test can't fail when the business rule changes, it isn't
-  testing the rule. Name tests as scenarios (`Test_FooReturnsErrorOnEmptyInput`), not
-  `Test_Foo_2`.
-- **Deterministic.** No real network, time, or randomness in unit tests; no `sleep()`.
+  testing the rule. Name tests `Test<Thing>_<Scenario>_<Outcome>`
+  (e.g. `TestSelectAuditLLM_EmptyActive_ReturnsHintError`), not `Test_Foo_2`.
+- **Deterministic.** No real network, time, or randomness in unit tests; no `time.Sleep`.
   A flaky test is fixed or quarantined, never ignored. Tests that read host state
   (e.g. `$HOME`) isolate it to a temp dir.
 - **Mock at the boundary** (the LLM CLI invoker / HTTP client), never hit a real LLM


### PR DESCRIPTION
## Problem
The docs added in #124 follow the MSH-monorepo "**delta over org baseline**" convention: each opened with `> Baseline: MSH/docs/<topic>.md` and CLAUDE.md pointed at `~/Projects/MSH/docs/`. That baseline (~330 lines of general engineering rules) ships in **nobody else's clone**. So an external contributor cloning from GitHub got only the thin project delta — plus an explicit pointer to files they can't access — and the repo leaked a maintainer's local directory path.

This is an open-source repo, so its docs must stand alone.

## Fix
Fold the needed general content into each repo doc and remove every private reference:

- **developer.md** — new "General engineering principles" section + "Definition of done".
- **testing.md** — new test-strategy section (pyramid, behavior-not-implementation, determinism, mock-at-boundary).
- **security.md** — added logging hygiene, untrusted-input handling, and dependency currency; **also fixed a stale list**: the untrusted-config section now includes `api_key_env` (stripped since #122 but never documented here).
- **code-review.md / release.md** — already comprehensive and self-contained; just dropped the dangling baseline line.
- **CLAUDE.md** — Docs section now describes the docs as self-contained, no `MSH/docs/` path.

## Verification
`git grep` for `MSH/docs`, `~/Projects/MSH`, and `> Baseline:` across `*.md` returns **nothing** — the repo docs no longer reference anything outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation consumption guidelines for project files
  * Added comprehensive release process documentation covering version management, build workflows, and publishing procedures
  * Enhanced developer guidelines with Definition of Done requirements for contributions
  * Expanded security documentation with threat modeling and input handling practices
  * Updated testing strategy with structured expectations and requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->