### PR TITLE
ci(sonar): switch to CI-based PR analysis (fix stale Automatic Analysis gate)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,19 +1,24 @@
 name: SonarCloud
 
-# Runs SonarCloud analysis ONLY when a release-labeled PR merges to main.
-# Mirrors the gating logic in release.yml — Sonar is part of the release
-# quality bar, not a per-PR check that runs on every doc tweak.
+# CI-based SonarCloud analysis. Runs a fresh scan on every pull request and on
+# every push to main, so each PR push gets a quality gate that reflects THAT
+# PR's actual code.
 #
-# Why "release-labeled merges only" instead of "every push to main":
-#   - Sonar consumes a quota per scan; running on every doc / refactor /
-#     CI fiddle PR would burn it without surfacing actionable findings.
-#   - Release-labeled PRs are the ones we promote to a tag + binaries,
-#     so they're the ones we actually care about scoring against the
-#     long-term quality trend.
+# Why CI-based instead of SonarCloud's Automatic Analysis:
+#   - Automatic Analysis (the SonarCloud GitHub App) does not reliably
+#     re-analyze each PR push — it serves a stale analysis of an earlier
+#     commit, so the PR gate would go red on code that's green on main.
+#     CI-based analysis is computed from the exact checked-out commit.
+#   - Automatic Analysis MUST stay disabled in the SonarCloud project settings
+#     (Administration → Analysis Method): CI-based and Automatic analysis are
+#     mutually exclusive and the scan errors out if both are enabled.
+#   - This repo is public, so both SonarCloud analysis and GitHub Actions
+#     minutes are free — there's no per-scan quota to conserve.
 #
-# Failure posture: this workflow can fail without breaking the release
-# pipeline. release.yml is a separate workflow, so a Sonar quota outage
-# or scan glitch won't gate the binary publish.
+# Failure posture: Sonar is NOT a required status check (the branch ruleset
+# requires `test` + CodeQL only), so a red Sonar gate surfaces a finding
+# without blocking merge. Fork PRs don't run the scan (SONAR_TOKEN isn't
+# exposed to forks) — see the job-level `if:` guard.
 
 on:
   push:
