### PR TITLE
chore: ignore _do_not_commit/ (single local junk drawer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,14 @@
 *.bak*
 .local-review/reviews/
 
-# Local scratch / working notes that must never be committed. `_do-not-commit/`
-# holds planning + business docs (and is named to say so); `local-review-doc/`
-# holds ad-hoc audit/report output. Previously only the typo'd `do-not-merge/`
-# was listed, so a stray `git add -A` could have committed either dir.
+# Local scratch / working notes that must never be committed.
+# `_do_not_commit/` is the single local junk drawer — planning + business
+# docs, secrets (e.g. sonar.token), ad-hoc audit/report output (the old
+# `local-review-doc/` now lives under it), and per-session handoff notes.
+# Never `git add` anything under it. The `_do-not-commit/` (hyphen) and
+# `local-review-doc/` spellings stay ignored too as a belt-and-suspenders
+# guard against an old path or a stray `git add -A`.
+_do_not_commit/
 _do-not-commit/
 local-review-doc/
 


### PR DESCRIPTION
Tidies the repo's local-scratch handling into a single gitignored junk drawer.

- `.gitignore` now ignores **`_do_not_commit/`** (underscores) — the existing `_do-not-commit/` was renamed to it locally and the ad-hoc `local-review-doc/` output folded under it.
- Legacy `_do-not-commit/` and `local-review-doc/` spellings stay ignored as a safety net.
- Go package layout untouched (already idiomatic); only OS junk (`.DS_Store`) cleaned + scratch consolidated locally.

`.gitignore`-only change; no tracked file referenced the old paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to keep local scratch and review-note folders out of version control.
  * Added clearer guidance to help prevent accidental commits of temporary work files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->