### PR TITLE
test(config): land the MIN-8 merge-overlay change that missed v0.16.0

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -781,7 +781,15 @@ func TestValidate_StrayModeFieldIsIgnored(t *testing.T) {
 // drift is caught the moment a new field lands.
 func TestMergeCoversAllExportedFields(t *testing.T) {
 	src := nonZeroConfig()
-	var dst Config
+	// Seed dst with a pre-existing entry under the SAME key ("claude") so
+	// merge() takes the per-field OVERLAY branch — the normal cascade
+	// (defaults populate every CLI LLM, then user YAML overlays an existing
+	// key), not the wholesale "new LLM, copy the struct" branch. The overlay
+	// branch is where a dropped field silently no-ops in production (the
+	// documented LLMConfig.Mode-drifted-inert footgun), so coverage must
+	// walk THAT branch. The entry starts zero-valued so every field has to
+	// be copied in by an explicit overlay line.
+	dst := Config{LLMs: map[string]LLMConfig{"claude": {}}}
 	merge(&dst, src)
 
 	missing := findZeroFields(reflect.ValueOf(dst), "")


### PR DESCRIPTION
v0.16.0 shipped with its CHANGELOG claiming the MIN-8 merge-coverage fix, but `config_test.go` was accidentally left out of that release's commit (`config.go` was staged, the test wasn't). `main` still has `var dst Config`, which only exercises `merge()`'s wholesale-copy branch — not the per-field overlay branch where a dropped field silently no-ops.

This lands the one-line intended change: seed `dst` with a same-key entry so the reflection coverage walks the overlay branch. Test-only; `go test ./internal/config/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for merge behavior to ensure all code paths are properly exercised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->