### PR TITLE
refactor: cut cognitive complexity in cmd/local-review's danger zone to ≤15

### DIFF
--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -256,16 +256,16 @@ func checkPromptOverride(w io.Writer, cfg config.Config) {
 // pack and lists any that are unreadable or empty. Two things to check,
 // both caught by self-review iterations:
 //
-// 1. Counting any *.md file silenced the diagnostic when the user dropped
-//    a README.md into the prompts directory but no actual override files.
-//    Fix: match against the known language-id set.
+//  1. Counting any *.md file silenced the diagnostic when the user dropped
+//     a README.md into the prompts directory but no actual override files.
+//     Fix: match against the known language-id set.
 //
-// 2. A known-language override file that EXISTS but isn't READABLE (perms
-//    drift, broken symlink, NFS hiccup) would pass the count check but get
-//    silently skipped at review time by the resolver's fall-through-on-
-//    error contract. Fix: actively probe readability here, where surfacing
-//    the problem doesn't disrupt a real review run. The resolver stays
-//    resilient; doctor stays loud.
+//  2. A known-language override file that EXISTS but isn't READABLE (perms
+//     drift, broken symlink, NFS hiccup) would pass the count check but get
+//     silently skipped at review time by the resolver's fall-through-on-
+//     error contract. Fix: actively probe readability here, where surfacing
+//     the problem doesn't disrupt a real review run. The resolver stays
+//     resilient; doctor stays loud.
 func scanPromptOverrides(dir string, entries []os.DirEntry) (overrideCount int, unreadable []string) {
 	knownLangs := promptLanguageSet()
 	for _, e := range entries {

--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -68,13 +68,6 @@ func runDoctor(out io.Writer) error {
 	fmt.Fprintln(w, "Checking LLM installations and authentication...")
 	fmt.Fprintln(w)
 
-	// Mirror the runner: honor cfg.LLMs[*].CLIPath overrides so doctor
-	// and runtime see the same binaries. Without this a user with a
-	// custom cli_path would see ✗ in doctor but a successful run, or
-	// vice versa.
-	overrides := map[string]string{}
-	customEnvVars := map[string]string{}
-	models := map[string]string{}
 	cfg, cfgErr := loadConfig()
 	if cfgErr != nil {
 		// Surface the failure inline. doctor's whole job is "tell me
@@ -85,56 +78,10 @@ func runDoctor(out io.Writer) error {
 		fmt.Fprintf(w, "WARNING: failed to load config: %v\n", cfgErr)
 		fmt.Fprintln(w, "         Falling back to compiled-in defaults; cli_path / api_key_env shown below may not reflect your config.")
 		fmt.Fprintln(w)
-	} else {
-		for name, c := range cfg.LLMs {
-			if c.CLIPath != "" {
-				overrides[name] = c.CLIPath
-			}
-			// Honor cfg.LLMs[*].APIKeyEnv so a user with a key under,
-			// say, MY_GEMINI_KEY sees ✓ ready instead of "not authed".
-			// Empty falls through to the canonical default per LLM.
-			if c.APIKeyEnv != "" {
-				customEnvVars[name] = c.APIKeyEnv
-			}
-			// Surface the configured model so doctor exposes "which
-			// weights will run" — pre-fix the user only learned the
-			// model name when `review` printed the roster, too late
-			// to catch a misconfigured model before triggering an
-			// expensive call.
-			if c.Model != "" {
-				models[name] = c.Model
-			}
-		}
 	}
+	overrides, customEnvVars, models := doctorLLMOverrides(cfg, cfgErr)
 	llms := cli.DetectAllWithOverrides(overrides)
-	// Provider agents (entries with base_url in cfg.LLMs) — detected via
-	// HTTP /v1/models probe and rendered alongside CLI agents in the same
-	// readiness summary. Empty when no provider entries are configured.
-	// Specs sorted by name so doctor's provider rows appear in a stable
-	// order across runs (Go map iteration is randomised; without the sort
-	// the output flickered between invocations).
-	var providerSpecs []cli.ProviderSpec
-	if cfgErr == nil {
-		names := make([]string, 0, len(cfg.LLMs))
-		for name, c := range cfg.LLMs {
-			if c.BaseURL == "" {
-				continue
-			}
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		for _, name := range names {
-			c := cfg.LLMs[name]
-			providerSpecs = append(providerSpecs, cli.ProviderSpec{
-				Name:       name,
-				BaseURL:    c.BaseURL,
-				Model:      c.Model,
-				APIKey:     c.APIKey,
-				TimeoutSec: c.TimeoutSec,
-			})
-		}
-	}
-	llms = append(llms, cli.DetectProviders(context.Background(), providerSpecs)...)
+	llms = append(llms, cli.DetectProviders(context.Background(), doctorProviderSpecs(cfg, cfgErr))...)
 
 	// Capture `now` once so every clock-driven decision in this
 	// run (sunset gate on the numerator AND denominator, sunset
@@ -145,8 +92,99 @@ func runDoctor(out io.Writer) error {
 	// agent as available, or vice versa. (v0.15 pre-release QA
 	// catch from codex.)
 	now := time.Now().UTC()
-	readyCount := 0
-	reviewCapable := 0
+	readyCount, reviewCapable := printLLMRows(w, llms, cfg, customEnvVars, models, now)
+
+	fmt.Fprintln(w)
+	// Denominator is the review-capable count, not len(llms): an
+	// experimental CLI (e.g. antigravity) is detected but can't join
+	// the fan-out, so counting it would make "3/4 ready" read like a
+	// fixable gap when nothing is wrong.
+	fmt.Fprintf(w, "%d/%d LLMs ready for multi-review.\n", readyCount, reviewCapable)
+
+	// Issue #55: warn when prompts.pack_dir is configured but the
+	// directory is missing/empty. A misconfigured override is silent
+	// at runtime (the resolver falls through to embedded packs), so
+	// without doctor surfacing it the user would only notice their
+	// house rules aren't applying after running a review and seeing
+	// the wrong tone.
+	if cfgErr == nil {
+		checkPromptOverride(w, cfg)
+	}
+
+	return w.err
+}
+
+// doctorLLMOverrides mirrors the runner: honor cfg.LLMs[*].CLIPath overrides
+// so doctor and runtime see the same binaries (without this a user with a
+// custom cli_path would see ✗ in doctor but a successful run, or vice
+// versa), plus per-LLM APIKeyEnv and Model overrides. Returns empty maps
+// when cfg failed to load (cfgErr != nil) — same as runDoctor's pre-
+// extraction behaviour, which only populated these from a successfully
+// loaded cfg.
+func doctorLLMOverrides(cfg config.Config, cfgErr error) (overrides, customEnvVars, models map[string]string) {
+	overrides = map[string]string{}
+	customEnvVars = map[string]string{}
+	models = map[string]string{}
+	if cfgErr != nil {
+		return overrides, customEnvVars, models
+	}
+	for name, c := range cfg.LLMs {
+		if c.CLIPath != "" {
+			overrides[name] = c.CLIPath
+		}
+		// Honor cfg.LLMs[*].APIKeyEnv so a user with a key under,
+		// say, MY_GEMINI_KEY sees ✓ ready instead of "not authed".
+		// Empty falls through to the canonical default per LLM.
+		if c.APIKeyEnv != "" {
+			customEnvVars[name] = c.APIKeyEnv
+		}
+		// Surface the configured model so doctor exposes "which
+		// weights will run" — pre-fix the user only learned the
+		// model name when `review` printed the roster, too late
+		// to catch a misconfigured model before triggering an
+		// expensive call.
+		if c.Model != "" {
+			models[name] = c.Model
+		}
+	}
+	return overrides, customEnvVars, models
+}
+
+// doctorProviderSpecs builds the provider agents (entries with base_url in
+// cfg.LLMs) — detected via HTTP /v1/models probe and rendered alongside CLI
+// agents in the same readiness summary. Empty when no provider entries are
+// configured (or cfg failed to load). Specs sorted by name so doctor's
+// provider rows appear in a stable order across runs (Go map iteration is
+// randomised; without the sort the output flickered between invocations).
+func doctorProviderSpecs(cfg config.Config, cfgErr error) []cli.ProviderSpec {
+	if cfgErr != nil {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.LLMs))
+	for name, c := range cfg.LLMs {
+		if c.BaseURL == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var providerSpecs []cli.ProviderSpec
+	for _, name := range names {
+		c := cfg.LLMs[name]
+		providerSpecs = append(providerSpecs, cli.ProviderSpec{
+			Name:       name,
+			BaseURL:    c.BaseURL,
+			Model:      c.Model,
+			APIKey:     c.APIKey,
+			TimeoutSec: c.TimeoutSec,
+		})
+	}
+	return providerSpecs
+}
+
+// printLLMRows prints one row per detected LLM and returns the ready /
+// review-capable counts runDoctor needs for the "N/M LLMs ready" summary.
+func printLLMRows(w io.Writer, llms []cli.LLM, cfg config.Config, customEnvVars, models map[string]string, now time.Time) (readyCount, reviewCapable int) {
 	for _, llm := range llms {
 		var force bool
 		if c, ok := cfg.LLMs[llm.Name]; ok && c.ForceAfterSunset != nil {
@@ -170,25 +208,7 @@ func runDoctor(out io.Writer) error {
 		}
 		printLLMRow(w, llm, status, auth, models[llm.Name], force, now)
 	}
-
-	fmt.Fprintln(w)
-	// Denominator is the review-capable count, not len(llms): an
-	// experimental CLI (e.g. antigravity) is detected but can't join
-	// the fan-out, so counting it would make "3/4 ready" read like a
-	// fixable gap when nothing is wrong.
-	fmt.Fprintf(w, "%d/%d LLMs ready for multi-review.\n", readyCount, reviewCapable)
-
-	// Issue #55: warn when prompts.pack_dir is configured but the
-	// directory is missing/empty. A misconfigured override is silent
-	// at runtime (the resolver falls through to embedded packs), so
-	// without doctor surfacing it the user would only notice their
-	// house rules aren't applying after running a review and seeing
-	// the wrong tone.
-	if cfgErr == nil {
-		checkPromptOverride(w, cfg)
-	}
-
-	return w.err
+	return readyCount, reviewCapable
 }
 
 // checkPromptOverride writes a warning line when cfg.Prompts.PackDir
@@ -217,23 +237,37 @@ func checkPromptOverride(w io.Writer, cfg config.Config) {
 		fmt.Fprintf(w, "\n⚠ Prompt pack_dir %q is unreadable: %v\n", dir, err)
 		return
 	}
-	// Two things to check, both caught by self-review iterations:
-	//
-	// 1. Counting any *.md file silenced the diagnostic when the
-	//    user dropped a README.md into the prompts directory but
-	//    no actual override files. Fix: match against the known
-	//    language-id set.
-	//
-	// 2. A known-language override file that EXISTS but isn't
-	//    READABLE (perms drift, broken symlink, NFS hiccup) would
-	//    pass the count check but get silently skipped at review
-	//    time by the resolver's fall-through-on-error contract.
-	//    Fix: actively probe readability here, where surfacing the
-	//    problem doesn't disrupt a real review run. The resolver
-	//    stays resilient; doctor stays loud.
+	overrideCount, unreadable := scanPromptOverrides(dir, entries)
+	if overrideCount == 0 {
+		fmt.Fprintf(w, "\n⚠ Prompt pack_dir %q has no <language>.md files matching a shipped pack.\n", dir)
+		fmt.Fprintln(w, "  Drop a file like `go.md` or `default.md` into the directory to override the embedded pack.")
+		return
+	}
+	if len(unreadable) > 0 {
+		fmt.Fprintf(w, "\n⚠ Prompt override file(s) in %q present but unreadable:\n", dir)
+		for _, u := range unreadable {
+			fmt.Fprintf(w, "    %s\n", u)
+		}
+		fmt.Fprintln(w, "  Reviews will silently fall through to embedded packs for those languages. Fix permissions or remove the file.")
+	}
+}
+
+// scanPromptOverrides counts <language>.md files in dir matching a shipped
+// pack and lists any that are unreadable or empty. Two things to check,
+// both caught by self-review iterations:
+//
+// 1. Counting any *.md file silenced the diagnostic when the user dropped
+//    a README.md into the prompts directory but no actual override files.
+//    Fix: match against the known language-id set.
+//
+// 2. A known-language override file that EXISTS but isn't READABLE (perms
+//    drift, broken symlink, NFS hiccup) would pass the count check but get
+//    silently skipped at review time by the resolver's fall-through-on-
+//    error contract. Fix: actively probe readability here, where surfacing
+//    the problem doesn't disrupt a real review run. The resolver stays
+//    resilient; doctor stays loud.
+func scanPromptOverrides(dir string, entries []os.DirEntry) (overrideCount int, unreadable []string) {
 	knownLangs := promptLanguageSet()
-	overrideCount := 0
-	var unreadable []string
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -269,18 +303,7 @@ func checkPromptOverride(w io.Writer, cfg config.Config) {
 			unreadable = append(unreadable, fmt.Sprintf("%s (empty)", name))
 		}
 	}
-	if overrideCount == 0 {
-		fmt.Fprintf(w, "\n⚠ Prompt pack_dir %q has no <language>.md files matching a shipped pack.\n", dir)
-		fmt.Fprintln(w, "  Drop a file like `go.md` or `default.md` into the directory to override the embedded pack.")
-		return
-	}
-	if len(unreadable) > 0 {
-		fmt.Fprintf(w, "\n⚠ Prompt override file(s) in %q present but unreadable:\n", dir)
-		for _, u := range unreadable {
-			fmt.Fprintf(w, "    %s\n", u)
-		}
-		fmt.Fprintln(w, "  Reviews will silently fall through to embedded packs for those languages. Fix permissions or remove the file.")
-	}
+	return overrideCount, unreadable
 }
 
 // promptLanguageSet returns the set of language ids that have a
@@ -695,52 +718,63 @@ func checkCodexAuth(customEnvVar string) authStatus {
 			detail:        envVar + envVarSetSuffix,
 		}
 	}
-	// Codex stores an explicit auth_mode field in ~/.codex/auth.json.
-	// Newer versions write "chatgpt" or "api_key"; older versions or
-	// hand-edited files may have an empty auth_mode but a non-null
-	// OPENAI_API_KEY field — also treat that as authenticated.
 	if home := authHomeDir(); home != "" {
-		b, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
-		if err == nil {
-			var a struct {
-				AuthMode     string  `json:"auth_mode"`
-				OpenAIAPIKey *string `json:"OPENAI_API_KEY"`
-			}
-			if err := json.Unmarshal(b, &a); err == nil {
-				switch a.AuthMode {
-				case "chatgpt":
-					return authStatus{
-						authenticated: true,
-						detail:        "logged in via 'codex login' (ChatGPT subscription)",
-					}
-				case "api_key":
-					// auth_mode: "api_key" only counts when the stored
-					// key is actually non-empty. A partial / corrupted
-					// auth.json with the mode set but the key cleared
-					// must not produce a false "authenticated" result.
-					if a.OpenAIAPIKey != nil && *a.OpenAIAPIKey != "" {
-						return authStatus{
-							authenticated: true,
-							detail:        "API key configured via 'codex login --api-key'",
-						}
-					}
-				default:
-					// Older / hand-edited auth.json files may lack
-					// auth_mode but have a stored key. Honor that.
-					if a.OpenAIAPIKey != nil && *a.OpenAIAPIKey != "" {
-						return authStatus{
-							authenticated: true,
-							detail:        "API key stored in ~/.codex/auth.json",
-						}
-					}
-				}
-			}
+		if status, ok := codexAuthFromFile(home); ok {
+			return status
 		}
 	}
 	return authStatus{
 		authenticated: false,
 		hint:          fmt.Sprintf("run 'codex login' (ChatGPT Plus, $20/mo) — or export %s=... (pay-per-token, usually cheaper)", envVar),
 	}
+}
+
+// codexAuthFromFile reads ~/.codex/auth.json, which stores an explicit
+// auth_mode field. Newer versions write "chatgpt" or "api_key"; older
+// versions or hand-edited files may have an empty auth_mode but a non-null
+// OPENAI_API_KEY field — also treated as authenticated. Returns ok=false
+// when the file is missing/unreadable/unparseable or doesn't establish
+// authentication.
+func codexAuthFromFile(home string) (authStatus, bool) {
+	b, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		return authStatus{}, false
+	}
+	var a struct {
+		AuthMode     string  `json:"auth_mode"`
+		OpenAIAPIKey *string `json:"OPENAI_API_KEY"`
+	}
+	if err := json.Unmarshal(b, &a); err != nil {
+		return authStatus{}, false
+	}
+	switch a.AuthMode {
+	case "chatgpt":
+		return authStatus{
+			authenticated: true,
+			detail:        "logged in via 'codex login' (ChatGPT subscription)",
+		}, true
+	case "api_key":
+		// auth_mode: "api_key" only counts when the stored key is
+		// actually non-empty. A partial / corrupted auth.json with
+		// the mode set but the key cleared must not produce a false
+		// "authenticated" result.
+		if a.OpenAIAPIKey != nil && *a.OpenAIAPIKey != "" {
+			return authStatus{
+				authenticated: true,
+				detail:        "API key configured via 'codex login --api-key'",
+			}, true
+		}
+	default:
+		// Older / hand-edited auth.json files may lack auth_mode but
+		// have a stored key. Honor that.
+		if a.OpenAIAPIKey != nil && *a.OpenAIAPIKey != "" {
+			return authStatus{
+				authenticated: true,
+				detail:        "API key stored in ~/.codex/auth.json",
+			}, true
+		}
+	}
+	return authStatus{}, false
 }
 
 // copilotConfigDir returns Copilot CLI's config/login home — $COPILOT_HOME

--- a/cmd/local-review/doctor_test.go
+++ b/cmd/local-review/doctor_test.go
@@ -645,6 +645,49 @@ func TestGeminiSunsetBanner_PostSunsetForceShowsOverride(t *testing.T) {
 	}
 }
 
+// TestRunDoctor_Smoke exercises runDoctor end-to-end — it had NO direct
+// test before the cognitive-complexity refactor split it into named
+// helpers, which is itself the point: this fills a real, pre-existing gap
+// (SonarCloud's new-code coverage gate caught it) rather than just
+// asserting against a mock. Hermetic per runConfigCmdIn's established
+// pattern in this package: fake $HOME (no repo/user config, no auth
+// files) + a real, empty cwd, so loadConfig() falls through to compiled-in
+// defaults deterministically regardless of the machine running the test.
+//
+// Doesn't assert exact ready/review-capable counts — cli.DetectAllWithOverrides
+// does real PATH lookups, so which LLM CLIs are actually installed on the
+// machine running this test is out of this test's control. Asserts only
+// what runDoctor itself guarantees: no error, and the summary line it
+// always prints.
+func TestRunDoctor_Smoke(t *testing.T) {
+	withFakeHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(origCwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runDoctor(&buf); err != nil {
+		t.Fatalf("runDoctor returned an error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "LLMs ready for multi-review.") {
+		t.Errorf("expected the ready-count summary line, got:\n%s", out)
+	}
+}
+
 // --- doctorLLMOverrides / doctorProviderSpecs / printLLMRows ---
 // (extracted from runDoctor to cut its cognitive complexity — SonarCloud)
 

--- a/cmd/local-review/doctor_test.go
+++ b/cmd/local-review/doctor_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -641,6 +642,112 @@ func TestGeminiSunsetBanner_PostSunsetForceShowsOverride(t *testing.T) {
 	// Must NOT show auto-disabled wording when the user has opted in.
 	if strings.Contains(out, "auto-disabled") {
 		t.Errorf("force-overridden banner must not say 'auto-disabled':\n%s", out)
+	}
+}
+
+// --- doctorLLMOverrides / doctorProviderSpecs / printLLMRows ---
+// (extracted from runDoctor to cut its cognitive complexity — SonarCloud)
+
+func TestDoctorLLMOverrides_CfgErrReturnsEmptyMaps(t *testing.T) {
+	overrides, customEnvVars, models := doctorLLMOverrides(config.Config{
+		LLMs: map[string]config.LLMConfig{"claude": {CLIPath: "/x/claude"}},
+	}, errFakeConfigLoad)
+	if len(overrides) != 0 || len(customEnvVars) != 0 || len(models) != 0 {
+		t.Errorf("cfgErr != nil must yield empty maps, got overrides=%v customEnvVars=%v models=%v", overrides, customEnvVars, models)
+	}
+}
+
+func TestDoctorLLMOverrides_PopulatesOnlySetFields(t *testing.T) {
+	cfg := config.Config{LLMs: map[string]config.LLMConfig{
+		"claude": {CLIPath: "/usr/local/bin/claude", APIKeyEnv: "MY_KEY", Model: "opus"},
+		"gemini": {}, // no overrides set — must not appear in any map
+	}}
+	overrides, customEnvVars, models := doctorLLMOverrides(cfg, nil)
+	if overrides["claude"] != "/usr/local/bin/claude" {
+		t.Errorf("overrides[claude] = %q, want the configured CLIPath", overrides["claude"])
+	}
+	if customEnvVars["claude"] != "MY_KEY" {
+		t.Errorf("customEnvVars[claude] = %q, want MY_KEY", customEnvVars["claude"])
+	}
+	if models["claude"] != "opus" {
+		t.Errorf("models[claude] = %q, want opus", models["claude"])
+	}
+	if _, ok := overrides["gemini"]; ok {
+		t.Error("gemini has no CLIPath set; must not appear in overrides")
+	}
+	if _, ok := customEnvVars["gemini"]; ok {
+		t.Error("gemini has no APIKeyEnv set; must not appear in customEnvVars")
+	}
+	if _, ok := models["gemini"]; ok {
+		t.Error("gemini has no Model set; must not appear in models")
+	}
+}
+
+func TestDoctorProviderSpecs_CfgErrReturnsNil(t *testing.T) {
+	specs := doctorProviderSpecs(config.Config{
+		LLMs: map[string]config.LLMConfig{"local": {BaseURL: "http://x"}},
+	}, errFakeConfigLoad)
+	if specs != nil {
+		t.Errorf("cfgErr != nil must yield nil specs, got %v", specs)
+	}
+}
+
+func TestDoctorProviderSpecs_OnlyBaseURLEntriesSortedByName(t *testing.T) {
+	cfg := config.Config{LLMs: map[string]config.LLMConfig{
+		"zeta":  {BaseURL: "http://z", Model: "m-z"},
+		"alpha": {BaseURL: "http://a", Model: "m-a", APIKey: "k", TimeoutSec: 30},
+		"claude": {
+			// No BaseURL — a plain CLI agent, must be excluded.
+			CLIPath: "/usr/local/bin/claude",
+		},
+	}}
+	specs := doctorProviderSpecs(cfg, nil)
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 provider specs (BaseURL entries only), got %d: %+v", len(specs), specs)
+	}
+	if specs[0].Name != "alpha" || specs[1].Name != "zeta" {
+		t.Errorf("expected sorted [alpha, zeta], got [%s, %s]", specs[0].Name, specs[1].Name)
+	}
+	if specs[0].BaseURL != "http://a" || specs[0].Model != "m-a" || specs[0].APIKey != "k" || specs[0].TimeoutSec != 30 {
+		t.Errorf("alpha spec fields not carried through: %+v", specs[0])
+	}
+}
+
+// errFakeConfigLoad is a non-nil sentinel error for exercising the
+// cfgErr != nil branch of doctorLLMOverrides / doctorProviderSpecs — the
+// functions only check err != nil, never its value.
+var errFakeConfigLoad = fmt.Errorf("fake config load failure")
+
+func TestPrintLLMRows_CountsReadyAndReviewCapable(t *testing.T) {
+	// A fixed pre-2026 `now` keeps every CLI agent's sunset gate off
+	// regardless of real-world sunset dates, so this test doesn't
+	// depend on when it's run.
+	now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	llms := []cli.LLM{
+		// Provider agent, BaseURL set + Available=true: classify()
+		// returns statusReady with zero filesystem/env dependency —
+		// the simplest deterministic "ready" case.
+		{Name: "myprovider", BaseURL: "http://x", Available: true},
+		// A real CLI agent that isn't installed: statusNotInstalled,
+		// still review-capable (not experimental), just not ready.
+		{Name: "claude", Available: false},
+		// Experimental (review-incapable): must NOT count toward
+		// reviewCapable even though Available=true.
+		{Name: "antigravity", Available: true},
+	}
+	var buf bytes.Buffer
+	readyCount, reviewCapable := printLLMRows(&buf, llms, config.Config{}, map[string]string{}, map[string]string{}, now)
+	if reviewCapable != 2 {
+		t.Errorf("reviewCapable = %d, want 2 (myprovider + claude; antigravity excluded)", reviewCapable)
+	}
+	if readyCount != 1 {
+		t.Errorf("readyCount = %d, want 1 (myprovider only)", readyCount)
+	}
+	out := buf.String()
+	for _, name := range []string{"myprovider", "Claude", "Antigravity"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("expected a printed row mentioning %q, got:\n%s", name, out)
+		}
 	}
 }
 

--- a/cmd/local-review/init.go
+++ b/cmd/local-review/init.go
@@ -158,58 +158,19 @@ var providerPresets = []providerPreset{
 func runInit(out io.Writer, in io.Reader, target string, force bool) error {
 	r := bufio.NewReader(in)
 
-	if info, err := os.Stat(target); err == nil {
-		if info.IsDir() {
-			return fmt.Errorf("%s is a directory; refusing to overwrite", target)
-		}
-		if !force {
-			fmt.Fprintf(out, "%s already exists.\n", target)
-			yn, err := promptString(out, r, "Overwrite?", "n")
-			if err != nil {
-				return err
-			}
-			if !isYes(yn) {
-				fmt.Fprintln(out, "Aborted; no changes made.")
-				return nil
-			}
-		}
+	proceed, err := confirmOverwriteExisting(out, r, target, force)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		fmt.Fprintln(out, "Aborted; no changes made.")
+		return nil
 	}
 
 	fmt.Fprintln(out, "local-review init — quick setup. Press Enter to accept defaults.")
 	fmt.Fprintln(out)
 
-	preset, err := promptProviderRetry(out, r)
-	if err != nil {
-		return err
-	}
-
-	baseURL := preset.baseURL
-	if baseURL == "" {
-		baseURL, err = promptNonEmpty(out, r, "Base URL (e.g. https://api.example.com/v1)", "")
-		if err != nil {
-			return err
-		}
-	}
-
-	model, err := promptNonEmpty(out, r, "Model", preset.defaultMdl)
-	if err != nil {
-		return err
-	}
-
-	var apiKeyEnv string
-	if preset.requiresKey {
-		apiKeyEnv, err = promptString(out, r, "API key environment variable", preset.apiKeyEnv)
-		if err != nil {
-			return err
-		}
-	}
-
-	minSeverity, err := promptChoiceRetry(out, r, "Minimum severity to show", []string{"nit", "info", "warning", "major", "critical"}, 2)
-	if err != nil {
-		return err
-	}
-
-	maxFindings, err := promptPositiveIntRetry(out, r, "Maximum findings per review", 20)
+	preset, baseURL, model, apiKeyEnv, minSeverity, maxFindings, err := promptConfigValues(out, r)
 	if err != nil {
 		return err
 	}
@@ -222,18 +183,13 @@ func runInit(out io.Writer, in io.Reader, target string, force bool) error {
 	fmt.Fprint(out, yml)
 	fmt.Fprintln(out, "----------------")
 
-	if force {
-		// --force is the non-interactive flag; don't prompt for the final confirmation either.
-		fmt.Fprintf(out, "Writing to %s (--force).\n", target)
-	} else {
-		confirm, err := promptString(out, r, fmt.Sprintf("Write to %s?", target), "y")
-		if err != nil {
-			return err
-		}
-		if !isYes(confirm) {
-			fmt.Fprintln(out, "Aborted; no changes made.")
-			return nil
-		}
+	proceed, err = confirmWrite(out, r, target, force)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		fmt.Fprintln(out, "Aborted; no changes made.")
+		return nil
 	}
 
 	if err := os.WriteFile(target, []byte(yml), 0o600); err != nil {
@@ -253,6 +209,87 @@ func runInit(out io.Writer, in io.Reader, target string, force bool) error {
 	}
 	fmt.Fprintln(out, "  Try a review:      local-review staged")
 	return nil
+}
+
+// confirmOverwriteExisting checks whether target already exists and, if so,
+// refuses outright for a directory or prompts (unless force) before
+// allowing the overwrite. Returns proceed=false (no error) when the user
+// declines — runInit treats that as a clean abort, not a failure.
+func confirmOverwriteExisting(out io.Writer, r *bufio.Reader, target string, force bool) (proceed bool, err error) {
+	info, statErr := os.Stat(target)
+	if statErr != nil {
+		return true, nil
+	}
+	if info.IsDir() {
+		return false, fmt.Errorf("%s is a directory; refusing to overwrite", target)
+	}
+	if force {
+		return true, nil
+	}
+	fmt.Fprintf(out, "%s already exists.\n", target)
+	yn, err := promptString(out, r, "Overwrite?", "n")
+	if err != nil {
+		return false, err
+	}
+	return isYes(yn), nil
+}
+
+// promptConfigValues walks the interactive prompt sequence that builds a
+// config: provider preset, base URL (only when the preset doesn't supply
+// one), model, API key env var (only when the preset requires one), min
+// severity, and max findings.
+func promptConfigValues(out io.Writer, r *bufio.Reader) (preset providerPreset, baseURL, model, apiKeyEnv, minSeverity string, maxFindings int, err error) {
+	preset, err = promptProviderRetry(out, r)
+	if err != nil {
+		return preset, "", "", "", "", 0, err
+	}
+
+	baseURL = preset.baseURL
+	if baseURL == "" {
+		baseURL, err = promptNonEmpty(out, r, "Base URL (e.g. https://api.example.com/v1)", "")
+		if err != nil {
+			return preset, "", "", "", "", 0, err
+		}
+	}
+
+	model, err = promptNonEmpty(out, r, "Model", preset.defaultMdl)
+	if err != nil {
+		return preset, "", "", "", "", 0, err
+	}
+
+	if preset.requiresKey {
+		apiKeyEnv, err = promptString(out, r, "API key environment variable", preset.apiKeyEnv)
+		if err != nil {
+			return preset, "", "", "", "", 0, err
+		}
+	}
+
+	minSeverity, err = promptChoiceRetry(out, r, "Minimum severity to show", []string{"nit", "info", "warning", "major", "critical"}, 2)
+	if err != nil {
+		return preset, "", "", "", "", 0, err
+	}
+
+	maxFindings, err = promptPositiveIntRetry(out, r, "Maximum findings per review", 20)
+	if err != nil {
+		return preset, "", "", "", "", 0, err
+	}
+
+	return preset, baseURL, model, apiKeyEnv, minSeverity, maxFindings, nil
+}
+
+// confirmWrite prompts "Write to <target>?" before the final write, unless
+// force is set (the non-interactive flag skips the final confirmation too).
+// Returns proceed=false (no error) when the user declines.
+func confirmWrite(out io.Writer, r *bufio.Reader, target string, force bool) (proceed bool, err error) {
+	if force {
+		fmt.Fprintf(out, "Writing to %s (--force).\n", target)
+		return true, nil
+	}
+	confirm, err := promptString(out, r, fmt.Sprintf("Write to %s?", target), "y")
+	if err != nil {
+		return false, err
+	}
+	return isYes(confirm), nil
 }
 
 func resolveTarget(location string) (string, error) {

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -1113,15 +1113,7 @@ func sortByRoster(results []multi.ReviewResult, available []cli.LLM) []multi.Rev
 // work for the merge prompt; whether an earlier per-LLM SaveReview
 // happened to succeed is unrelated.
 func selectMergeLLM(results []multi.ReviewResult, available []cli.LLM, preferred string) *cli.LLM {
-	eligible := make(map[string]cli.LLM)
-	for _, llm := range available {
-		for _, r := range results {
-			if r.LLM == llm.Name && multi.HasMergeableOutput(r) {
-				eligible[llm.Name] = llm
-				break
-			}
-		}
-	}
+	eligible := mergeEligibleAgents(results, available)
 	if len(eligible) == 0 {
 		return nil
 	}
@@ -1147,6 +1139,22 @@ func selectMergeLLM(results []multi.ReviewResult, available []cli.LLM, preferred
 		}
 	}
 	return nil
+}
+
+// mergeEligibleAgents returns the subset of available agents that produced
+// mergeable output (per multi.HasMergeableOutput) somewhere in results,
+// keyed by name for O(1) lookup by the caller's selection strategies.
+func mergeEligibleAgents(results []multi.ReviewResult, available []cli.LLM) map[string]cli.LLM {
+	eligible := make(map[string]cli.LLM)
+	for _, llm := range available {
+		for _, r := range results {
+			if r.LLM == llm.Name && multi.HasMergeableOutput(r) {
+				eligible[llm.Name] = llm
+				break
+			}
+		}
+	}
+	return eligible
 }
 
 // selectPromptPack picks the language pack for this multi-LLM run.


### PR DESCRIPTION
## Why

SonarCloud (Maintainability, High/Critical) flagged 5 functions in `cmd/local-review/{doctor,init,runner}.go` — the repo's own documented "danger zone" (CLAUDE.md rule 12) — over the 15-complexity budget: `runDoctor` (29), `checkPromptOverride` (19), `checkCodexAuth` (23), `runInit` (29), `selectMergeLLM` (18).

## What

Mechanical extraction only — every new function was moved verbatim out of its parent, no logic changes:

| File | Extracted | From |
|---|---|---|
| `doctor.go` | `doctorLLMOverrides`, `doctorProviderSpecs`, `printLLMRows` | `runDoctor`'s three sequential blocks |
| `doctor.go` | `scanPromptOverrides` | `checkPromptOverride`'s inner file-scan loop |
| `doctor.go` | `codexAuthFromFile` | `checkCodexAuth`'s nested auth.json parsing (3 levels of if/switch/if → a flat guard clause) |
| `init.go` | `confirmOverwriteExisting`, `promptConfigValues`, `confirmWrite` | `runInit`'s three phases (pre-check, prompt sequence, final confirm) |
| `runner.go` | `mergeEligibleAgents` | `selectMergeLLM`'s nested double-for-loop |

## Verification

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — full suite green, including all pre-existing coverage for the touched functions: 7 `TestCheckCodexAuth_*`, 8 `TestCheckPromptOverride_*`, 14 `TestInit_*`, 8 `TestSelectMergeLLM` subtests — all unchanged, all still passing
- [x] `golangci-lint run` with `gocognit` (min-complexity 15) — 0 findings across all 3 files, down from 5

## What's NOT in this PR

The other 17 cognitive-complexity findings from this same sweep (12 in other `internal/*` source files, 5 in test files) are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)