### PR TITLE
v0.17.2 — cleanup patch (audit Later-tier + SonarCloud board)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-06-12
+
+**Cleanup patch.** Robustness, accessibility, and tidy-ups from the audit "Later" tier and the SonarCloud board — no new features (those land in v0.18.0).
+
+### Fixed
+
+- **`git.Extract` is now bounded and interruptible (INF-1).** It previously used a plain `exec.Command` — no context (a Ctrl+C couldn't interrupt a wedged git), no deadline, and an unbounded stdout buffer. Now: the runner's signal-trapped context flows through (`exec.CommandContext`) with a generous 2-minute backstop timeout, and a 64 MiB fail-closed size cap rejects a pathological diff with an actionable message instead of ballooning memory or silently truncating.
+- **Landing-page contrast (WCAG AA).** `.btn-primary` text and the rule-severity badge were `#667eea` (3.67:1); deepened to `#4f46e5` (6.3:1).
+
+### Internal
+
+- **Accessibility / JS tidy-ups on the landing page:** copy-status live region uses `<output>` over `role="status"`; `dataset` over `setAttribute`/`removeAttribute`; `ta.remove()` over `removeChild`; `globalThis` over `window`.
+- **Stale comment fixed (MIN-9):** `audit.resolveTimeout`'s comment conflated bench's 120s with review's actual 600s default; corrected, and the bare `300` literal is now `defaultAuditTimeoutSec`.
+- **Drift guard (NIT-3):** new test asserts the `init` wizard reproduces every `config.Defaults()` exclude glob (the cascade merge replaces the list wholesale, so a missed default would silently vanish).
+- **Lint cleanups:** deduped the 4× `" env var set"` literal in `doctor.go`; `[[ ]]` over `[ ]` in `scripts/install-hooks.sh`.
+
 ## [0.17.1] - 2026-06-11
 
 **Security patch.** Closes a `major` finding surfaced by the tool's own `audit --topic security`, plus a v0.16.0 regression that mislabeled the user's home config as untrusted.

--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -25,6 +25,10 @@ import (
 // reflecting an explicit logout that wipes recent activity.
 const claudeSessionFreshness = 30 * 24 * time.Hour
 
+// envVarSetSuffix is the doctor "authenticated" detail shown when an agent's
+// API-key env var is present (e.g. "OPENAI_API_KEY env var set").
+const envVarSetSuffix = " env var set"
+
 func doctorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",
@@ -608,7 +612,7 @@ func checkClaudeAuth(customEnvVar string) authStatus {
 	if os.Getenv(envVar) != "" {
 		return authStatus{
 			authenticated: true,
-			detail:        envVar + " env var set",
+			detail:        envVar + envVarSetSuffix,
 		}
 	}
 	// Claude Code stores tokens in macOS Keychain (or equivalent on
@@ -658,7 +662,7 @@ func checkGeminiAuth(customEnvVar string) authStatus {
 	if os.Getenv(envVar) != "" {
 		return authStatus{
 			authenticated: true,
-			detail:        envVar + " env var set",
+			detail:        envVar + envVarSetSuffix,
 		}
 	}
 	// Gemini CLI stores OAuth state in ~/.gemini/google_accounts.json
@@ -688,7 +692,7 @@ func checkCodexAuth(customEnvVar string) authStatus {
 	if os.Getenv(envVar) != "" {
 		return authStatus{
 			authenticated: true,
-			detail:        envVar + " env var set",
+			detail:        envVar + envVarSetSuffix,
 		}
 	}
 	// Codex stores an explicit auth_mode field in ~/.codex/auth.json.
@@ -784,7 +788,7 @@ func checkCopilotAuth(customEnvVar string) authStatus {
 	if strings.TrimSpace(os.Getenv(envVar)) != "" {
 		return authStatus{
 			authenticated: true,
-			detail:        envVar + " env var set",
+			detail:        envVar + envVarSetSuffix,
 		}
 	}
 	// Stored `copilot login` session. A NON-EMPTY config dir is the

--- a/cmd/local-review/init.go
+++ b/cmd/local-review/init.go
@@ -437,8 +437,10 @@ func renderConfig(presetName, baseURL, model, apiKeyEnv, minSeverity string, max
 	fmt.Fprintf(&b, "  max_findings: %d\n", maxFindings)
 	// Config slices are replaced wholesale by the cascade merge (see
 	// internal/config/config.go), so the wizard must reproduce the
-	// built-in defaults *plus* any additions. Built-in defaults today
-	// are: **/*.lock, **/*.snap, **/dist/**, **/build/**.
+	// built-in defaults *plus* any additions. Built-in defaults today are
+	// **/*.lock, **/*.snap, **/dist/**, **/build/**; the wizard also adds
+	// **/node_modules/** as a convenience. TestRenderConfig_ReproducesAll-
+	// DefaultExcludeGlobs guards that every default stays reproduced here.
 	fmt.Fprintln(&b, "  exclude:")
 	fmt.Fprintln(&b, `    - "**/*.lock"`)
 	fmt.Fprintln(&b, `    - "**/*.snap"`)

--- a/cmd/local-review/init_test.go
+++ b/cmd/local-review/init_test.go
@@ -9,8 +9,36 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mshykov/local-review/internal/config"
 	"gopkg.in/yaml.v3"
 )
+
+// TestRenderConfig_ReproducesAllDefaultExcludeGlobs pins the sync between the
+// wizard's emitted exclude list and config.Defaults(). The cascade merge
+// replaces ExcludeGlobs WHOLESALE, so a wizard-generated config must reproduce
+// every built-in default (it may add more, e.g. node_modules). If a new
+// default lands in config.Defaults() but not in renderConfig, the wizard would
+// silently drop it — this test catches that drift.
+func TestRenderConfig_ReproducesAllDefaultExcludeGlobs(t *testing.T) {
+	yml := renderConfig("provider", "https://x/v1", "m", "ENV", "warning", 20)
+	var parsed struct {
+		Review struct {
+			Exclude []string `yaml:"exclude"`
+		} `yaml:"review"`
+	}
+	if err := unmarshalYAML([]byte(yml), &parsed); err != nil {
+		t.Fatalf("generated config is not valid YAML: %v", err)
+	}
+	got := make(map[string]bool, len(parsed.Review.Exclude))
+	for _, g := range parsed.Review.Exclude {
+		got[g] = true
+	}
+	for _, want := range config.Defaults().Review.ExcludeGlobs {
+		if !got[want] {
+			t.Errorf("wizard config omits built-in default exclude %q — merge replaces wholesale so it would be lost; add it to renderConfig", want)
+		}
+	}
+}
 
 // unmarshalYAML wraps yaml.Unmarshal so the round-trip test reads
 // naturally without an extra import everywhere.

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -355,7 +355,7 @@ func runMultiLLMReview(ctx context.Context, cfg config.Config, sf *sharedFlags, 
 	}
 	printAgentRoster(active, configDisabled, sunsetDropped, cfg, branch, commit)
 
-	diffs, err := git.Extract(mode, ref)
+	diffs, err := git.Extract(ctx, mode, ref)
 	if err != nil {
 		return fmt.Errorf("extract diff: %w", err)
 	}

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,7 @@
 
     .btn-primary {
       background: white;
-      color: #667eea;
+      color: #4f46e5; /* deepened from #667eea (3.67:1) → 6.3:1 on white for WCAG AA */
       box-shadow: 0 2px 8px rgba(0,0,0,0.15);
     }
 
@@ -457,7 +457,7 @@
       display: inline-block;
       font-size: 0.72em;
       font-weight: 700;
-      background: #667eea;
+      background: #4f46e5; /* deepened from #667eea → white text hits 6.3:1 (WCAG AA for small bold) */
       color: white;
       padding: 2px 8px;
       border-radius: 4px;
@@ -1372,18 +1372,18 @@
       </p>
     </div>
   </footer>
-  <div id="copy-live" role="status" aria-live="polite" aria-atomic="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap"></div>
+  <output id="copy-live" aria-live="polite" aria-atomic="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap"></output>
   <script>
     const copyTimers = new WeakMap();
     const copyLive = document.getElementById('copy-live');
 
     function showCopied(btn) {
       if (copyTimers.has(btn)) clearTimeout(copyTimers.get(btn));
-      btn.setAttribute('data-copied', '');
+      btn.dataset.copied = '';
       btn.setAttribute('aria-label', 'Copied!');
       copyLive.textContent = 'Copied to clipboard';
       copyTimers.set(btn, setTimeout(() => {
-        btn.removeAttribute('data-copied');
+        delete btn.dataset.copied;
         btn.setAttribute('aria-label', 'Copy to clipboard');
         copyLive.textContent = '';
         copyTimers.delete(btn);
@@ -1397,7 +1397,7 @@
       document.body.appendChild(ta);
       ta.select();
       const ok = document.execCommand('copy');
-      document.body.removeChild(ta);
+      ta.remove();
       if (ok) showCopied(btn);
     }
 
@@ -1406,7 +1406,7 @@
       if (!btn) return;
       const code = btn.closest('.code-wrapper').querySelector('code');
       const text = code.textContent.trim();
-      if (navigator.clipboard && window.isSecureContext) {
+      if (navigator.clipboard && globalThis.isSecureContext) {
         navigator.clipboard.writeText(text)
           .then(() => showCopied(btn))
           .catch(() => fallbackCopy(text, btn));

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -261,10 +261,17 @@ func runOne(ctx context.Context, c Chunk, pack string, invoker cli.Invoker, time
 	return pr
 }
 
-// resolveTimeout mirrors the bench package's helper — caller-
-// supplied wins, then LLM-configured, then a hardcoded fallback.
-// Audit's fallback is intentionally longer than review's (300s vs
-// 120s) because audit chunks are larger than review diffs.
+// defaultAuditTimeoutSec is the per-chunk fallback used only when neither
+// --timeout nor the agent's configured timeout applies.
+const defaultAuditTimeoutSec = 300
+
+// resolveTimeout picks the per-chunk timeout: caller-supplied (--timeout)
+// wins, then the agent's configured timeout, then defaultAuditTimeoutSec.
+// For reference, the other paths' fallbacks differ: review defaults to
+// cli.DefaultTimeoutSec (600s) and bench to 120s — audit's 300s sits
+// between them. (The earlier comment here claimed "longer than review's
+// 300s vs 120s", conflating bench's 120s with review's actual 600s; in
+// practice the agent's configured timeout usually applies anyway.)
 func resolveTimeout(provided time.Duration, llm cli.LLM) time.Duration {
 	if provided > 0 {
 		return provided
@@ -272,7 +279,7 @@ func resolveTimeout(provided time.Duration, llm cli.LLM) time.Duration {
 	if llm.TimeoutSec > 0 {
 		return time.Duration(llm.TimeoutSec) * time.Second
 	}
-	return 300 * time.Second
+	return defaultAuditTimeoutSec * time.Second
 }
 
 // cleanSentinelRE matches the audit-pack-mandated "[clean] no

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -41,36 +41,75 @@ type Hunk struct {
 	NewFrom int    // first line number in new file
 }
 
+// gitDiffTimeout bounds a single diff extraction so a wedged git (a lock,
+// a slow clean/smudge filter, a pathological repo) can't hang the tool
+// forever even without a user Ctrl+C. Generous — local diffs are fast; this
+// is a backstop, not a tuning knob. The caller's ctx (which carries the
+// signal-handler cancellation) still interrupts sooner on Ctrl+C.
+const gitDiffTimeout = 2 * time.Minute
+
+// maxDiffBytes caps the diff we buffer and parse. Past this, the review is
+// almost certainly noise (vendored-blob churn, a generated-file rewrite) and
+// parsing risks a multi-hundred-MB memory peak. var (not const) so tests can
+// shrink it. Fail-closed: over the cap returns an actionable error rather
+// than OOMing or silently truncating.
+var maxDiffBytes int64 = 64 << 20 // 64 MiB
+
 // Extract runs git and returns one Diff per changed file.
 //
 // args:
 //
+//	ctx:  cancellation / deadline (the runner threads its signal-trapped ctx)
 //	mode: which slice of history
 //	ref:  for ModeCommit, the revspec; for ModeBranch, the *base* ref to diff against
-func Extract(mode Mode, ref string) ([]Diff, error) {
+func Extract(ctx context.Context, mode Mode, ref string) ([]Diff, error) {
 	args, err := argsFor(mode, ref)
 	if err != nil {
 		return nil, err
 	}
 
-	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("git", args...)
-	cmd.Stdout = &stdout
+	ctx, cancel := context.WithTimeout(ctx, gitDiffTimeout)
+	defer cancel()
+
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, stderr.String())
+	pipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("git stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 	}
 
-	// Stream-parse stdout via bytes.NewReader → bufio.Scanner so we
-	// don't double-buffer the diff (string copy + strings.Split slice).
-	// Large monorepo branch diffs hit 10s of MB; the legacy version
-	// held 3-4 copies of that in flight.
+	// Bound the buffered diff. LimitReader stops at maxDiffBytes+1 so we can
+	// tell "exactly at cap" from "over". On overflow, cancel() first to
+	// unblock git (now blocked writing to a full pipe) so Wait doesn't hang.
+	var stdout bytes.Buffer
+	n, copyErr := io.Copy(&stdout, io.LimitReader(pipe, maxDiffBytes+1))
+	if n > maxDiffBytes {
+		cancel()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("diff exceeds the %d MiB cap — narrow it with include/exclude globs or review a smaller commit range", maxDiffBytes>>20)
+	}
+	if err := cmd.Wait(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), ctxErr)
+		}
+		return nil, fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, stderr.String())
+	}
+	// Fail closed on a read error: a partial diff + nil err would let the
+	// gate exit 0 on a materially incomplete review.
+	if copyErr != nil {
+		return nil, fmt.Errorf("read diff: %w", copyErr)
+	}
+
+	// Stream-parse stdout via bytes.NewReader → bufio.Scanner so we don't
+	// double-buffer the diff (string copy + strings.Split slice).
 	diffs, err := parseUnifiedDiff(bytes.NewReader(stdout.Bytes()))
 	if err != nil {
-		// Fail closed: a scanner error means we have only the prefix
-		// of the diff, and the unscanned tail might contain blocking
-		// changes. Returning a partial slice + nil err would let the
-		// gate exit 0 on a materially incomplete review.
+		// Same fail-closed reasoning: a scanner error means we have only the
+		// prefix, and the unscanned tail might carry blocking changes.
 		return nil, fmt.Errorf("parse diff: %w", err)
 	}
 	return diffs, nil

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -40,7 +40,9 @@ func TestExtract_StagedDiffAndSizeCap(t *testing.T) {
 	runGit("add", "f.txt")
 
 	// Extract shells out to git in CWD; chdir into the repo (Go 1.23 has
-	// no t.Chdir, so restore manually).
+	// no t.Chdir, so restore manually). NOTE: this mutates process-global
+	// CWD, so tests in this package must NOT use t.Parallel() (none do).
+	// Restored via defer below.
 	orig, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,10 +1,73 @@
 package git
 
 import (
+	"context"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestExtract_StagedDiffAndSizeCap exercises the real git path: a staged
+// change is extracted, and a shrunk maxDiffBytes trips the fail-closed cap
+// (which also proves the overflow path doesn't hang on the full pipe).
+func TestExtract_StagedDiffAndSizeCap(t *testing.T) {
+	repo := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "t@example.com")
+	runGit("config", "user.name", "T")
+	runGit("config", "commit.gpgsign", "false")
+	f := filepath.Join(repo, "f.txt")
+	if err := os.WriteFile(f, []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "f.txt")
+	runGit("commit", "-q", "-m", "init")
+	if err := os.WriteFile(f, []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "f.txt")
+
+	// Extract shells out to git in CWD; chdir into the repo (Go 1.23 has
+	// no t.Chdir, so restore manually).
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+
+	diffs, err := Extract(context.Background(), ModeStaged, "")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(diffs) == 0 {
+		t.Fatal("expected at least one staged diff")
+	}
+
+	// Shrink the cap so any real diff overflows; must fail closed, not hang.
+	old := maxDiffBytes
+	maxDiffBytes = 1
+	defer func() { maxDiffBytes = old }()
+	if _, err := Extract(context.Background(), ModeStaged, ""); err == nil {
+		t.Error("expected a size-cap error with maxDiffBytes=1, got nil")
+	} else if !strings.Contains(err.Error(), "cap") {
+		t.Errorf("expected a cap error, got: %v", err)
+	}
+}
 
 // errReader returns r.pre on the first read, then r.err on every
 // subsequent read. Used to simulate a real I/O failure mid-stream so

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -27,8 +27,8 @@ chained="$hooks_dir/pre-commit.local"
 
 mkdir -p "$hooks_dir"
 
-if [ -e "$hook" ] && ! grep -q "local-review secret/PII pre-commit" "$hook" 2>/dev/null; then
-  if [ -e "$chained" ]; then
+if [[ -e "$hook" ]] && ! grep -q "local-review secret/PII pre-commit" "$hook" 2>/dev/null; then
+  if [[ -e "$chained" ]]; then
     # Ambiguous: a foreign pre-commit AND a pre-commit.local both exist.
     # We can't chain a second one without clobbering the first, so
     # fail-closed and let the human resolve it — never silently disable
@@ -104,7 +104,7 @@ chmod +x "$hook"
 echo "✓ Installed pre-commit hook → $hook"
 
 # Seed the personal denylist from the template on first install.
-if [ ! -f "$repo_root/.git-personal-denylist" ] && [ -f "$repo_root/.git-personal-denylist.example" ]; then
+if [[ ! -f "$repo_root/.git-personal-denylist" && -f "$repo_root/.git-personal-denylist.example" ]]; then
   cp "$repo_root/.git-personal-denylist.example" "$repo_root/.git-personal-denylist"
   echo "✓ Created .git-personal-denylist (gitignored) — add your own IPs / emails / names to it."
 fi


### PR DESCRIPTION
The deferred **cleanup batch** — audit "Later" tier + SonarCloud board. All fixes/cleanups/docs, **no new features** → `patch` (the two roadmap features remain for v0.18.0). `release` + `patch` → tags v0.17.2 on merge. Pre-push self-review run (its one warning — CWD mutation in a git test — is documented; no major/critical).

## Fixed
- **INF-1** — `git.Extract` now uses the signal-trapped context (interruptible) + a 2-min backstop timeout + a 64 MiB fail-closed size cap (no more unbounded buffer / un-interruptible wedged git). Tested incl. the overflow-doesn't-hang path.
- **a11y contrast** — `.btn-primary` text + severity badge `#667eea` (3.67:1) → `#4f46e5` (6.3:1), WCAG AA.

## Internal / chore
- **MIN-9** — fixed the stale `audit.resolveTimeout` comment (conflated bench's 120s with review's 600s) + named the `300` literal.
- **NIT-3** — drift-guard test: `init` wizard reproduces every `config.Defaults()` exclude glob.
- **A2/A4** — deduped `" env var set"` literal; `[[ ]]` in `install-hooks.sh`.
- **docs/index.html** — `<output>` over `role=status`; `dataset`/`remove()`/`globalThis` JS modernizations.

## Deliberately *not* done
- **INF-2 (toolchain pin)** — pinning trades automatic compiler-security-patch pickup for byte-reproducibility; not a clear win, skipped.
- **3 "commented-out code" Sonar flags** — false positives (intent comments explaining design decisions, not dead code).
- **2 contrast spots** (hero gradient = large text, already clears 3:1; two translucent overlays) — left for rendered-composite judgment.

## Verification
`gofmt`/`vet`/`go test -race ./...`/e2e all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)