### PR TITLE
v0.16.0 — close the senior-engineer audit backlog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,32 @@ jobs:
           curl -fsSL "${base_url}/local-review_linux_amd64.tar.gz"  -o linux_amd64.tar.gz
           curl -fsSL "${base_url}/local-review_linux_arm64.tar.gz"  -o linux_arm64.tar.gz
 
+          # Cross-verify the downloaded tarballs against the release's OWN
+          # checksums manifest before recording their hashes in the formula.
+          # Without this, the formula records the hash of whatever bytes the
+          # release URL served at homebrew-update time, rather than attesting
+          # against the manifest the build produced — so a swapped/corrupted
+          # asset in the publish->homebrew window would be silently blessed.
+          # install.sh already does this cross-check; this makes the manifest
+          # the single integrity root for BOTH install channels.
+          checksums="local-review_${VERSION_TAG}_checksums.txt"
+          curl -fsSL "${base_url}/${checksums}" -o "$checksums"
+          verify() { # <local-file> <canonical-asset-name>
+            local computed expected
+            computed=$(shasum -a 256 "$1" | awk '{print $1}')
+            expected=$(awk -v a="$2" '$NF == a {print $1}' "$checksums")
+            if [ -z "$expected" ]; then
+              echo "ERROR: $2 not listed in $checksums (manifest malformed?)"; exit 1
+            fi
+            if [ "$computed" != "$expected" ]; then
+              echo "ERROR: checksum mismatch for $2: downloaded $computed, manifest $expected"; exit 1
+            fi
+          }
+          verify darwin_amd64.tar.gz "local-review_darwin_amd64.tar.gz"
+          verify darwin_arm64.tar.gz "local-review_darwin_arm64.tar.gz"
+          verify linux_amd64.tar.gz  "local-review_linux_amd64.tar.gz"
+          verify linux_arm64.tar.gz  "local-review_linux_arm64.tar.gz"
+
           sha_darwin_amd64=$(shasum -a 256 darwin_amd64.tar.gz | awk '{print $1}')
           sha_darwin_arm64=$(shasum -a 256 darwin_arm64.tar.gz | awk '{print $1}')
           sha_linux_amd64=$(shasum -a 256 linux_amd64.tar.gz | awk '{print $1}')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
+## [0.16.0] - 2026-06-09
 
