### PR TITLE
ci: add govulncheck dependency vulnerability scanning

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,43 @@
+name: govulncheck
+
+# Go dependency vulnerability scanning. CodeQL covers our own source
+# (SAST); this covers *known CVEs in dependencies*, which CodeQL doesn't.
+# govulncheck is low-noise: it reports a vuln only when the vulnerable
+# symbol is actually reachable from our code, not merely present in go.sum.
+#
+# Runs on every push/PR AND on a weekly schedule — the schedule is the
+# point: a CVE can be disclosed against an already-merged, pinned
+# dependency long after the PR that introduced it, and only a time-based
+# run will catch that.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Mondays 06:00 UTC — catch vulns disclosed since the last push.
+    - cron: '0 6 * * 1'
+
+# Read-only: this job checks out code and scans it — no writes.
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26'
+          cache: true
+      - name: Install govulncheck (pinned, Go-module-checksum verified)
+        # Pinned version (not @latest) for reproducible runs and supply-chain
+        # hygiene — same rationale as the gitleaks pin in secret-scan.yml.
+        # GOTOOLCHAIN=auto lets `go install` fetch a newer toolchain if a
+        # future govulncheck needs one, so this won't silently break on bump.
+        env:
+          GOTOOLCHAIN: auto
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
+      - name: Scan dependencies for known vulnerabilities
+        run: govulncheck ./...


### PR DESCRIPTION
Tech-debt Phase 1B (dependency/infrastructure debt).

Adds Go dependency vulnerability scanning — the one gap in an otherwise mature CI (CodeQL is SAST over our own code; it doesn't catch known CVEs in dependencies).

- **`govulncheck` pinned to v1.4.0** (supply-chain hygiene, same as the gitleaks pin).
- **Reachability-based** → low noise: flags a vuln only when the vulnerable symbol is actually called from our code.
- **push + PR + weekly schedule** (Mon 06:00 UTC). The schedule matters: CVEs get disclosed against already-pinned deps after merge; only a time-based run catches those.
- Mirrors `secret-scan.yml` conventions (pinned SHAs, `contents: read`, `GOTOOLCHAIN=auto` for install).

Verified locally: `govulncheck ./...` → **No vulnerabilities found** (exit 0), so this lands green.

Note: not added to the branch ruleset's required checks — it'll show on PRs but won't block merge unless you add it to required status checks (your call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)