### PR TITLE
chore: bump Go toolchain to 1.26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -87,4 +87,4 @@ body:
     id: go-version
     attributes:
       label: Go version (if building from source)
-      placeholder: "e.g., go1.23.0"
+      placeholder: "e.g., go1.26.0"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: true
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: true
       - name: Tidy + verify
         run: go mod tidy && git diff --exit-code go.mod go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: true
 
       - name: Build

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -23,12 +23,13 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           # This job only BUILDS the gitleaks tool — it doesn't build
-          # local-review (that's ci.yml, pinned to the project's 1.23).
-          # gitleaks v8.30.1 requires Go >= 1.24.11, so this job uses a
-          # newer toolchain. GOTOOLCHAIN=auto (below) lets `go install`
-          # fetch a still-newer toolchain if a future gitleaks needs one,
-          # so this won't silently break on the next gitleaks bump.
-          go-version: '1.24'
+          # local-review (that's ci.yml, pinned to the project's 1.26).
+          # Matches the project's 1.26 toolchain, which already clears
+          # gitleaks v8.30.1's Go >= 1.24.11 floor. GOTOOLCHAIN=auto
+          # (below) lets `go install` fetch a still-newer toolchain if a
+          # future gitleaks needs one, so this won't silently break on
+          # the next gitleaks bump.
+          go-version: '1.26'
           cache: true
       - name: Install gitleaks (pinned, Go-module-checksum verified)
         # `go install <module>@<version>` is pinned AND verified against

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -86,7 +86,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: true
 
       - name: Run tests with coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ go build -o local-review ./cmd/local-review
 ./local-review doctor            # check LLM installs
 ```
 
-Required: Go 1.23+, git in PATH. For real end-to-end testing: Node 20+ plus at least one of `@anthropic-ai/claude-code`, `@google/gemini-cli`, `@openai/codex`, `@github/copilot`. For provider-agent testing: a reachable OpenAI-compat endpoint (local `ollama serve` is easiest) configured under `llms.<name>.base_url` in `~/.local-review.yml` or `./.local-review.yml`. The v0 `LOCAL_REVIEW_API_KEY` single-LLM-fallback env var was removed in v0.15 along with the `provider:` block; API keys now live under `llms.<name>.api_key_env: NAME_OF_YOUR_ENV_VAR`.
+Required: Go 1.26+, git in PATH. For real end-to-end testing: Node 20+ plus at least one of `@anthropic-ai/claude-code`, `@google/gemini-cli`, `@openai/codex`, `@github/copilot`. For provider-agent testing: a reachable OpenAI-compat endpoint (local `ollama serve` is easiest) configured under `llms.<name>.base_url` in `~/.local-review.yml` or `./.local-review.yml`. The v0 `LOCAL_REVIEW_API_KEY` single-LLM-fallback env var was removed in v0.15 along with the `provider:` block; API keys now live under `llms.<name>.api_key_env: NAME_OF_YOUR_ENV_VAR`.
 
 CI (`.github/workflows/ci.yml`) runs `go vet` + `go test -race` + build on every push. Tagging `vX.Y.Z` on main triggers cross-compiled releases (darwin/linux/windows × amd64/arm64).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ go build -o local-review ./cmd/local-review
 ```
 
 Required:
-- Go 1.23+
+- Go 1.26+
 - Node.js 20+ and npm — only if you want to test the multi-LLM mode locally
 
 ### Multi-LLM development setup

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -32,7 +32,7 @@ reviewers) hold contributions to:
 
 ## Toolchain & basics
 
-- **Go 1.23+**, `git` in PATH.
+- **Go 1.26+**, `git` in PATH.
 - `gofmt -s` and `go vet` must be clean before pushing.
 - New logic needs a unit test — see [testing.md](testing.md).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mshykov/local-review
 
-go 1.23.0
+go 1.26.0
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## Why

[Dependabot #136](https://github.com/mshykov/local-review/pull/136) (`golang.org/x/term` 0.33.0 → 0.44.0) fails CI:

```
go: go.mod requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)
Error: Process completed with exit code 1.
```

`x/term@0.44.0`'s `go.mod` declares `go 1.25.0`, so `go mod tidy` raised our `go` directive past the **1.23** every workflow pins. With `GOTOOLCHAIN=local` the runner can't auto-upgrade, so it fails before tidy even runs. Rather than chase the floor dep-by-dep, raise the project to the current stable **1.26**.

## Changes

- **go.mod** — `go 1.23.0` → `go 1.26.0`. Deps unchanged; `x/term` stays `0.33.0` here (its bump rides in on the rebased #136).
- **Workflows** — `ci`, `bench`, `release`, `sonar` `setup-go` `1.23` → `1.26`; `secret-scan` `1.24` → `1.26` (still clears gitleaks v8.30.1's `1.24.11` floor), stale "project's 1.23" comment refreshed.
- **Docs** — `CLAUDE.md`, `docs/developer.md`, `CONTRIBUTING.md` "Go 1.23+" → "Go 1.26+"; bug-report template placeholder `go1.23.0` → `go1.26.0`.

## Verification (local, go1.26.4)

`go mod tidy` clean · `gofmt -s -l` clean · `go vet ./...` clean · `go test -race ./...` pass · `go test -tags e2e ./e2e/...` pass · build OK.

## Follow-up

After this merges, #136 rebases onto the new `main` and its `test` check should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go toolchain requirement to version 1.26 across build, test, and development configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->