-- **The repo-level `.local-review.yml` is now an untrusted config layer.** Because a `.local-review.yml` ships inside code you may be reviewing for the first time (a CI runner checking out a hostile commit, a fresh clone), the security-sensitive LLM fields it could carry are no longer honored from the repo layer by default: `cli_path` (the runner feeds it to `exec.LookPath` + `exec.CommandContext` → arbitrary binary execution), `base_url` (registers a provider agent that POSTs your diff — or, under `audit`, the whole tracked source tree — to that endpoint → silent exfiltration), and `api_key` (a credential committed into a repo). Each is stripped from the repo layer with a stderr warning naming what was dropped; non-sensitive fields (`prompts`, `review`, model/timeout/enabled) still apply. The user-home `~/.local-review.yml` is unaffected (it isn't writable by the code under review). A team that genuinely trusts a checked-in config (e.g. a standardised LAN Ollama `base_url`) opts back in with `LOCAL_REVIEW_TRUST_REPO_CONFIG=1`. This is the same trust boundary already drawn for `prompts.pack_dir`, extended to the execution / network / secret fields. (`config.sanitizeUntrustedLayer`; closes the two `major` findings from the v0.15.1 senior-engineer audit.)
+**Theme: close the senior-engineer audit's backlog.** A focused sweep of the confirmed findings from the v0.15.1 L6 audit: the untrusted-config security boundary, `audit`-path robustness brought to parity with the `review` path, the `--min-severity` / `--max-findings` flags finally doing what they advertise, plus v0.15 cleanup debt and supply-chain hardening.
+
+### Added
+
+- **`--min-severity` / `--max-findings` now actually filter the `audit` report.** Both flags were advertised on `audit` but inert (the single-LLM path that consumed them was removed in v0.15). `audit` now applies a severity floor (drops findings below the threshold) and/or a total cap (across packages in report order), resolved flag-first then `review.*` config. Hidden findings are disclosed on stderr — never silently dropped (CLAUDE.md rule 4) — and an invalid `--min-severity` is rejected up front. Implemented as a tested, pure `audit.Report.Filtered`. Help text corrected to "audit only" (bench never honored them). (MIN-10)
+
+### Changed
+
+- **`audit` honors Ctrl+C / SIGTERM.** Previously the worker pool kept dispatching every remaining chunk against an already-canceled context, recording each as "errored" and exiting 0 — a "completed" report that silently dropped the tail. The loop now short-circuits on cancellation and the run exits non-zero with an "audit canceled after N/M chunks" message, matching the review path. (MIN-2)
+- **`audit` no longer counts an empty LLM response as "clean."** A CLI that exits 0 with empty stdout (rate-limited / capacity-exhausted reply, empty `--output-last-message`) is now recorded as an error rather than folded into `PackagesClean`, which had overstated coverage. (MIN-4)
+- **Provider reviews record `mode: "provider"` in `metadata.json`** (was hardcoded `"cli"` for every agent, including HTTP/Ollama/vLLM providers that never spawn a subprocess). (MIN-5)
+- **Default `review.min_severity` / `review.max_findings` are now empty / `0`** (no implicit filter). The prior `"warning"` / `20` defaults were inert — nothing read them before v0.16 — and would otherwise have started silently filtering `audit` output.
 
 ### Fixed
 
 - **Provider auth-failure error no longer names the removed `LOCAL_REVIEW_API_KEY`.** A provider configured with `llms.<name>.api_key_env: FOO` but no key exported previously errored `export LOCAL_REVIEW_API_KEY=…` — a variable removed in v0.15 that the tool never reads — because the configured env-var name was dropped before the HTTP client was built (`cli.NewInvoker` passed `apiKeyEnv=""`). The name is now threaded through (`cli.LLM.APIKeyEnv` → `ProviderSpec.APIKeyEnv` → `provider.New`), so the error names the variable you actually configured; when none is set it points at `llms.<name>.api_key_env` rather than the dead default.
 - **Setting `base_url` on a CLI agent name no longer double-runs it.** `llms.claude.base_url: …` with the claude CLI installed previously produced both a CLI `claude` and a provider `claude` in the roster — two same-named agents that both ran and collided in the name-keyed ready/merge maps. `pickAgents` now drops the CLI twin so the provider entry wins (`dropCLITwins`).
+- **Mid-review Ctrl+C now reports cancellation, not "all N LLM reviews failed."** The fan-out re-checks `ctx.Err()` after the result drain, so a user interrupt during the long review phase surfaces as cancellation instead of a fabricated "all agents failed" diagnosis. (MIN-3)
+- **`init` wizard and `examples/.local-review.yml` stop defaulting `api_key_env` to the removed `LOCAL_REVIEW_API_KEY`** — generated configs now use a neutral `YOUR_PROVIDER_API_KEY` / `OPENAI_API_KEY` placeholder. (NIT-4)
+
+### Security
+
+- **The repo-level `.local-review.yml` is now an untrusted config layer.** Because a `.local-review.yml` ships inside code you may be reviewing for the first time (a CI runner checking out a hostile commit, a fresh clone), the security-sensitive LLM fields it could carry are no longer honored from the repo layer by default: `cli_path` (the runner feeds it to `exec.LookPath` + `exec.CommandContext` → arbitrary binary execution), `base_url` (registers a provider agent that POSTs your diff — or, under `audit`, the whole tracked source tree — to that endpoint → silent exfiltration), `api_key` (a credential committed into a repo), and `api_key_env` (redirects which env var is read as a credential). Each is stripped from the repo layer with a stderr warning naming what was dropped; non-sensitive fields (`prompts`, `review`, model/timeout/enabled) still apply. The user-home `~/.local-review.yml` is unaffected (it isn't writable by the code under review). A team that genuinely trusts a checked-in config (e.g. a standardised LAN Ollama `base_url`) opts back in with `LOCAL_REVIEW_TRUST_REPO_CONFIG=1`. This is the same trust boundary already drawn for `prompts.pack_dir`, extended to the execution / network / secret fields. (`config.sanitizeUntrustedLayer`; closes the two `major` findings from the v0.15.1 senior-engineer audit.)
+- **Homebrew formula SHAs are cross-verified against the release checksums manifest.** The `update-homebrew` job now downloads the release's own `checksums.txt` and verifies each tarball against it before recording the hash in the formula — making the build-time manifest the single integrity root for both the `install.sh` and Homebrew channels (previously the formula recorded the hash of whatever bytes the URL served at homebrew-update time). (MIN-12)
+- **`install.sh` fails closed when no `sha256sum` / `shasum` verifier is present.** Previously it warned and installed anyway; now it requires an explicit `INSTALL_REVIEW_SKIP_VERIFICATION=1` or an interactive acknowledgement, matching the already-hardened manifest-missing branch. Closes the silent-unverified-install gap on minimal container / CI images. (MIN-13)
 
 ### Internal
 
 - **Review exit-gate decision extracted into a pure, tested helper (`decideExitGate`).** The security-critical ordering — the per-LLM blocking scan must run even when the merged report is empty, so a merger timeout/rate-limit can't collapse an exit-2 (blocked) into an exit-1 (which pre-commit hooks let through) — was previously only testable through the full git/probe/orchestrator path. New `TestDecideExitGate` table-tests all four cases directly.
+- **Removed dead code and never-written schema fields.** Deleted the unused exported `CountSuccessful` / `GetSuccessful` (Error==nil remnants of the `CountWithOutput` migration) and the three `metadata.json` findings-count fields (`findings_count`, `final_findings_count`, `deduplication_removed`) that the markdown-only review path never populated. (MIN-6, MIN-7)
+- **Stale `Invoker.Review` docs** no longer describe the removed single-LLM JSON path as a live mode (`internal/agents`). (NIT-1)
+- **Config merge-coverage test** now seeds `dst` with the same key so it exercises `merge()`'s per-field overlay branch — the path where a dropped field silently no-ops in production — instead of only the wholesale-copy branch. (MIN-8)
+- **Audit-path test coverage:** new tests for cancellation, empty-output handling, parser-miss-as-clean, the severity/cap filter, and provider-vs-cli mode.
 
 ## [0.15.1] - 2026-05-29
 

--- a/cmd/local-review/audit.go
+++ b/cmd/local-review/audit.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mshykov/local-review/internal/audit"
 	"github.com/mshykov/local-review/internal/cli"
+	"github.com/mshykov/local-review/internal/config"
 	"github.com/mshykov/local-review/internal/prompts"
 )
 
@@ -21,6 +22,15 @@ type auditFlags struct {
 	// topic is the audit-pack id (security / tech-debt / …).
 	// Required — no default, because the choice IS the audit.
 	topic string
+
+	// minSeveritySet / maxFindingsSet record whether the user passed
+	// --min-severity / --max-findings on the command line (captured via
+	// cobra's Flags().Changed in RunE). Needed so an explicit flag value
+	// — including the disabling values "" / 0 — overrides config, instead
+	// of a zero-value being mistaken for "unset" and falling back to the
+	// configured value.
+	minSeveritySet bool
+	maxFindingsSet bool
 
 	// include / exclude are path-prefix filters passed through to
 	// the walker. Comma-separated. Empty include = walk every
@@ -114,6 +124,11 @@ Audit runs against the whole committed source tree (git ls-files),
 so a working-tree-only change won't appear in findings until it's
 committed.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Capture explicit-flag presence so runAudit can let a CLI
+			// --min-severity/--max-findings (even the disabling "" / 0)
+			// override config, rather than treating a zero value as unset.
+			af.minSeveritySet = cmd.Flags().Changed("min-severity")
+			af.maxFindingsSet = cmd.Flags().Changed("max-findings")
 			return runAudit(cmd.Context(), sf, af)
 		},
 	}
@@ -188,6 +203,22 @@ func runAudit(ctx context.Context, sf *sharedFlags, af auditFlags) error {
 		return writeAuditPlan(os.Stdout, af.topic, chunks)
 	}
 
