### PR TITLE
Use SVG logo on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -962,7 +962,7 @@
 <body>
   <header>
     <div class="container">
-      <img src="logo.png" alt="local-review logo" class="logo">
+      <img src="logo.svg" alt="local-review logo" class="logo">
       <h1>local-review</h1>
       <p class="tagline">Privacy-first AI code reviews with multi-LLM support</p>
       <div class="cta-buttons">


### PR DESCRIPTION
## Summary
- switch the visible landing-page header logo from the oversized PNG to the existing SVG asset
- keep logo.png for Apple/PWA icon surfaces

## Why
- Lighthouse flagged logo.png as 1024x1024 for a 120x120 display slot, with about 75 KiB of avoidable transfer
- the existing logo.svg is much smaller and better suited for the visible page logo

## Verification
- header logo assertion: visible logo uses logo.svg and apple-touch-icon keeps logo.png
- git diff --check origin/main...HEAD
- go test ./...