@@ -24,62 +29,32 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - 'examples/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'examples/**'
 
-# Default to read-only; jobs that need more escalate explicitly.
+# Default to read-only; the scan only checks out and uploads results.
 permissions:
   contents: read
 
 jobs:
-  gate:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read  # gh pr view --json labels
-    outputs:
-      should_scan: ${{ steps.gate.outputs.should_scan }}
-    steps:
-      - name: Gate (release-labeled PR merge)
-        id: gate
-        env:
-          GH_TOKEN: ${{ github.token }}
-          COMMIT_SHA: ${{ github.sha }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Lookup the PR via the GitHub API (works for squash, merge
-          # commit, and rebase merge strategies — parsing the commit
-          # subject only catches merge commits). Using `gh api`
-          # instead of `gh pr view` because this job doesn't check
-          # out the repo, so `gh pr view` would fail trying to infer
-          # the git context from cwd.
-          pr_number=$(gh api "/repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
-            --jq '.[0].number' 2>/dev/null || echo "")
-          if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
-            echo "No PR found for commit ${COMMIT_SHA} — skipping Sonar"
-            echo "should_scan=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Same reason for `gh api ... --jq` over `gh pr view --repo`:
-          # explicit, no cwd dependency.
-          labels=$(gh api "/repos/${REPO}/pulls/${pr_number}" \
-            --jq '.labels[].name' 2>/dev/null || echo "")
-          if echo "$labels" | grep -qxF "release"; then
-            echo "PR #$pr_number has 'release' label — running Sonar scan"
-            echo "should_scan=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "PR #$pr_number has no 'release' label — skipping Sonar"
-            echo "should_scan=false" >> "$GITHUB_OUTPUT"
-          fi
-
   scan:
-    needs: gate
-    if: needs.gate.outputs.should_scan == 'true'
+    # Skip PRs from forks: SONAR_TOKEN isn't exposed to fork PRs, so the scan
+    # can't authenticate and would fail noisily. Same-repo PRs (head repo ==
+    # this repo) and pushes to main run normally.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read  # checkout + read-only Sonar upload
     steps:
-      # fetch-depth: 0 gives Sonar the full history it needs for blame
-      # data ("new code" calculations against branch lifetime).
+      # fetch-depth: 0 gives Sonar the full history it needs for blame data
+      # ("new code" calculations against branch lifetime) and PR base detection.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
@@ -102,6 +77,9 @@ jobs:
           go test -race -covermode=atomic -coverprofile=coverage.out ./...
 
       - name: SonarQube Scan
+        # The action auto-detects PR context (sonar.pullrequest.key/branch/base)
+        # from the GitHub Actions environment, so PRs and main both work with no
+        # extra config.
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -123,9 +123,11 @@ CI/infra change.
 
 - **SonarCloud Automatic Analysis doesn't reliably re-analyze PR pushes.** PR-level
   gate "failures" were stale analyses of an *earlier* commit; the identical code was
-  green on `main` after merge. Don't trust the PR Sonar check's timing — confirm
-  against `branch=main` after merge, or move Sonar to a `pull_request`-triggered CI
-  job (it only runs on push-to-main today) for a trustworthy per-PR signal.
+  green on `main` after merge. Fixed by switching Sonar to CI-based analysis on
+  `pull_request` (`.github/workflows/sonar.yml`) and disabling Automatic Analysis in
+  the project settings (the two are mutually exclusive) — each PR push now gets a
+  fresh gate computed from its exact commit. Note: Sonar is still not a *required*
+  check, so a red gate surfaces a finding without blocking merge.
 - **Extraction relocates coverage; it does not create it.** Moving already-tested
   logic out of `cmd` *lowers* `cmd`'s coverage % — numerator and denominator both
   leave. The real win is a smaller danger zone with the logic in a cohesive, tested

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 # SonarCloud configuration. The scan workflow (.github/workflows/sonar.yml)
-# fires only on release-labeled PR merges to main; this file tells Sonar
-# what to scan and where to find coverage.
+# runs CI-based analysis on every pull request and push to main; this file
+# tells Sonar what to scan and where to find coverage.
 #
 # The action auto-detects organization + project key from secrets, but we
 # pin them here so the wiring is visible in-repo (and a future contributor


### PR DESCRIPTION
## Problem

SonarCloud's **Automatic Analysis** (the GitHub App) doesn't reliably re-analyze each PR push — it serves a stale analysis of an *earlier* commit. So PR gates went red on code that was green on `main` after merge (observed this session on #143, #144). The PR-level Sonar signal was untrustworthy.

Meanwhile the CI `sonar.yml` job was gated to **release-labeled merges only** and so effectively never ran — every run completed in 5–13s with the scan job *skipped*. All real analysis was Automatic Analysis.

## Change

Switch to **CI-based analysis** that runs a fresh scan on every `pull_request` and `push: [main]`, so each PR gate reflects that PR's exact commit:

- **Drop the `gate` job** + release-label logic entirely (it contradicts per-PR analysis, and `main` now needs per-merge analysis to stay current).
- **Add `pull_request`** trigger (keep `push: [main]`); same `paths-ignore` for docs/markdown.
- **Guard against fork PRs** — `SONAR_TOKEN` isn't exposed to forks, so the scan would fail noisily; the job `if:` skips fork PRs (same-repo PRs + main pushes run normally).
- Coverage (`coverage.out`) is produced on both paths via the single scan job.

## Manual prerequisite (done)

**Automatic Analysis disabled** in the SonarCloud project settings (Administration → Analysis Method) — CI-based and Automatic analysis are mutually exclusive; the scan errors if both are on. Verified `sonar.autoscan.enabled = false` via the API.

## Notes

- The repo is **public**, so SonarCloud analysis and GitHub Actions minutes are free — the old "conserve quota, scan release-merges only" rationale no longer applies.
- Sonar remains a **non-required** check (the branch ruleset requires `test` + CodeQL only), so a red gate surfaces a finding without blocking merge. Promoting it to required is deliberately deferred until PR analysis is confirmed reliable (per #149).
- `actionlint` clean; YAML validated.

## Acceptance criteria (#149)

- [x] Automatic Analysis disabled in SonarCloud settings (documented here).
- [x] A fresh Sonar analysis runs on this PR's push — verified: PR analyzed `2026-06-24T08:46:15Z` from the CI scan, gate `OK`, `SonarCloud Code Analysis` check green.
- [ ] `main` analysis still runs on merge; gate stays green.

Closes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