+	// Resolve the --min-severity / --max-findings filters up front, BEFORE
+	// the expensive Run, so a config-parse error or an invalid severity
+	// fails fast instead of after paying for the whole audit. Precedence:
+	// an explicitly-passed flag wins — INCLUDING the disabling values
+	// "" / 0 (e.g. `--max-findings 0` to uncap a configured limit) — else
+	// the matching review.* config key. These filters were advertised on
+	// `audit` but inert before v0.16.
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	minSev, maxF, err := resolveAuditFilters(af, sf, cfg)
+	if err != nil {
+		return err
+	}
+
 	llm, err := pickAuditLLM(sf, af)
 	if err != nil {
 		return err
@@ -203,28 +234,6 @@ func runAudit(ctx context.Context, sf *sharedFlags, af auditFlags) error {
 		return err
 	}
 
-	// Apply the --min-severity / --max-findings filters (flag wins, else
-	// the matching review.* config key). These were advertised on `audit`
-	// but inert before v0.16.
-	cfg, cfgErr := loadConfig()
-	if cfgErr != nil {
-		return cfgErr
-	}
-	minSev := sf.minSeverity
-	if minSev == "" {
-		minSev = cfg.Review.MinSeverity
-	}
-	if minSev != "" {
-		switch strings.ToLower(minSev) {
-		case "nit", "info", "warning", "major", "critical":
-		default:
-			return fmt.Errorf("--min-severity %q is invalid (use nit|info|warning|major|critical)", minSev)
-		}
-	}
-	maxF := sf.maxFindings
-	if maxF == 0 {
-		maxF = cfg.Review.MaxFindings
-	}
 	rep, hidden := rep.Filtered(minSev, maxF)
 	if hidden > 0 {
 		word := "findings"
@@ -236,6 +245,31 @@ func runAudit(ctx context.Context, sf *sharedFlags, af auditFlags) error {
 
 	rep.Root = "." // stamp the conceptual working-tree root onto the report
 	return emitAuditReport(sf, af, rep)
+}
+
+// resolveAuditFilters computes the effective min-severity floor and
+// max-findings cap for an audit run. An explicitly-passed flag wins over
+// config — INCLUDING the disabling values "" / 0, so `--max-findings 0`
+// uncaps a configured review.max_findings and an unset flag inherits config.
+// Returns an error for an invalid --min-severity value. Pure (no I/O) so
+// the precedence contract is unit-testable.
+func resolveAuditFilters(af auditFlags, sf *sharedFlags, cfg config.Config) (minSev string, maxF int, err error) {
+	minSev = cfg.Review.MinSeverity
+	if af.minSeveritySet {
+		minSev = sf.minSeverity
+	}
+	if minSev != "" {
+		switch strings.ToLower(minSev) {
+		case "nit", "info", "warning", "major", "critical":
+		default:
+			return "", 0, fmt.Errorf("--min-severity %q is invalid (use nit|info|warning|major|critical)", minSev)
+		}
+	}
+	maxF = cfg.Review.MaxFindings
+	if af.maxFindingsSet {
+		maxF = sf.maxFindings
+	}
+	return minSev, maxF, nil
 }
 
 // pickAuditLLM picks ONE authenticated LLM for the audit run.

--- a/cmd/local-review/audit.go
+++ b/cmd/local-review/audit.go
@@ -202,6 +202,38 @@ func runAudit(ctx context.Context, sf *sharedFlags, af auditFlags) error {
 	if err != nil {
 		return err
 	}
+
+	// Apply the --min-severity / --max-findings filters (flag wins, else
+	// the matching review.* config key). These were advertised on `audit`
+	// but inert before v0.16.
+	cfg, cfgErr := loadConfig()
+	if cfgErr != nil {
+		return cfgErr
+	}
+	minSev := sf.minSeverity
+	if minSev == "" {
+		minSev = cfg.Review.MinSeverity
+	}
+	if minSev != "" {
+		switch strings.ToLower(minSev) {
+		case "nit", "info", "warning", "major", "critical":
+		default:
+			return fmt.Errorf("--min-severity %q is invalid (use nit|info|warning|major|critical)", minSev)
+		}
+	}
+	maxF := sf.maxFindings
+	if maxF == 0 {
+		maxF = cfg.Review.MaxFindings
+	}
+	rep, hidden := rep.Filtered(minSev, maxF)
+	if hidden > 0 {
+		word := "findings"
+		if hidden == 1 {
+			word = "finding"
+		}
+		fmt.Fprintf(os.Stderr, "Note: %d %s hidden by --min-severity/--max-findings (lower the floor or raise the cap to see them).\n", hidden, word)
+	}
+
 	rep.Root = "." // stamp the conceptual working-tree root onto the report
 	return emitAuditReport(sf, af, rep)
 }

--- a/cmd/local-review/audit_test.go
+++ b/cmd/local-review/audit_test.go
@@ -5,7 +5,51 @@ import (
 	"testing"
 
 	"github.com/mshykov/local-review/internal/cli"
+	"github.com/mshykov/local-review/internal/config"
 )
+
+// TestResolveAuditFilters pins the flag-vs-config precedence for the audit
+// --min-severity / --max-findings filters, including the key case the final
+// review flagged: an explicit flag must override config even when its value
+// is the disabling "" / 0 (e.g. `--max-findings 0` to uncap a configured
+// review.max_findings).
+func TestResolveAuditFilters(t *testing.T) {
+	cfg := config.Config{Review: config.Review{MinSeverity: "warning", MaxFindings: 20}}
+
+	t.Run("unset flags inherit config", func(t *testing.T) {
+		minSev, maxF, err := resolveAuditFilters(auditFlags{}, &sharedFlags{}, cfg)
+		if err != nil || minSev != "warning" || maxF != 20 {
+			t.Fatalf("got (%q, %d, %v), want (warning, 20, nil)", minSev, maxF, err)
+		}
+	})
+
+	t.Run("explicit --max-findings 0 overrides config to uncap", func(t *testing.T) {
+		af := auditFlags{maxFindingsSet: true}
+		minSev, maxF, err := resolveAuditFilters(af, &sharedFlags{maxFindings: 0}, cfg)
+		if err != nil || maxF != 0 {
+			t.Fatalf("got maxF=%d err=%v, want 0/nil (flag must override configured 20)", maxF, err)
+		}
+		if minSev != "warning" {
+			t.Errorf("min-severity should still inherit config, got %q", minSev)
+		}
+	})
+
+	t.Run("explicit flags win over config", func(t *testing.T) {
+		af := auditFlags{minSeveritySet: true, maxFindingsSet: true}
+		minSev, maxF, err := resolveAuditFilters(af, &sharedFlags{minSeverity: "critical", maxFindings: 5}, cfg)
+		if err != nil || minSev != "critical" || maxF != 5 {
+			t.Fatalf("got (%q, %d, %v), want (critical, 5, nil)", minSev, maxF, err)
+		}
+	})
+
+	t.Run("invalid --min-severity is rejected", func(t *testing.T) {
+		af := auditFlags{minSeveritySet: true}
+		_, _, err := resolveAuditFilters(af, &sharedFlags{minSeverity: "bogus"}, cfg)
+		if err == nil {
+			t.Fatal("expected error for invalid severity, got nil")
+		}
+	})
+}
 
 // selectAuditLLM is the only audit-internal seam users can change
 // behaviour through (the rest is delegated to pickAgents +

--- a/cmd/local-review/init.go
+++ b/cmd/local-review/init.go
@@ -113,7 +113,7 @@ var providerPresets = []providerPreset{
 		presetName:  "provider",
 		baseURL:     "",
 		defaultMdl:  "",
-		apiKeyEnv:   "LOCAL_REVIEW_API_KEY",
+		apiKeyEnv:   "YOUR_PROVIDER_API_KEY",
 		requiresKey: true,
 		note:        "Any /v1/chat/completions endpoint works (Groq, Together, OpenRouter, vLLM, etc.). Edit the agent name (`provider:`) under `llms:` in the file to whatever reads best for your team.",
 	},

--- a/cmd/local-review/main.go
+++ b/cmd/local-review/main.go
@@ -177,8 +177,8 @@ See README and https://mshykov.github.io/local-review/ for details.`,
 	}
 
 	// review-tuning (apply to all review-shape commands)
-	root.PersistentFlags().StringVar(&sf.minSeverity, "min-severity", "", "filter findings: nit|info|warning|major|critical (audit + bench only; ignored on review)")
-	root.PersistentFlags().IntVar(&sf.maxFindings, "max-findings", 0, "cap total findings shown (audit + bench only; ignored on review)")
+	root.PersistentFlags().StringVar(&sf.minSeverity, "min-severity", "", "filter findings: nit|info|warning|major|critical (audit only; ignored on review)")
+	root.PersistentFlags().IntVar(&sf.maxFindings, "max-findings", 0, "cap total findings shown (audit only; ignored on review)")
 	root.PersistentFlags().BoolVar(&sf.jsonOut, "json", false, "emit JSON instead of markdown (audit + bench only; ignored on review)")
 
 	// multi-LLM flags

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -486,6 +486,15 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	}
 	fmt.Println()
 
