### PR TITLE
docs(contributing): refresh LLM install list + internal/llm test note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,16 @@ Install LLM CLIs for testing multi-LLM features:
 # Install Node.js via Homebrew (macOS)
 brew install node
 
-# Install LLM CLIs
-npm install -g @google/gemini-cli
-npm install -g @openai/codex
+# Install LLM CLIs (any subset works)
 npm install -g @anthropic-ai/claude-code
+npm install -g @openai/codex
+npm install -g @github/copilot
 ```
 
-Note: You don't need all 3 LLMs installed to develop. The code gracefully handles missing CLIs.
+Note: You don't need all of them installed to develop — the code gracefully
+handles missing CLIs. Gemini's CLI (`@google/gemini-cli`) was sunset on
+2026-06-18 and v0.15+ auto-disables it after the cutoff, so there's no point
+installing it for dev work.
 
 ## Adding a prompt pack
 
@@ -95,7 +98,7 @@ The test suite verifies every pack file loads. Add a case to `internal/lang/dete
 ## Tests
 
 - Pure logic gets a unit test. We won't merge new behaviour without one.
-- `internal/llm/` is intentionally not mocked in tests yet — that's a gap, contributions welcome.
+- `internal/llm/`'s happy-path round-trip is exercised by the e2e suite against a fake OpenAI-compatible server; unit tests for its failure modes (non-2xx bodies, malformed JSON, truncation) are still welcome. See `docs/testing.md` → "Known gap".
 
 ## Secrets & personal data — install the pre-commit hook
 


### PR DESCRIPTION
Tech-debt Phase 1A (documentation drift).

- **Install list**: dropped sunset `@google/gemini-cli` (v0.15+ auto-disables it), added `@github/copilot` (a live reviewer), fixed "all 3 LLMs" wording.
- **Test note**: the "internal/llm not mocked yet" claim contradicted its ~93% coverage and `docs/testing.md`; reworded to match reality.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified CLI installation requirements—installing any subset of supported tools is sufficient
  * Added Gemini CLI deprecation notice (sunset 2026-06-18); auto-disabled in newer versions
  * Clarified test coverage approach with expanded guidance on e2e and unit testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->