### PR TITLE
chore: ignore non-Claude AI assistant local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,28 @@
 # template is .git-personal-denylist.example. See scripts/install-hooks.sh.
 .git-personal-denylist
 
-# Antigravity CLI (`agy`) drops a per-project working dir on invocation
+# AI coding assistant local artifacts (per-developer, never committed).
+# .claude/ is intentionally NOT ignored — its skills/ are project config.
+AGENTS.md
 .antigravitycli/
+.antigravity/
+.codex/
+.openai/
+.openAI/
+.aider*
+.continue/
+.windsurf/
+.windsurfrules
+.gemini/
+.copilot/
+.github/copilot-instructions.md
+.cline/
+.clinerules
+.roo/
+.qodo/
+.tabnine/
+.sourcegraph/
+.cody/
 
 # Go
 /coverage.out


### PR DESCRIPTION
## What

Consolidate per-developer AI coding-assistant artifacts under a single `.gitignore` section, and ignore `AGENTS.md` (the Codex instruction file) as a per-developer artifact.

Covers: Codex (`AGENTS.md`, `.codex/`, `.openai/`), antigravity, aider, windsurf, gemini, copilot (incl. `.github/copilot-instructions.md`), cline, roo, qodo, tabnine, sourcegraph/cody.

## Why

These are per-developer local artifacts that should never be committed. `.claude/` stays tracked — its `skills/` are project config. The prior standalone `.antigravitycli/` entry is now subsumed by this section.

## Scope

`.gitignore`-only, trivial-config change — pre-push multi-LLM self-review skipped per CLAUDE.md rule 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)