+	// If the user interrupted during the fan-out — the long phase where
+	// Ctrl+C is most likely — surface cancellation directly. Otherwise every
+	// invoker returns a context error and the downstream gate reports "all N
+	// LLM reviews failed", which misdiagnoses a user interrupt as an agent
+	// failure. Mirrors the post-probe handler above.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Sort results back to roster order before any downstream use.
 	// Display lines above already printed in completion order (the
 	// streaming UX); everything from here on (BuildMergeInput,

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -835,10 +835,10 @@ func warnIgnoredFlags(sf *sharedFlags) {
 		fmt.Fprintln(os.Stderr, "Warning: --json is ignored on the review path (the merged report is markdown); it still applies to audit and bench.")
 	}
 	if sf.minSeverity != "" {
-		fmt.Fprintln(os.Stderr, "Warning: --min-severity is ignored on the review path (filtering happens inside the merge prompt); it still applies to audit and bench.")
+		fmt.Fprintln(os.Stderr, "Warning: --min-severity is ignored on the review path (filtering happens inside the merge prompt); it applies to audit.")
 	}
 	if sf.maxFindings != 0 {
-		fmt.Fprintln(os.Stderr, "Warning: --max-findings is ignored on the review path (trimming happens inside the merge prompt); it still applies to audit and bench.")
+		fmt.Fprintln(os.Stderr, "Warning: --max-findings is ignored on the review path (trimming happens inside the merge prompt); it applies to audit.")
 	}
 }
 

--- a/examples/.local-review.yml
+++ b/examples/.local-review.yml
@@ -27,7 +27,7 @@ llms:
     # Optional: env var name for the API key. Local Ollama / LAN /
     # Tailscale endpoints are auth-free by default (see isLocalURL).
     # Public-internet endpoints (OpenAI, Anthropic, …) need this set.
-    # api_key_env: LOCAL_REVIEW_API_KEY
+    # api_key_env: YOUR_PROVIDER_API_KEY
 
     # Optional per-call timeout; default 60.
     # timeout_seconds: 60
@@ -38,7 +38,7 @@ llms:
   # cloud-openai:
   #   base_url: https://api.openai.com/v1
   #   model: gpt-4o-mini
-  #   api_key_env: LOCAL_REVIEW_API_KEY
+  #   api_key_env: OPENAI_API_KEY
 
   # CLI agents are auto-detected — listing them is optional, but if you
   # do, the same shape works (no base_url needed; the runtime locates

--- a/install.sh
+++ b/install.sh
@@ -97,8 +97,33 @@ if curl -fsSL "$checksums_url" -o "${tmp}/${checksums}" 2>/dev/null; then
       exit 1
     fi
   else
