### PR TITLE
Fix social preview metadata

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,16 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>local-review - Privacy-First AI Code Reviews</title>
-  <meta name="description" content="Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.">
+  <meta name="description" content="Run local AI code reviews across CLI and provider LLMs. Privacy-first, no telemetry, no SaaS, BYOK.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://local-review.shykov.dev/">
+  <meta property="og:site_name" content="local-review">
   <meta property="og:title" content="local-review — Privacy-First Multi-LLM Code Reviews">
-  <meta property="og:description" content="Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.">
+  <meta property="og:description" content="Run local AI code reviews across CLI and provider LLMs. Privacy-first, no telemetry, no SaaS, BYOK.">
   <meta property="og:image" content="https://local-review.shykov.dev/social-preview.png">
   <meta property="og:image:alt" content="local-review — privacy-first AI code review CLI">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="local-review — Privacy-First Multi-LLM Code Reviews">
-  <meta name="twitter:description" content="Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.">
+  <meta name="twitter:description" content="Run local AI code reviews across CLI and provider LLMs. Privacy-first, no telemetry, no SaaS, BYOK.">
   <meta name="twitter:image" content="https://local-review.shykov.dev/social-preview.png">
   <link rel="canonical" href="https://local-review.shykov.dev/">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -939,7 +940,7 @@
     "name": "local-review",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux, Windows",
-    "description": "Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.",
+    "description": "Run local AI code reviews across CLI and provider LLMs. Privacy-first, no telemetry, no SaaS, BYOK.",
     "url": "https://local-review.shykov.dev/",
     "downloadUrl": "https://github.com/mshykov/local-review/releases",
     "softwareVersion": "0.15.1",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "local-review",
   "short_name": "local-review",
-  "description": "Run AI code reviews locally with Claude, Gemini, Codex, and Copilot in parallel. Privacy-first, no telemetry, no SaaS. Free options available.",
+  "description": "Run local AI code reviews across CLI and provider LLMs. Privacy-first, no telemetry, no SaaS, BYOK.",
   "start_url": "/",
   "scope": "/",
   "display": "minimal-ui",


### PR DESCRIPTION
## Summary
- shorten the shared social preview description to avoid mobile truncation
- add og:site_name for richer Open Graph/Discord cards
- keep HTML, Twitter, JSON-LD, and manifest descriptions aligned

## Verification
- metadata assertion: descriptions are 99 chars and og:site_name is local-review
- git diff --check
- go test ./...