-    echo "⚠️  no sha256sum / shasum binary found — skipping integrity check" >&2
-    echo "   install one of: coreutils (sha256sum) or perl (shasum) for tamper resistance" >&2
+    # Manifest IS present but no verifier binary exists. Pre-fix we warned
+    # and installed anyway — the exact silent-unverified-install posture
+    # the manifest-missing branch below was hardened (v0.10.3) to prevent.
+    # Apply the same three-way fail-closed resolution so a minimal
+    # container / CI image (no coreutils, no perl) can't silently skip the
+    # integrity check. cwd is already "$tmp" (set above), so the proceed
+    # arms just fall through to the extract.
+    if [ "${INSTALL_REVIEW_SKIP_VERIFICATION:-}" = "1" ]; then
+      echo "⚠️  no sha256sum / shasum binary found — skipping integrity check" >&2
+      echo "   (INSTALL_REVIEW_SKIP_VERIFICATION=1; install coreutils or perl for tamper resistance)" >&2
+    elif : </dev/tty >/dev/tty 2>/dev/null; then
+      echo "⚠️  no sha256sum / shasum binary found — checksum verification can't run" >&2
+      echo "   install coreutils (sha256sum) or perl (shasum) for tamper resistance." >&2
+      printf "Continue without integrity verification? [y/N] " >/dev/tty
+      if ! read -r answer </dev/tty; then
+        echo "Aborted (could not read response from /dev/tty)." >&2
+        exit 1
+      fi
+      case "$answer" in
+        y|Y|yes|YES|Yes) ;;
+        *) echo "Aborted." >&2; exit 1 ;;
+      esac
+    else
+      echo "❌ no sha256sum / shasum binary found — refusing to install without integrity verification" >&2
+      echo "   install coreutils (sha256sum) or perl (shasum), or re-run with INSTALL_REVIEW_SKIP_VERIFICATION=1 to bypass" >&2
+      exit 1
+    fi
   fi
 else
   # Manifest fetch failed. Pre-fix we always fell through to install-

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -30,12 +30,13 @@ import "context"
 // downstream knows or cares which backend produced the output.
 type Invoker interface {
 	// Review takes a system prompt (the resolved pack) and a diff,
-	// returns the model's review text plus token usage. The returned
-	// string is the format the system prompt asked for — markdown in
-	// multi-LLM mode (buildReviewPrompt appends a "markdown not JSON"
-	// override), JSON in the single-LLM JSON path (Resolve appends the
-	// findings schema when RequireJSON is set). The invoker doesn't
-	// know or care which; it just shuttles bytes.
+	// returns the model's review text plus token usage. The production
+	// review path asks for markdown (buildReviewPrompt appends a
+	// "markdown not JSON" override); a structured-JSON mode is reserved
+	// for the future (Resolve appends the findings schema only when
+	// ResolveOptions.RequireJSON is set, which no production caller does
+	// today). The invoker doesn't know or care which; it just shuttles
+	// bytes.
 	Review(ctx context.Context, systemPrompt, diff string) (string, TokenUsage, error)
 
 	// RunPrompt sends a raw prompt without wrapping it in a review

--- a/internal/agents/provider/provider_invoker.go
+++ b/internal/agents/provider/provider_invoker.go
@@ -72,11 +72,12 @@ func New(name, baseURL, apiKey, apiKeyEnv, model string, timeoutSec int) *Invoke
 }
 
 // Review wraps a system prompt + diff into a chat-completions call.
-// The returned string is whatever the system prompt asked the model
-// for — markdown in multi-LLM mode (buildReviewPrompt appends a
-// "respond in markdown, NOT JSON" override), JSON in the single-LLM
-// JSON path (Resolve appends the findings schema when RequireJSON
-// is set). This invoker is format-agnostic; it just shuttles bytes.
+// The production review path asks for markdown (buildReviewPrompt
+// appends a "respond in markdown, NOT JSON" override); a structured-JSON
+// mode is reserved for the future (Resolve appends the findings schema
+// only when ResolveOptions.RequireJSON is set, which no production
+// caller does today). This invoker is format-agnostic; it just shuttles
+// bytes.
 func (p *Invoker) Review(ctx context.Context, systemPrompt, diff string) (string, agents.TokenUsage, error) {
 	msgs := []llm.Message{
 		{Role: "system", Content: systemPrompt},

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -375,6 +375,60 @@ func TestRunOne_EmptyOutputCountsAsErrorNotClean(t *testing.T) {
 	}
 }
 
+// TestReportFiltered pins MIN-10: --min-severity drops sub-threshold
+// findings, --max-findings caps the total across packages in order, both
+// recompute aggregates, and the hidden count is reported (never silently
+// dropped). The source report is left untouched.
+func TestReportFiltered(t *testing.T) {
+	newBase := func() Report {
+		r := Report{
+			FindingsBySeverity: map[string]int{},
+			Packages: []PackageReport{
+				{Package: "a", Findings: []Finding{{Severity: "critical"}, {Severity: "warning"}, {Severity: "info"}}},
+				{Package: "b", Findings: []Finding{{Severity: "major"}, {Severity: "info"}}},
+			},
+		}
+		fillAggregates(&r)
+		return r
+	}
+
+	// No floor, no cap → unchanged.
+	if got, hidden := newBase().Filtered("", 0); hidden != 0 || got.TotalFindings != 5 {
+		t.Errorf("no-op: total=%d hidden=%d, want 5/0", got.TotalFindings, hidden)
+	}
+
+	// Floor = major → keep critical + major; drop warning + 2 info.
+	maj, hidden := newBase().Filtered("major", 0)
+	if maj.TotalFindings != 2 || hidden != 3 {
+		t.Errorf("min-severity major: total=%d hidden=%d, want 2/3", maj.TotalFindings, hidden)
+	}
+	if maj.FindingsBySeverity["critical"] != 1 || maj.FindingsBySeverity["major"] != 1 || maj.FindingsBySeverity["info"] != 0 {
+		t.Errorf("severity breakdown after floor wrong: %v", maj.FindingsBySeverity)
+	}
+
+	// Cap = 2 → keep the first 2 findings across packages in order.
+	capped, hidden := newBase().Filtered("", 2)
+	if capped.TotalFindings != 2 || hidden != 3 {
+		t.Errorf("max-findings 2: total=%d hidden=%d, want 2/3", capped.TotalFindings, hidden)
+	}
+
+	// nit floor keeps everything (audit emits no nit, rank 0).
+	if got, hidden := newBase().Filtered("nit", 0); got.TotalFindings != 5 || hidden != 0 {
+		t.Errorf("nit floor: total=%d hidden=%d, want 5/0", got.TotalFindings, hidden)
+	}
+
+	// Source report must be untouched by Filtered.
+	base := newBase()
+	_, _ = base.Filtered("critical", 1)
+	total := 0
+	for _, p := range base.Packages {
+		total += len(p.Findings)
+	}
+	if total != 5 {
+		t.Errorf("Filtered mutated the source report: base now has %d findings, want 5", total)
+	}
+}
+
 // TestRun_CanceledContextStopsAndErrors pins MIN-2: a canceled audit returns
 // a non-nil error so the caller exits non-zero, instead of emitting a
 // "completed" report whose unstarted chunks were silently skipped.

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -133,6 +133,11 @@ func TestFillAggregates_CountsAcrossPackagesAndStatuses(t *testing.T) {
 			},
 			{Package: "internal/git", Clean: true, InputTokens: 500, OutputTokens: 50},
 			{Package: "internal/multi", Error: "timeout", InputTokens: 100, OutputTokens: 0},
+			// Parser-miss: no error, not the clean sentinel, zero parsed
+			// findings (LLM phrased "looks fine" in prose). Documented to
+			// count as clean — pin that branch so a parseFindings
+			// regression that drops real findings here is at least visible.
+			{Package: "internal/lang", Raw: "Looks fine to me, nothing to flag."},
 		},
 	}
 	fillAggregates(&rep)
@@ -142,7 +147,7 @@ func TestFillAggregates_CountsAcrossPackagesAndStatuses(t *testing.T) {
 	if rep.FindingsBySeverity["critical"] != 1 || rep.FindingsBySeverity["warning"] != 1 {
 		t.Errorf("FindingsBySeverity wrong: %v", rep.FindingsBySeverity)
 	}
-	if rep.PackagesWithFindings != 1 || rep.PackagesClean != 1 || rep.PackagesErrored != 1 {
+	if rep.PackagesWithFindings != 1 || rep.PackagesClean != 2 || rep.PackagesErrored != 1 {
 		t.Errorf("package status counts wrong: %+v", rep)
 	}
 	if rep.TotalInputTokens != 1600 || rep.TotalOutputTokens != 250 {
@@ -337,6 +342,63 @@ func TestRun_ParallelDispatch_ReducesWallclock(t *testing.T) {
 }
 
 func fmtPkg(i int) string { return "pkg-" + strconv.Itoa(i) }
+
+// stubInvoker returns a fixed output/error, for tests that need to drive
+// a specific Review outcome (empty output, cancellation).
+type stubInvoker struct {
+	out string
+	err error
+}
+
+func (s stubInvoker) Review(_ context.Context, _, _ string) (string, agents.TokenUsage, error) {
+	return s.out, agents.TokenUsage{}, s.err
+}
+func (s stubInvoker) RunPrompt(_ context.Context, _ string) (string, agents.TokenUsage, error) {
+	return s.out, agents.TokenUsage{}, s.err
+}
+
+// TestRunOne_EmptyOutputCountsAsErrorNotClean pins MIN-4: a CLI that exits
+// 0 with empty stdout is recorded as an error, never folded into the clean
+// bucket (which would overstate audit coverage).
+func TestRunOne_EmptyOutputCountsAsErrorNotClean(t *testing.T) {
+	pr := runOne(context.Background(),
+		Chunk{Package: "p", Files: []string{"f.go"}, Body: "x"},
+		"pack", stubInvoker{out: "   \n\t"}, time.Second)
+	if pr.Clean {
+		t.Error("empty output must not be Clean")
+	}
+	if pr.Error == "" {
+		t.Error("empty output must set Error so it lands in PackagesErrored")
+	}
+	if len(pr.Findings) != 0 {
+		t.Errorf("empty output should parse no findings, got %d", len(pr.Findings))
+	}
+}
+
+// TestRun_CanceledContextStopsAndErrors pins MIN-2: a canceled audit returns
+// a non-nil error so the caller exits non-zero, instead of emitting a
+// "completed" report whose unstarted chunks were silently skipped.
+func TestRun_CanceledContextStopsAndErrors(t *testing.T) {
+	chunks := make([]Chunk, 8)
+	for i := range chunks {
+		chunks[i] = Chunk{Package: fmtPkg(i), Files: []string{"f.go"}, Body: "x", SizeBytes: 1}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before Run dispatches any chunk
+
+	_, err := Run(ctx, chunks, Options{
+		Topic:       "security",
+		LLM:         cli.LLM{Name: "fake"},
+		Invoker:     stubInvoker{out: "clean — no issues found"},
+		Parallelism: 1,
+	})
+	if err == nil {
+		t.Fatal("canceled audit must return an error, not a clean nil")
+	}
+	if !strings.Contains(err.Error(), "canceled") {
+		t.Errorf("error should mention cancellation, got: %v", err)
+	}
+}
 
 // TestClampParallelism pins the v0.15.1 self-review fix for the
 // unbounded-worker concern. A user passing --parallel 1000 must not

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -359,6 +359,70 @@ func parseFindings(out string) []Finding {
 	return findings
 }
 
+// auditSeverityRank orders the audit severity tiers (audit has no nit —
+// see the audit packs). Higher = more severe. An unrecognized label ranks
+// 0, so it survives only when no --min-severity floor is set.
+func auditSeverityRank(sev string) int {
+	switch strings.ToLower(strings.TrimSpace(sev)) {
+	case "critical":
+		return 4
+	case "major":
+		return 3
+	case "warning":
+		return 2
+	case "info":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// Filtered returns a copy of the report keeping only findings at or above
+// minSeverity (when non-empty) and capping the total number of findings at
+// maxFindings (when > 0, across packages in report order). Aggregates are
+// recomputed on the filtered set. The second return is the number of
+// findings hidden, so the caller can disclose the truncation rather than
+// dropping it silently (CLAUDE.md rule 4). With no floor and no cap the
+// report is returned unchanged and hidden is 0.
+func (r Report) Filtered(minSeverity string, maxFindings int) (Report, int) {
+	minRank := auditSeverityRank(minSeverity)
+	hasFloor := strings.TrimSpace(minSeverity) != ""
+	if !hasFloor && maxFindings <= 0 {
+		return r, 0
+	}
+
+	out := r
+	out.FindingsBySeverity = map[string]int{}
+	out.TotalFindings = 0
+	out.PackagesWithFindings = 0
+	out.PackagesClean = 0
+	out.PackagesErrored = 0
+	out.TotalInputTokens = 0
+	out.TotalOutputTokens = 0
+	out.Packages = make([]PackageReport, len(r.Packages))
+
+	hidden, kept := 0, 0
+	for i, pr := range r.Packages {
+		np := pr
+		np.Findings = nil
+		for _, f := range pr.Findings {
+			if hasFloor && auditSeverityRank(f.Severity) < minRank {
+				hidden++
+				continue
+			}
+			if maxFindings > 0 && kept >= maxFindings {
+				hidden++
+				continue
+			}
+			np.Findings = append(np.Findings, f)
+			kept++
+		}
+		out.Packages[i] = np
+	}
+	fillAggregates(&out)
+	return out, hidden
+}
+
 // fillAggregates sums TotalFindings, FindingsBySeverity, the
 // per-package status counts, and total tokens across rep.Packages.
 // Called once at the end of Run; not exported.

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -142,6 +142,15 @@ func Run(ctx context.Context, chunks []Chunk, opts Options) (Report, error) {
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
+				// Stop pulling queued chunks once the run is canceled
+				// (Ctrl+C / SIGTERM). Without this, every remaining chunk
+				// is dispatched against an already-canceled ctx, fails
+				// instantly, and is recorded as "errored" — a "completed"
+				// report that silently dropped the tail. Mirrors the
+				// review runner, which short-circuits on ctx.Err().
+				if ctx.Err() != nil {
+					return
+				}
 				if opts.Progress != nil {
 					progMu.Lock()
 					// Stderr-shaped progress write: explicitly
@@ -162,6 +171,20 @@ func Run(ctx context.Context, chunks []Chunk, opts Options) (Report, error) {
 
 	rep.Packages = results
 	fillAggregates(&rep)
+	// Surface cancellation as an error so the caller exits non-zero rather
+	// than emitting a "completed" report whose not-yet-started chunks were
+	// silently skipped (CLAUDE.md rule 4: "completed" is wrong if anything
+	// was skipped). The partial report is still returned for callers that
+	// want to show what did finish.
+	if err := ctx.Err(); err != nil {
+		done := 0
+		for _, pr := range results {
+			if pr.Package != "" {
+				done++
+			}
+		}
+		return rep, fmt.Errorf("audit canceled after %d/%d chunks: %w", done, len(chunks), err)
+	}
 	return rep, nil
 }
 
@@ -218,6 +241,15 @@ func runOne(ctx context.Context, c Chunk, pack string, invoker cli.Invoker, time
 	}
 	if err != nil {
 		pr.Error = err.Error()
+		return pr
+	}
+	if strings.TrimSpace(out) == "" {
+		// CLI exited 0 with empty stdout (rate-limited / capacity-
+		// exhausted reply, empty --output-last-message, a parser that
+		// stripped everything). Not a clean result — record it as an
+		// error so it lands in PackagesErrored, never silently inflating
+		// PackagesClean. The review path catches the same pathology.
+		pr.Error = "LLM exited 0 but returned empty output"
 		return pr
 	}
 	pr.Raw = out

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,8 +142,14 @@ func boolPtr(b bool) *bool {
 func Defaults() Config {
 	return Config{
 		Review: Review{
-			MinSeverity:  "warning",
-			MaxFindings:  20,
+			// No severity floor / findings cap by default: audit applies
+			// these only when the user explicitly sets --min-severity /
+			// --max-findings (or the matching review.* config keys). A
+			// non-empty default would silently filter audit output, which
+			// nothing did pre-v0.16. (No production code read these before
+			// v0.16, so the prior "warning"/20 defaults were inert.)
+			MinSeverity:  "",
+			MaxFindings:  0,
 			ExcludeGlobs: []string{"**/*.lock", "**/*.snap", "**/dist/**", "**/build/**"},
 		},
 

--- a/internal/multi/metadata.go
+++ b/internal/multi/metadata.go
@@ -17,14 +17,13 @@ type Metadata struct {
 
 // ReviewMeta holds details about a single LLM's review.
 type ReviewMeta struct {
-	LLM           string `json:"llm"`
-	Version       string `json:"version"`
-	Mode          string `json:"mode"`   // "cli" or "api"
-	Status        string `json:"status"` // "success" or "failed"
-	DurationMs    int64  `json:"duration_ms"`
-	FindingsCount int    `json:"findings_count,omitempty"`
-	OutputFile    string `json:"output_file,omitempty"`
-	Error         string `json:"error,omitempty"`
+	LLM        string `json:"llm"`
+	Version    string `json:"version"`
+	Mode       string `json:"mode"`   // "cli" or "provider"
+	Status     string `json:"status"` // "success" or "failed"
+	DurationMs int64  `json:"duration_ms"`
+	OutputFile string `json:"output_file,omitempty"`
+	Error      string `json:"error,omitempty"`
 	// InputTokens / OutputTokens are prompt and response *size* in
 	// tokens — not billing numbers. Sourced from each CLI's
 	// structured output (claude / gemini JSON, codex stdout
@@ -55,12 +54,10 @@ type ReviewMeta struct {
 
 // MergeMeta holds details about the merge operation.
 type MergeMeta struct {
-	LLM                  string `json:"llm"`
-	Status               string `json:"status"`
-	FinalFindingsCount   int    `json:"final_findings_count,omitempty"`
-	DeduplicationRemoved int    `json:"deduplication_removed,omitempty"`
-	DurationMs           int64  `json:"duration_ms,omitempty"`
-	Error                string `json:"error,omitempty"`
+	LLM        string `json:"llm"`
+	Status     string `json:"status"`
+	DurationMs int64  `json:"duration_ms,omitempty"`
+	Error      string `json:"error,omitempty"`
 	// InputTokens / OutputTokens for the merge step's own LLM call,
 	// same shape and semantics as ReviewMeta — prompt/response
 	// *size*, not billed amount. Aggregating across ReviewMeta +

--- a/internal/multi/orchestrator.go
+++ b/internal/multi/orchestrator.go
@@ -100,10 +100,18 @@ func (o *Orchestrator) RunParallel(ctx context.Context, systemPrompt, diff, comm
 // the point that the channel-send pattern was hard to see.
 func (o *Orchestrator) runOne(ctx context.Context, l cli.LLM, systemPrompt, diff, commit, branch string) ReviewResult {
 	start := time.Now()
+	// Mode reflects the backend kind, discriminated by BaseURL the same
+	// way NewInvoker dispatches: a provider agent (Ollama / vLLM / any
+	// OpenAI-compat HTTP endpoint) never spawns a CLI subprocess, so
+	// recording it as "cli" was simply wrong.
+	mode := "cli"
+	if l.BaseURL != "" {
+		mode = "provider"
+	}
 	result := ReviewResult{
 		LLM:     l.Name,
 		Version: l.Version,
-		Mode:    "cli", // TODO: pass mode from invoker once API fallback is implemented
+		Mode:    mode,
 	}
 
 	invoker := o.invokerFactory(l)
@@ -144,17 +152,6 @@ func (o *Orchestrator) runOne(ctx context.Context, l cli.LLM, systemPrompt, diff
 
 	result.FilePath = path
 	return result
-}
-
-// CountSuccessful returns the number of successful reviews (Error == nil); for framing decisions prefer CountWithOutput.
-func CountSuccessful(results []ReviewResult) int {
-	count := 0
-	for _, r := range results {
-		if r.Error == nil {
-			count++
-		}
-	}
-	return count
 }
 
 // CountWithOutput returns the number of reviews with non-blank Output (matches BuildMergeInput's filter).
@@ -276,15 +273,4 @@ func (g GateDecision) ClassifyZero() ZeroMergeableReason {
 	default:
 		return ZeroMergeableMixed
 	}
-}
-
-// GetSuccessful returns only successful review results.
-func GetSuccessful(results []ReviewResult) []ReviewResult {
-	var successful []ReviewResult
-	for _, r := range results {
-		if r.Error == nil {
-			successful = append(successful, r)
-		}
-	}
-	return successful
 }

--- a/internal/multi/orchestrator_test.go
+++ b/internal/multi/orchestrator_test.go
@@ -345,3 +345,31 @@ func TestDecideGate_Empty(t *testing.T) {
 		t.Error("HasMergeable() = true on empty set, want false")
 	}
 }
+
+// TestRunParallel_ModeReflectsBackendKind pins that a provider agent
+// (BaseURL set) records mode:"provider" and a CLI agent records "cli" —
+// metadata.json was previously hardcoded to "cli" for every agent.
+func TestRunParallel_ModeReflectsBackendKind(t *testing.T) {
+	llms := []cli.LLM{
+		{Name: "claude"}, // BaseURL == "" → CLI agent
+		{Name: "local", BaseURL: "http://192.0.2.10/v1"}, // provider agent
+	}
+	storage := NewStorage(t.TempDir())
+	orch := NewOrchestrator(llms, storage)
+	orch.invokerFactory = func(cli.LLM) cli.Invoker { return &fakeInvoker{output: "## Major\n- x\n"} }
+
+	ch, err := orch.RunParallel(context.Background(), "", "diff", "abc", "main")
+	if err != nil {
+		t.Fatalf("RunParallel: %v", err)
+	}
+	modes := map[string]string{}
+	for r := range ch {
+		modes[r.LLM] = r.Mode
+	}
+	if modes["claude"] != "cli" {
+		t.Errorf("CLI agent mode = %q, want \"cli\"", modes["claude"])
+	}
+	if modes["local"] != "provider" {
+		t.Errorf("provider agent mode = %q, want \"provider\"", modes["local"])
+	}
+}


### PR DESCRIPTION
Ships the **"Next" tier** of the v0.15.1 senior-engineer audit — 12 confirmed findings across three themes — as one release. **Release: `release` + `minor`** (changes user-visible `audit` behavior + adds working filter flags).

A final pre-merge self-review (`local-review review --only claude,codex,gemini main`) was run on this branch; its findings are already folded in (see the last commit).

## 1. v0.15 cleanup
- **MIN-5** providers now record `mode:"provider"` in metadata.json (was hardcoded `"cli"`).
- **MIN-6** delete dead exported `CountSuccessful`/`GetSuccessful`.
- **MIN-7** drop three never-written metadata findings-count fields.
- **NIT-1** `Invoker.Review` docs no longer describe the removed single-LLM JSON path as live.
- **NIT-4** `init`/examples stop defaulting `api_key_env` to the removed `LOCAL_REVIEW_API_KEY`.

## 2. Audit-path parity with review
- **MIN-2** `audit` honors Ctrl+C/SIGTERM (exits non-zero, "canceled after N/M chunks") instead of a silent exit-0 "completed" report.
- **MIN-4** an exit-0-with-empty-output is an error, not "clean".
- **NIT-2** test coverage for the parser-miss → clean branch.

## 3. Smaller fixes
- **MIN-10** `--min-severity`/`--max-findings` now actually filter `audit` (flag-wins-else-config, explicit flag overrides config even to disable, invalid severity rejected, hidden count disclosed). Help text corrected to "audit only".
- **MIN-3** mid-review Ctrl+C reports cancellation, not "all N reviews failed".
- **MIN-8** merge-coverage test now exercises the per-field overlay branch.
- **MIN-12** Homebrew formula SHAs cross-verified against the release checksums manifest.
- **MIN-13** `install.sh` fails closed when no sha verifier is present.

## Verification
`gofmt -s` / `go vet` / `go build` clean; `go test -race ./...` all pass. New tests: provider-mode, audit cancel/empty-output/parser-miss, `Report.Filtered`, `resolveAuditFilters` precedence (incl. `--max-findings 0` override), merge-overlay coverage. `release.yml` validated as YAML; `install.sh` passes `sh -n`.

Full details in [CHANGELOG.md](CHANGELOG.md) under v0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit command now honors `--min-severity` and `--max-findings` flags to filter findings.
  * Installation script now enforces checksum verification with explicit opt-out or user confirmation when verification tools are unavailable.

* **Bug Fixes**
  * Improved handling of user interruption (Ctrl+C) during multi-agent reviews—now reports cancellation clearly instead of misclassifying as agent failures.

* **Documentation**
  * Clarified that `--min-severity` and `--max-findings` flags apply to audit only.
  * Updated configuration examples for provider API key environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->