### PR TITLE
refactor: cut cognitive complexity in internal/* source files to ≤15

### DIFF
--- a/internal/agentselect/agentselect.go
+++ b/internal/agentselect/agentselect.go
@@ -121,29 +121,43 @@ func ProviderSpecsFromConfig(cfg config.Config) []cli.ProviderSpec {
 // in printAgentRoster.
 func Select(detected []cli.LLM, ready map[string]bool, cfg config.Config, only string, now time.Time) (active []cli.LLM, configDisabled, sunsetDropped []string) {
 	if want := ParseOnlyList(only); len(want) > 0 {
-		for _, llm := range detected {
-			if !want[llm.Name] {
-				continue
-			}
-			if !cli.IsReviewCapable(llm.Name) {
-				continue
-			}
-			if !ready[llm.Name] {
-				continue
-			}
-			if isSunsetAndNotForced(llm, cfg, now) {
-				// --only is an explicit allow-list; honour the user's
-				// intent over the sunset auto-disable. Warn so they
-				// see they're past the cutoff (force_after_sunset is
-				// always implicit under --only of a sunset agent).
-				fmt.Fprintf(os.Stderr, "Warning: --only %s past manufacturer sunset (%s) — running anyway (treat any failures as expected).\n",
-					llm.Name, cli.AgentSunsetDate(llm.Name).Format("2006-01-02"))
-			}
-			active = append(active, applyConfig(llm, cfg))
-		}
-		return active, nil, nil
+		return selectOnly(detected, ready, cfg, want, now), nil, nil
 	}
+	return selectDefault(detected, ready, cfg, now)
+}
 
+// selectOnly implements Select's --only path: an explicit allow-list wins
+// absolutely (including over the sunset auto-disable, with a warning),
+// except review-incapable experimental CLIs, which stay excluded even
+// under --only.
+func selectOnly(detected []cli.LLM, ready map[string]bool, cfg config.Config, want map[string]bool, now time.Time) (active []cli.LLM) {
+	for _, llm := range detected {
+		if !want[llm.Name] {
+			continue
+		}
+		if !cli.IsReviewCapable(llm.Name) {
+			continue
+		}
+		if !ready[llm.Name] {
+			continue
+		}
+		if isSunsetAndNotForced(llm, cfg, now) {
+			// --only is an explicit allow-list; honour the user's
+			// intent over the sunset auto-disable. Warn so they
+			// see they're past the cutoff (force_after_sunset is
+			// always implicit under --only of a sunset agent).
+			fmt.Fprintf(os.Stderr, "Warning: --only %s past manufacturer sunset (%s) — running anyway (treat any failures as expected).\n",
+				llm.Name, cli.AgentSunsetDate(llm.Name).Format("2006-01-02"))
+		}
+		active = append(active, applyConfig(llm, cfg))
+	}
+	return active
+}
+
+// selectDefault implements Select's default (no --only) path: ready +
+// review-capable agents run unless explicitly disabled in config or
+// dropped for a passed manufacturer sunset.
+func selectDefault(detected []cli.LLM, ready map[string]bool, cfg config.Config, now time.Time) (active []cli.LLM, configDisabled, sunsetDropped []string) {
 	for _, llm := range detected {
 		if !cli.IsReviewCapable(llm.Name) {
 			continue

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -704,6 +705,80 @@ func TestWalk_RejectsNegativeMaxBytesPerChunk(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "MaxBytesPerChunk must be >= 0") {
 		t.Errorf("error should mention the constraint; got %v", err)
+	}
+}
+
+// initTestGitRepo creates a real git repo at t.TempDir() with the given
+// tracked files, mirroring internal/git's own test pattern (diff_test.go) —
+// Walk shells out to real `git ls-files`, so groupFilesByPackage /
+// buildChunksFromPackages need an actual repo to exercise, not a mock.
+func initTestGitRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "t@example.com")
+	runGit("config", "user.name", "T")
+	runGit("config", "commit.gpgsign", "false")
+	for rel, content := range files {
+		full := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit("add", rel)
+	}
+	runGit("commit", "-q", "-m", "init")
+	return repo
+}
+
+// TestWalk_GroupsFilesByPackageAndSortsDeterministically exercises Walk
+// end-to-end against a real git repo: two packages, each with tracked
+// source files plus one file that pathPassesFilters/isAuditable should
+// exclude (Exclude prefix, and a binary-shaped extension). Covers
+// groupFilesByPackage + buildChunksFromPackages, which had no direct test
+// before the cognitive-complexity refactor extracted them from Walk.
+func TestWalk_GroupsFilesByPackageAndSortsDeterministically(t *testing.T) {
+	repo := initTestGitRepo(t, map[string]string{
+		"pkgb/z.go":       "package pkgb\n",
+		"pkgb/a.go":       "package pkgb\n",
+		"pkga/main.go":    "package pkga\n",
+		"pkga/skip.png":   "not source",
+		"excluded/foo.go": "package excluded\n",
+	})
+	chunks, err := Walk(WalkOptions{Root: repo, Exclude: []string{"excluded"}})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 package chunks (pkga, pkgb), got %d: %+v", len(chunks), chunks)
+	}
+	// Packages sorted alphabetically: pkga before pkgb.
+	if chunks[0].Package != "pkga" || chunks[1].Package != "pkgb" {
+		t.Errorf("expected chunks sorted [pkga, pkgb], got [%s, %s]", chunks[0].Package, chunks[1].Package)
+	}
+	if len(chunks[0].Files) != 1 || chunks[0].Files[0] != "pkga/main.go" {
+		t.Errorf("pkga chunk should contain only main.go (skip.png excluded by isAuditable), got %v", chunks[0].Files)
+	}
+	// Files within a package sorted too: a.go before z.go.
+	wantPkgB := []string{"pkgb/a.go", "pkgb/z.go"}
+	if len(chunks[1].Files) != 2 || chunks[1].Files[0] != wantPkgB[0] || chunks[1].Files[1] != wantPkgB[1] {
+		t.Errorf("pkgb chunk files = %v, want %v (sorted)", chunks[1].Files, wantPkgB)
+	}
+	for _, c := range chunks {
+		if strings.Contains(c.Package, "excluded") {
+			t.Errorf("excluded/ package must not appear in chunks, got %+v", c)
+		}
 	}
 }
 

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -125,21 +125,9 @@ func WriteMarkdown(w io.Writer, rep Report) error {
 	if err := writeMarkdownSummary(w, rep); err != nil {
 		return err
 	}
-	// Group: packages with findings first, then clean (collapsed),
-	// then errored (so they stand out at the bottom).
-	var clean, errored []PackageReport
-	for _, pr := range rep.Packages {
-		if pr.Error != "" {
-			errored = append(errored, pr)
-			continue
-		}
-		if pr.Clean || len(pr.Findings) == 0 {
-			clean = append(clean, pr)
-			continue
-		}
-		if err := writeMarkdownPackage(w, pr); err != nil {
-			return err
-		}
+	clean, errored, err := writeMarkdownPackages(w, rep.Packages)
+	if err != nil {
+		return err
 	}
 	if len(clean) > 0 {
 		if err := writeMarkdownCleanList(w, clean); err != nil {
@@ -152,6 +140,28 @@ func WriteMarkdown(w io.Writer, rep Report) error {
 		}
 	}
 	return nil
+}
+
+// writeMarkdownPackages writes each package with findings immediately (in
+// rep.Packages order) and buckets the rest into clean / errored for the
+// caller to render as collapsed lists afterward — packages with findings
+// come first, then clean (collapsed), then errored, so errors stand out at
+// the bottom.
+func writeMarkdownPackages(w io.Writer, packages []PackageReport) (clean, errored []PackageReport, err error) {
+	for _, pr := range packages {
+		if pr.Error != "" {
+			errored = append(errored, pr)
+			continue
+		}
+		if pr.Clean || len(pr.Findings) == 0 {
+			clean = append(clean, pr)
+			continue
+		}
+		if err := writeMarkdownPackage(w, pr); err != nil {
+			return nil, nil, err
+		}
+	}
+	return clean, errored, nil
 }
 
 func writeMarkdownSummary(w io.Writer, rep Report) error {

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -82,22 +82,9 @@ type Options struct {
 // Returns a Report with aggregate counts filled in. The caller
 // renders to text / markdown / JSON via internal/audit/report.go.
 func Run(ctx context.Context, chunks []Chunk, opts Options) (Report, error) {
-	if opts.Topic == "" {
-		return Report{}, fmt.Errorf("audit topic is required (use --topic security or --topic tech-debt)")
-	}
-	if opts.LLM.Name == "" {
-		return Report{}, fmt.Errorf("audit requires an LLM (none authenticated; run `local-review doctor`)")
-	}
-	pack, err := prompts.GetAuditPack(opts.Topic)
+	pack, invoker, err := prepareAuditRun(opts)
 	if err != nil {
 		return Report{}, err
-	}
-	invoker := opts.Invoker
-	if invoker == nil {
-		invoker = cli.NewInvoker(opts.LLM)
-		if invoker == nil {
-			return Report{}, fmt.Errorf("no invoker for LLM %q", opts.LLM.Name)
-		}
 	}
 
 	rep := Report{
@@ -111,12 +98,58 @@ func Run(ctx context.Context, chunks []Chunk, opts Options) (Report, error) {
 
 	timeout := resolveTimeout(opts.Timeout, opts.LLM)
 	parallelism := clampParallelism(opts.Parallelism, len(chunks))
+	results := runAuditWorkerPool(ctx, chunks, pack, invoker, opts.Progress, timeout, parallelism)
 
-	// Pre-allocate by index so completion order doesn't shuffle the
-	// final report. Worker pool reads chunks in walker order; each
-	// worker writes to its assigned slot. fillAggregates traverses
-	// the slice in order, so users still see packages in the same
-	// walker order they would have under sequential dispatch.
+	rep.Packages = results
+	fillAggregates(&rep)
+	// Surface cancellation as an error so the caller exits non-zero rather
+	// than emitting a "completed" report whose not-yet-started chunks were
+	// silently skipped (CLAUDE.md rule 4: "completed" is wrong if anything
+	// was skipped). The partial report is still returned for callers that
+	// want to show what did finish.
+	if err := ctx.Err(); err != nil {
+		done := 0
+		for _, pr := range results {
+			if pr.Package != "" {
+				done++
+			}
+		}
+		return rep, fmt.Errorf("audit canceled after %d/%d chunks: %w", done, len(chunks), err)
+	}
+	return rep, nil
+}
+
+// prepareAuditRun validates opts and resolves the audit prompt pack + the
+// invoker Run will use, in one place so Run itself starts from ready-to-use
+// values.
+func prepareAuditRun(opts Options) (pack string, invoker cli.Invoker, err error) {
+	if opts.Topic == "" {
+		return "", nil, fmt.Errorf("audit topic is required (use --topic security or --topic tech-debt)")
+	}
+	if opts.LLM.Name == "" {
+		return "", nil, fmt.Errorf("audit requires an LLM (none authenticated; run `local-review doctor`)")
+	}
+	pack, err = prompts.GetAuditPack(opts.Topic)
+	if err != nil {
+		return "", nil, err
+	}
+	invoker = opts.Invoker
+	if invoker == nil {
+		invoker = cli.NewInvoker(opts.LLM)
+		if invoker == nil {
+			return "", nil, fmt.Errorf("no invoker for LLM %q", opts.LLM.Name)
+		}
+	}
+	return pack, invoker, nil
+}
+
+// runAuditWorkerPool dispatches chunks to a pool of `parallelism` workers
+// and returns per-chunk results, pre-allocated by index so completion order
+// doesn't shuffle the final report — the worker pool reads chunks in walker
+// order; each worker writes to its assigned slot, so fillAggregates (which
+// traverses the slice in order) shows packages in the same walker order
+// sequential dispatch would have produced.
+func runAuditWorkerPool(ctx context.Context, chunks []Chunk, pack string, invoker cli.Invoker, progress io.Writer, timeout time.Duration, parallelism int) []PackageReport {
 	results := make([]PackageReport, len(chunks))
 	type job struct {
 		idx int
@@ -151,7 +184,7 @@ func Run(ctx context.Context, chunks []Chunk, opts Options) (Report, error) {
 				if ctx.Err() != nil {
 					return
 				}
-				if opts.Progress != nil {
+				if progress != nil {
 					progMu.Lock()
 					// Stderr-shaped progress write: explicitly
 					// discard the error. Same policy as the
@@ -159,7 +192,7 @@ func Run(ctx context.Context, chunks []Chunk, opts Options) (Report, error) {
 					// the rationale (aborting an audit because a
 					// progress line failed to flush would be the
 					// wrong choice).
-					_, _ = fmt.Fprintf(opts.Progress, "[%d/%d] auditing %s (%d file%s, %s)...\n",
+					_, _ = fmt.Fprintf(progress, "[%d/%d] auditing %s (%d file%s, %s)...\n",
 						j.idx+1, len(chunks), j.c.Package, len(j.c.Files), pluralS(len(j.c.Files)), FormatBytes(j.c.SizeBytes))
 					progMu.Unlock()
 				}
@@ -168,24 +201,7 @@ func Run(ctx context.Context, chunks []Chunk, opts Options) (Report, error) {
 		}()
 	}
 	wg.Wait()
-
-	rep.Packages = results
-	fillAggregates(&rep)
-	// Surface cancellation as an error so the caller exits non-zero rather
-	// than emitting a "completed" report whose not-yet-started chunks were
-	// silently skipped (CLAUDE.md rule 4: "completed" is wrong if anything
-	// was skipped). The partial report is still returned for callers that
-	// want to show what did finish.
-	if err := ctx.Err(); err != nil {
-		done := 0
-		for _, pr := range results {
-			if pr.Package != "" {
-				done++
-			}
-		}
-		return rep, fmt.Errorf("audit canceled after %d/%d chunks: %w", done, len(chunks), err)
-	}
-	return rep, nil
+	return results
 }
 
 // MaxAuditParallelism is the hard ceiling on the worker pool size,
@@ -336,25 +352,9 @@ func parseFindings(out string) []Finding {
 		bodyBuf.Reset()
 	}
 	for _, line := range lines {
-		if m := findingHeaderRE.FindStringSubmatch(line); m != nil {
+		if f := parseFindingHeader(line); f != nil {
 			flush()
-			lineNum, lineEnd := 0, 0
-			if m[3] != "" {
-				if n, err := strconv.Atoi(m[3]); err == nil {
-					lineNum = n
-				}
-			}
-			if m[4] != "" {
-				if n, err := strconv.Atoi(m[4]); err == nil {
-					lineEnd = n
-				}
-			}
-			current = &Finding{
-				Severity: m[1],
-				Path:     m[2],
-				Line:     lineNum,
-				LineEnd:  lineEnd,
-			}
+			current = f
 			continue
 		}
 		if current != nil {
@@ -364,6 +364,32 @@ func parseFindings(out string) []Finding {
 	}
 	flush()
 	return findings
+}
+
+// parseFindingHeader parses one line as a finding-header match (see
+// findingHeaderRE), returning nil when the line isn't a header.
+func parseFindingHeader(line string) *Finding {
+	m := findingHeaderRE.FindStringSubmatch(line)
+	if m == nil {
+		return nil
+	}
+	lineNum, lineEnd := 0, 0
+	if m[3] != "" {
+		if n, err := strconv.Atoi(m[3]); err == nil {
+			lineNum = n
+		}
+	}
+	if m[4] != "" {
+		if n, err := strconv.Atoi(m[4]); err == nil {
+			lineEnd = n
+		}
+	}
+	return &Finding{
+		Severity: m[1],
+		Path:     m[2],
+		Line:     lineNum,
+		LineEnd:  lineEnd,
+	}
 }
 
 // auditSeverityRank orders the audit severity tiers (audit has no nit —

--- a/internal/audit/walker.go
+++ b/internal/audit/walker.go
@@ -147,10 +147,16 @@ func Walk(opts WalkOptions) ([]Chunk, error) {
 		maxBytes = defaultMaxBytesPerChunk
 	}
 
-	// Group eligible files by package (directory).
+	byPkg := groupFilesByPackage(files, opts.Include, opts.Exclude)
+	return buildChunksFromPackages(root, byPkg, maxBytes, opts.Warn)
+}
+
+// groupFilesByPackage buckets files by package (directory) after applying
+// the Include/Exclude filters and the isAuditable eligibility check.
+func groupFilesByPackage(files, include, exclude []string) map[string][]string {
 	byPkg := map[string][]string{}
 	for _, p := range files {
-		if !pathPassesFilters(p, opts.Include, opts.Exclude) {
+		if !pathPassesFilters(p, include, exclude) {
 			continue
 		}
 		if !isAuditable(p) {
@@ -162,9 +168,13 @@ func Walk(opts WalkOptions) ([]Chunk, error) {
 		}
 		byPkg[pkg] = append(byPkg[pkg], p)
 	}
+	return byPkg
+}
 
-	// Build chunks. Sort packages so the audit output order is
-	// stable; sort files within each package for the same reason.
+// buildChunksFromPackages sorts packages (and each package's files) for
+// deterministic output order, then splits each package into one or more
+// Chunks via splitChunk.
+func buildChunksFromPackages(root string, byPkg map[string][]string, maxBytes int, warn io.Writer) ([]Chunk, error) {
 	pkgs := make([]string, 0, len(byPkg))
 	for p := range byPkg {
 		pkgs = append(pkgs, p)
@@ -175,7 +185,7 @@ func Walk(opts WalkOptions) ([]Chunk, error) {
 	for _, pkg := range pkgs {
 		paths := byPkg[pkg]
 		sort.Strings(paths)
-		parts, err := splitChunk(root, pkg, paths, maxBytes, opts.Warn)
+		parts, err := splitChunk(root, pkg, paths, maxBytes, warn)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/bench/consistency.go
+++ b/internal/bench/consistency.go
@@ -24,18 +24,7 @@ func jaccard(runs [][]ProducedFinding) float64 {
 		return 0
 	}
 
-	sets := make([]map[string]struct{}, len(runs))
-	allEmpty := true
-	for i, r := range runs {
-		s := make(map[string]struct{}, len(r))
-		for _, f := range r {
-			s[findingKey(f)] = struct{}{}
-		}
-		sets[i] = s
-		if len(s) > 0 {
-			allEmpty = false
-		}
-	}
+	sets, allEmpty := findingSets(runs)
 	if allEmpty {
 		return 1
 	}
@@ -48,7 +37,32 @@ func jaccard(runs [][]ProducedFinding) float64 {
 		}
 	}
 
-	// Intersection: every key seen in *every* run.
+	if len(union) == 0 {
+		return 1
+	}
+	return float64(countIntersection(sets)) / float64(len(union))
+}
+
+// findingSets reduces each run to its set of "<file>:<line>" keys.
+// allEmpty is true only when every run's set is empty.
+func findingSets(runs [][]ProducedFinding) (sets []map[string]struct{}, allEmpty bool) {
+	sets = make([]map[string]struct{}, len(runs))
+	allEmpty = true
+	for i, r := range runs {
+		s := make(map[string]struct{}, len(r))
+		for _, f := range r {
+			s[findingKey(f)] = struct{}{}
+		}
+		sets[i] = s
+		if len(s) > 0 {
+			allEmpty = false
+		}
+	}
+	return sets, allEmpty
+}
+
+// countIntersection counts keys present in every one of sets[0:].
+func countIntersection(sets []map[string]struct{}) int {
 	intersection := 0
 	for k := range sets[0] {
 		inAll := true
@@ -62,11 +76,7 @@ func jaccard(runs [][]ProducedFinding) float64 {
 			intersection++
 		}
 	}
-
-	if len(union) == 0 {
-		return 1
-	}
-	return float64(intersection) / float64(len(union))
+	return intersection
 }
 
 // findingKey returns the dedupe key Jaccard works on. file:line is

--- a/internal/bench/markdown.go
+++ b/internal/bench/markdown.go
@@ -84,37 +84,57 @@ func writeMarkdownOverhead(w io.Writer, rep Report) error {
 	}
 	var coverageNotes []string
 	for _, lr := range rep.LLMReports {
-		o := lr.Overhead
-		tMean, tHave := treatmentMeanDurationMs(o)
-		bMean, bHave := baselineMeanDurationMs(o)
-		timeCell := markdownOverheadDurationCell(tMean, bMean, tHave && bHave)
-
-		tTok, tTokHave := treatmentMeanTokens(o)
-		bTok, bTokHave := baselineMeanTokens(o)
-		tokenCell := markdownOverheadTokenCell(tTok, bTok, tTokHave && bTokHave)
-
-		if _, err := fmt.Fprintf(w, "| %s | %s | %s |\n",
-			lr.LLM, timeCell, tokenCell); err != nil {
+		note, err := writeMarkdownOverheadRow(w, lr)
+		if err != nil {
 			return err
 		}
-		if note := overheadCoverageNote(o); note != "" {
-			coverageNotes = append(coverageNotes, fmt.Sprintf("_%s: %s._", lr.LLM, note))
+		if note != "" {
+			coverageNotes = append(coverageNotes, note)
 		}
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
 		return err
 	}
-	for _, n := range coverageNotes {
+	return writeMarkdownCoverageNotes(w, coverageNotes)
+}
+
+// writeMarkdownCoverageNotes writes each partial-coverage note on its own
+// line, followed by a trailing blank line — but only when there's at least
+// one note to write.
+func writeMarkdownCoverageNotes(w io.Writer, notes []string) error {
+	for _, n := range notes {
 		if _, err := fmt.Fprintln(w, n); err != nil {
 			return err
 		}
 	}
-	if len(coverageNotes) > 0 {
+	if len(notes) > 0 {
 		if _, err := fmt.Fprintln(w); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// writeMarkdownOverheadRow writes one LLM's overhead table row and returns
+// its coverage note (formatted, ready to print), or "" when the row had
+// full coverage.
+func writeMarkdownOverheadRow(w io.Writer, lr LLMReport) (note string, err error) {
+	o := lr.Overhead
+	tMean, tHave := treatmentMeanDurationMs(o)
+	bMean, bHave := baselineMeanDurationMs(o)
+	timeCell := markdownOverheadDurationCell(tMean, bMean, tHave && bHave)
+
+	tTok, tTokHave := treatmentMeanTokens(o)
+	bTok, bTokHave := baselineMeanTokens(o)
+	tokenCell := markdownOverheadTokenCell(tTok, bTok, tTokHave && bTokHave)
+
+	if _, err := fmt.Fprintf(w, "| %s | %s | %s |\n", lr.LLM, timeCell, tokenCell); err != nil {
+		return "", err
+	}
+	if n := overheadCoverageNote(o); n != "" {
+		return fmt.Sprintf("_%s: %s._", lr.LLM, n), nil
+	}
+	return "", nil
 }
 
 // markdownOverheadDurationCell renders one "treatment (Δ)" time

--- a/internal/bench/report.go
+++ b/internal/bench/report.go
@@ -121,52 +121,60 @@ func writeUpliftBlock(w io.Writer, rep Report) error {
 		return err
 	}
 	for _, lr := range rep.LLMReports {
-		errs := countBaselineErrors(lr)
-		if !baselineHasAnyNumericData(lr.Baseline) {
-			// Either uplift wasn't run for this LLM, or every
-			// baseline pass errored. Render a single status line
-			// instead of numeric deltas — iter-3 self-review
-			// flagged that printing "0.91 (+0.91)" against a
-			// zero-baseline that nobody measured is a misleading
-			// headline. The aggregate may still be present in
-			// JSON for the "feature attempted" signal.
-			label := "(not measured)"
-			if errs > 0 {
-				label = fmt.Sprintf("(baseline failed on %d case(s))", errs)
-			}
-			if _, err := fmt.Fprintf(w, "%-10s  %s\n", lr.LLM, label); err != nil {
-				return err
-			}
-			continue
-		}
-		b := lr.Baseline
-		// Quality cells (F1 / precision / recall) gate on
-		// non-clean coverage; the noise cell gates on clean
-		// coverage. A baseline that succeeded only on clean
-		// cases has meaningful noise and meaningless F1, and
-		// vice versa. Iter-4 self-review (codex) caught the
-		// shape where both gated together let the unmeasured
-		// half show "0.00 (+X)" against a phantom value.
-		qualityMeasured := b.MeasuredNonCleanCases > 0
-		noiseMeasured := b.MeasuredCleanCases > 0
-		if _, err := fmt.Fprintf(w, "%-10s  %s  %s  %s  %s\n",
-			lr.LLM,
-			fmtUpliftCellOrDash(lr.F1, b.F1, qualityMeasured),
-			fmtUpliftCellOrDash(lr.Precision, b.Precision, qualityMeasured),
-			fmtUpliftCellOrDash(lr.Recall, b.Recall, qualityMeasured),
-			fmtUpliftCellOrDash(lr.NoiseRate, b.NoiseRate, noiseMeasured),
-		); err != nil {
+		if err := writeUpliftRow(w, lr); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// writeUpliftRow writes one LLM's uplift-over-baseline row (or, when the
+// baseline has no numeric data at all, a single status line instead of
+// numeric deltas).
+func writeUpliftRow(w io.Writer, lr LLMReport) error {
+	errs := countBaselineErrors(lr)
+	if !baselineHasAnyNumericData(lr.Baseline) {
+		// Either uplift wasn't run for this LLM, or every
+		// baseline pass errored. Render a single status line
+		// instead of numeric deltas — iter-3 self-review
+		// flagged that printing "0.91 (+0.91)" against a
+		// zero-baseline that nobody measured is a misleading
+		// headline. The aggregate may still be present in
+		// JSON for the "feature attempted" signal.
+		label := "(not measured)"
 		if errs > 0 {
-			// Even with a populated aggregate we want users to
-			// see "this comparison covers M of N cases" when the
-			// baseline partially failed — the aggregate itself
-			// micro-averages over only the survivors and would
-			// otherwise misleadingly look like full coverage.
-			if _, err := fmt.Fprintf(w, "%-10s  note: baseline failed on %d case(s); delta is over the surviving subset only\n", "", errs); err != nil {
-				return err
-			}
+			label = fmt.Sprintf("(baseline failed on %d case(s))", errs)
+		}
+		_, err := fmt.Fprintf(w, "%-10s  %s\n", lr.LLM, label)
+		return err
+	}
+	b := lr.Baseline
+	// Quality cells (F1 / precision / recall) gate on
+	// non-clean coverage; the noise cell gates on clean
+	// coverage. A baseline that succeeded only on clean
+	// cases has meaningful noise and meaningless F1, and
+	// vice versa. Iter-4 self-review (codex) caught the
+	// shape where both gated together let the unmeasured
+	// half show "0.00 (+X)" against a phantom value.
+	qualityMeasured := b.MeasuredNonCleanCases > 0
+	noiseMeasured := b.MeasuredCleanCases > 0
+	if _, err := fmt.Fprintf(w, "%-10s  %s  %s  %s  %s\n",
+		lr.LLM,
+		fmtUpliftCellOrDash(lr.F1, b.F1, qualityMeasured),
+		fmtUpliftCellOrDash(lr.Precision, b.Precision, qualityMeasured),
+		fmtUpliftCellOrDash(lr.Recall, b.Recall, qualityMeasured),
+		fmtUpliftCellOrDash(lr.NoiseRate, b.NoiseRate, noiseMeasured),
+	); err != nil {
+		return err
+	}
+	if errs > 0 {
+		// Even with a populated aggregate we want users to
+		// see "this comparison covers M of N cases" when the
+		// baseline partially failed — the aggregate itself
+		// micro-averages over only the survivors and would
+		// otherwise misleadingly look like full coverage.
+		if _, err := fmt.Fprintf(w, "%-10s  note: baseline failed on %d case(s); delta is over the surviving subset only\n", "", errs); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/bench/report_test.go
+++ b/internal/bench/report_test.go
@@ -1,0 +1,61 @@
+package bench
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestWriteUpliftBlock_MeasuredAndUnmeasuredRows covers writeUpliftBlock's
+// (and writeUpliftRow's) two branches: an LLM with real baseline numbers
+// renders numeric deltas; an LLM with no baseline data at all renders the
+// "(not measured)" status line instead. Neither had a direct test before
+// the cognitive-complexity refactor pulled writeUpliftRow out of the loop
+// — WriteText (report.go's public entry point) was itself untested end to
+// end, so exercising writeUpliftBlock directly (this package's existing
+// convention for unexported render helpers — see jaccard's own tests)
+// covers the extracted code without depending on unrelated 0%-covered
+// siblings like writeOverallTable.
+func TestWriteUpliftBlock_MeasuredAndUnmeasuredRows(t *testing.T) {
+	rep := Report{
+		LLMReports: []LLMReport{
+			{
+				LLM:       "claude",
+				F1:        0.91,
+				Precision: 0.95,
+				Recall:    0.88,
+				NoiseRate: 0.1,
+				Cases: []CaseScore{
+					{BaselineError: "timeout"},
+				},
+				Baseline: &LLMBaselineAggregate{
+					F1:                    0.60,
+					Precision:             0.70,
+					Recall:                0.55,
+					NoiseRate:             0.3,
+					MeasuredNonCleanCases: 4,
+					MeasuredCleanCases:    2,
+				},
+			},
+			{
+				LLM:      "gemini",
+				Baseline: nil, // uplift never measured for this LLM
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := writeUpliftBlock(&buf, rep); err != nil {
+		t.Fatalf("writeUpliftBlock: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "claude") {
+		t.Errorf("expected a row for claude, got:\n%s", out)
+	}
+	if !strings.Contains(out, "note: baseline failed on 1 case(s)") {
+		t.Errorf("expected the partial-baseline-failure note for claude, got:\n%s", out)
+	}
+	if !strings.Contains(out, "gemini") || !strings.Contains(out, "(not measured)") {
+		t.Errorf("expected gemini's row to say (not measured), got:\n%s", out)
+	}
+}

--- a/internal/bench/swe.go
+++ b/internal/bench/swe.go
@@ -215,45 +215,68 @@ func LoadSWEBenchDataset(rootDir string) ([]SWEBenchCase, error) {
 func loadSWEBenchCase(dir string) (*SWEBenchCase, error) {
 	yamlPath := filepath.Join(dir, "case.yaml")
 	diffPath := filepath.Join(dir, "diff.patch")
-	yb, yerr := os.ReadFile(yamlPath)
-	db, derr := os.ReadFile(diffPath)
-	if yerr != nil || derr != nil {
-		// Each non-nil error is evaluated independently so a mixed
-		// pair — e.g. case.yaml missing AND diff.patch returns
-		// EACCES — still surfaces the EACCES instead of being
-		// swallowed by the NotExist on the sibling. The pre-fix
-		// shape used `errors.Is(yerr, NotExist) || errors.Is(derr,
-		// NotExist)` which short-circuited to "skip silently" on
-		// any partial-missing, hiding real corruption on the
-		// other file. Caught by CodeRabbit + Copilot on PR #70.
-		if yerr != nil && !errors.Is(yerr, os.ErrNotExist) {
-			return nil, fmt.Errorf("read case.yaml: %w", yerr)
-		}
-		if derr != nil && !errors.Is(derr, os.ErrNotExist) {
-			return nil, fmt.Errorf("read diff.patch: %w", derr)
-		}
-		// At least one file is missing AND neither sibling
-		// produced a non-NotExist error: partial entry, skip
-		// per the LoadSWEBenchDataset contract.
-		return nil, nil
+	yb, db, err := readCaseFiles(yamlPath, diffPath)
+	if err != nil || yb == nil {
+		return nil, err
 	}
+
 	var c SWEBenchCase
 	if err := yaml.Unmarshal(yb, &c); err != nil {
 		return nil, fmt.Errorf("parse case.yaml: %w", err)
 	}
-	// TrimSpace before required-field checks so a YAML value of
-	// `id: "   "` doesn't sneak past validation and produce a
-	// task whose fixture lookup, dedup, and reporting indexing
-	// all silently break in different ways. CLAUDE.md rule 4
-	// ("Fail loud, fail closed — use TrimSpace for emptiness
-	// checks").
+	if err := validateCaseFields(&c); err != nil {
+		return nil, err
+	}
+	trimmed, err := trimAndValidateKeywords(c.ExpectedKeywords)
+	if err != nil {
+		return nil, err
+	}
+	c.ExpectedKeywords = trimmed
+	c.DiffPath = diffPath
+	c.Diff = string(db)
+	return &c, nil
+}
+
+// readCaseFiles reads case.yaml + diff.patch. A nil, nil, nil return means
+// "partial entry, skip" (per the LoadSWEBenchDataset contract) — at least
+// one file is missing and neither sibling produced a non-NotExist error.
+func readCaseFiles(yamlPath, diffPath string) (yb, db []byte, err error) {
+	yb, yerr := os.ReadFile(yamlPath)
+	db, derr := os.ReadFile(diffPath)
+	if yerr == nil && derr == nil {
+		return yb, db, nil
+	}
+	// Each non-nil error is evaluated independently so a mixed
+	// pair — e.g. case.yaml missing AND diff.patch returns
+	// EACCES — still surfaces the EACCES instead of being
+	// swallowed by the NotExist on the sibling. The pre-fix
+	// shape used `errors.Is(yerr, NotExist) || errors.Is(derr,
+	// NotExist)` which short-circuited to "skip silently" on
+	// any partial-missing, hiding real corruption on the
+	// other file. Caught by CodeRabbit + Copilot on PR #70.
+	if yerr != nil && !errors.Is(yerr, os.ErrNotExist) {
+		return nil, nil, fmt.Errorf("read case.yaml: %w", yerr)
+	}
+	if derr != nil && !errors.Is(derr, os.ErrNotExist) {
+		return nil, nil, fmt.Errorf("read diff.patch: %w", derr)
+	}
+	return nil, nil, nil
+}
+
+// validateCaseFields trims + validates the required id/title fields on c,
+// in place. TrimSpace before the required-field checks so a YAML value of
+// `id: "   "` doesn't sneak past validation and produce a task whose
+// fixture lookup, dedup, and reporting indexing all silently break in
+// different ways. CLAUDE.md rule 4 ("Fail loud, fail closed — use
+// TrimSpace for emptiness checks").
+func validateCaseFields(c *SWEBenchCase) error {
 	c.ID = strings.TrimSpace(c.ID)
 	c.Title = strings.TrimSpace(c.Title)
 	if c.ID == "" {
-		return nil, fmt.Errorf("case.yaml missing required field: id")
+		return fmt.Errorf("case.yaml missing required field: id")
 	}
 	if c.Title == "" {
-		return nil, fmt.Errorf("case.yaml missing required field: title")
+		return fmt.Errorf("case.yaml missing required field: title")
 	}
 	// ID must pass the same safeIdentifierRE the replay path uses
 	// for fixture lookups (readFixture → validateIdentifier).
@@ -261,13 +284,15 @@ func loadSWEBenchCase(dir string) (*SWEBenchCase, error) {
 	// loading and explode at fixture-read time — or worse, escape
 	// the replay root before validateIdentifier catches it.
 	// Caught by Copilot on PR #70.
-	if err := validateIdentifier("swe-bench case id", c.ID); err != nil {
-		return nil, err
-	}
-	// Trim and validate keywords: empty list (or list of only-empties)
-	// would silently mark every task missed; loud failure is right.
-	trimmed := make([]string, 0, len(c.ExpectedKeywords))
-	for _, k := range c.ExpectedKeywords {
+	return validateIdentifier("swe-bench case id", c.ID)
+}
+
+// trimAndValidateKeywords trims each keyword and drops empties. An empty
+// result (or a list of only-empties) would silently mark every task
+// missed; loud failure is right.
+func trimAndValidateKeywords(keywords []string) ([]string, error) {
+	trimmed := make([]string, 0, len(keywords))
+	for _, k := range keywords {
 		k = strings.TrimSpace(k)
 		if k != "" {
 			trimmed = append(trimmed, k)
@@ -276,10 +301,7 @@ func loadSWEBenchCase(dir string) (*SWEBenchCase, error) {
 	if len(trimmed) == 0 {
 		return nil, fmt.Errorf("case.yaml requires at least one non-empty expected_keywords entry")
 	}
-	c.ExpectedKeywords = trimmed
-	c.DiffPath = diffPath
-	c.Diff = string(db)
-	return &c, nil
+	return trimmed, nil
 }
 
 // ScoreSWE returns the per-task verdict by case-insensitive

--- a/internal/cli/classify.go
+++ b/internal/cli/classify.go
@@ -69,27 +69,39 @@ func ClassifyExit(ctx context.Context, err error, combinedOutput []byte, agent s
 	// `claude login`", gemini says "API key not valid", codex says
 	// "Tool 'web_search_preview' is not supported with gpt-4", etc.
 	if strings.HasPrefix(errMsg, "exit status ") || strings.Contains(errMsg, "exited with status") {
-		stderr := strings.TrimSpace(string(combinedOutput))
-		if stderr != "" {
-			if len(stderr) > stderrTailMaxLen {
-				// Walk the cut forward to a UTF-8 rune boundary.
-				// Pre-fix this byte slice could split a multi-byte
-				// codepoint (Cyrillic, CJK, emoji) and emit invalid
-				// UTF-8 in the failure line — exactly when the user
-				// is already debugging a non-ASCII error message.
-				cut := len(stderr) - stderrTailMaxLen
-				for cut < len(stderr) && !utf8.RuneStart(stderr[cut]) {
-					cut++
-				}
-				stderr = "…" + stderr[cut:]
-			}
-			return fmt.Sprintf("%s: %s", errMsg, stderr)
-		}
-		return fmt.Sprintf("%s (no stderr captured — re-run with `%s --help` to verify auth and model)", errMsg, agent)
+		return formatExitStatusFailure(errMsg, combinedOutput, agent)
 	}
 
 	if errMsg != "" {
 		return errMsg
 	}
 	return "unknown error"
+}
+
+// formatExitStatusFailure formats the non-zero-exit-status case: the
+// stderr tail when there is one (truncated to stderrTailMaxLen), or a
+// re-run hint when stderr was empty.
+func formatExitStatusFailure(errMsg string, combinedOutput []byte, agent string) string {
+	stderr := strings.TrimSpace(string(combinedOutput))
+	if stderr == "" {
+		return fmt.Sprintf("%s (no stderr captured — re-run with `%s --help` to verify auth and model)", errMsg, agent)
+	}
+	return fmt.Sprintf("%s: %s", errMsg, truncateStderrTail(stderr))
+}
+
+// truncateStderrTail keeps only the last stderrTailMaxLen bytes of stderr
+// (the actionable signal is almost always toward the end — see
+// stderrTailMaxLen's doc), walking the cut point forward to a UTF-8 rune
+// boundary so a multi-byte codepoint (Cyrillic, CJK, emoji) can't be split
+// and emit invalid UTF-8 in the failure line — exactly when the user is
+// already debugging a non-ASCII error message.
+func truncateStderrTail(stderr string) string {
+	if len(stderr) <= stderrTailMaxLen {
+		return stderr
+	}
+	cut := len(stderr) - stderrTailMaxLen
+	for cut < len(stderr) && !utf8.RuneStart(stderr[cut]) {
+		cut++
+	}
+	return "…" + stderr[cut:]
 }

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -196,36 +196,8 @@ func ValidateRef(ref string) error {
 // change set.
 func parseUnifiedDiff(r io.Reader) ([]Diff, error) {
 	br := bufio.NewReader(r)
+	var s diffParseState
 
-	var diffs []Diff
-	var cur *Diff
-	var hunk *Hunk
-	var hunkBody strings.Builder
-
-	flushHunk := func() {
-		if cur != nil && hunk != nil {
-			hunk.Content = hunkBody.String()
-			cur.Hunks = append(cur.Hunks, *hunk)
-		}
-		hunk = nil
-		hunkBody.Reset()
-	}
-	flushFile := func() {
-		flushHunk()
-		if cur != nil {
-			diffs = append(diffs, *cur)
-		}
-		cur = nil
-	}
-
-	// Case order matters here — once we're inside a hunk (post-@@),
-	// every line is content even if it happens to start with `--- a/`
-	// or `+++ b/`. A deleted SQL comment `-- a/users` renders as
-	// `--- a/users` in the diff (the leading `-` is the diff prefix),
-	// and the previous case order matched that as a file header,
-	// silently overwriting cur.Path AND swallowing the line from the
-	// hunk content. Putting `hunk != nil` ahead of the header cases
-	// makes header recognition pre-@@ only.
 	for {
 		raw, readErr := br.ReadString('\n')
 		// ReadString returns the partial line + io.EOF when input
@@ -236,41 +208,7 @@ func parseUnifiedDiff(r io.Reader) ([]Diff, error) {
 			// \r into paths or hunk content. (Same job the old
 			// strings.ReplaceAll did, done per-line during streaming.)
 			line := strings.TrimRight(strings.TrimSuffix(raw, "\n"), "\r")
-			switch {
-			case strings.HasPrefix(line, "diff --git"):
-				flushFile()
-				cur = &Diff{}
-			case strings.HasPrefix(line, "@@"):
-				flushHunk()
-				hunk = &Hunk{Header: line, NewFrom: parseNewFrom(line)}
-			case hunk != nil:
-				// Inside a hunk → all lines are content, regardless of
-				// what they look like. See the "Case order matters" comment
-				// above for why this can't move below the header cases.
-				hunkBody.WriteString(line)
-				hunkBody.WriteByte('\n')
-			case strings.HasPrefix(line, "--- a/"):
-				// Capture the original path as a fallback for deletions —
-				// `+++ /dev/null` is the standard `git diff` shape for a
-				// deleted file, so reading +++ alone would attribute every
-				// deletion to "/dev/null" and silently break filtering,
-				// finding attribution, and any path-based downstream logic.
-				if cur != nil {
-					cur.Path = strings.TrimPrefix(line, "--- a/")
-				}
-			case strings.HasPrefix(line, "+++ b/"):
-				if cur != nil {
-					cur.Path = strings.TrimPrefix(line, "+++ b/")
-				}
-			case strings.HasPrefix(line, "+++ ") && cur != nil && cur.Path == "":
-				// Fallback for unusual paths (e.g. patches with non-standard
-				// prefixes). Skip the "+++ /dev/null" deletion shape — we
-				// already captured the original path from --- above.
-				suffix := strings.TrimPrefix(line, "+++ ")
-				if suffix != "/dev/null" {
-					cur.Path = suffix
-				}
-			}
+			s.processLine(line)
 		}
 		if readErr != nil {
 			if readErr == io.EOF {
@@ -279,16 +217,91 @@ func parseUnifiedDiff(r io.Reader) ([]Diff, error) {
 			return nil, fmt.Errorf("scan diff: %w", readErr)
 		}
 	}
-	flushFile()
+	s.flushFile()
 
 	// Drop any malformed entries (no path means we never saw a file header)
-	out := diffs[:0]
-	for _, d := range diffs {
+	out := s.diffs[:0]
+	for _, d := range s.diffs {
 		if d.Path != "" {
 			out = append(out, d)
 		}
 	}
 	return out, nil
+}
+
+// diffParseState is parseUnifiedDiff's streaming accumulator: the diffs
+// built so far, the file/hunk currently being accumulated, and the current
+// hunk's body text.
+type diffParseState struct {
+	diffs    []Diff
+	cur      *Diff
+	hunk     *Hunk
+	hunkBody strings.Builder
+}
+
+func (s *diffParseState) flushHunk() {
+	if s.cur != nil && s.hunk != nil {
+		s.hunk.Content = s.hunkBody.String()
+		s.cur.Hunks = append(s.cur.Hunks, *s.hunk)
+	}
+	s.hunk = nil
+	s.hunkBody.Reset()
+}
+
+func (s *diffParseState) flushFile() {
+	s.flushHunk()
+	if s.cur != nil {
+		s.diffs = append(s.diffs, *s.cur)
+	}
+	s.cur = nil
+}
+
+// processLine classifies one already-newline-stripped diff line and
+// updates state accordingly.
+//
+// Case order matters here — once we're inside a hunk (post-@@), every
+// line is content even if it happens to start with `--- a/` or `+++ b/`.
+// A deleted SQL comment `-- a/users` renders as `--- a/users` in the diff
+// (the leading `-` is the diff prefix), and the previous case order
+// matched that as a file header, silently overwriting cur.Path AND
+// swallowing the line from the hunk content. Putting `hunk != nil` ahead
+// of the header cases makes header recognition pre-@@ only.
+func (s *diffParseState) processLine(line string) {
+	switch {
+	case strings.HasPrefix(line, "diff --git"):
+		s.flushFile()
+		s.cur = &Diff{}
+	case strings.HasPrefix(line, "@@"):
+		s.flushHunk()
+		s.hunk = &Hunk{Header: line, NewFrom: parseNewFrom(line)}
+	case s.hunk != nil:
+		// Inside a hunk → all lines are content, regardless of
+		// what they look like. See the "Case order matters" comment
+		// above for why this can't move below the header cases.
+		s.hunkBody.WriteString(line)
+		s.hunkBody.WriteByte('\n')
+	case strings.HasPrefix(line, "--- a/"):
+		// Capture the original path as a fallback for deletions —
+		// `+++ /dev/null` is the standard `git diff` shape for a
+		// deleted file, so reading +++ alone would attribute every
+		// deletion to "/dev/null" and silently break filtering,
+		// finding attribution, and any path-based downstream logic.
+		if s.cur != nil {
+			s.cur.Path = strings.TrimPrefix(line, "--- a/")
+		}
+	case strings.HasPrefix(line, "+++ b/"):
+		if s.cur != nil {
+			s.cur.Path = strings.TrimPrefix(line, "+++ b/")
+		}
+	case strings.HasPrefix(line, "+++ ") && s.cur != nil && s.cur.Path == "":
+		// Fallback for unusual paths (e.g. patches with non-standard
+		// prefixes). Skip the "+++ /dev/null" deletion shape — we
+		// already captured the original path from --- above.
+		suffix := strings.TrimPrefix(line, "+++ ")
+		if suffix != "/dev/null" {
+			s.cur.Path = suffix
+		}
+	}
 }
 
 // parseNewFrom extracts the "+N" line number from a hunk header

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -200,34 +200,8 @@ type response struct {
 // providers respect this; for those that don't, the system prompt
 // should still steer the model to JSON.
 func (c *Client) Complete(ctx context.Context, msgs []Message, jsonMode bool) (string, Usage, error) {
-	// Scheme guard at the actual exfil sink: Complete POSTs the diff (or,
-	// under audit, the source) to BaseURL. The pre-flight probe checks
-	// this too, but --no-preflight skips the probe, so validate here as
-	// well — a non-http(s) base_url must never reach the HTTP client.
-	if u, err := url.Parse(c.BaseURL); err != nil || (strings.ToLower(u.Scheme) != "http" && strings.ToLower(u.Scheme) != "https") {
-		return "", Usage{}, fmt.Errorf("invalid base_url %q: must be an http:// or https:// URL", c.BaseURL)
-	}
-	if c.APIKey == "" && !isLocalURL(c.BaseURL) {
-		// Local-review init's "Ollama" preset writes a config with no
-		// api_key_env line because Ollama doesn't authenticate. A blank
-		// LOCAL_REVIEW_API_KEY (the legacy default) used to crash the
-		// review here despite the provider needing no key. Skip the
-		// check when base_url points at a local-or-LAN host (see
-		// isLocalURL — loopback + RFC1918 + CGNAT/Tailscale + IPv6
-		// unique/link-local);
-		// any public URL still requires a key. A user with a LAN
-		// gateway that DOES authenticate just sets api_key as usual
-		// (the !c.APIKey guard here means the bypass only fires when
-		// no key is configured).
-		// Name the env var the user actually configured
-		// (llms.<name>.api_key_env), threaded through from the provider
-		// spec. When it's empty the key was never wired to a var name, so
-		// point at the config field rather than the removed-in-v0.15
-		// LOCAL_REVIEW_API_KEY default the old fallback named.
-		if envName := strings.TrimSpace(c.APIKeyEnv); envName != "" {
-			return "", Usage{}, fmt.Errorf("no API key: $%s is unset or empty\n         export %s=... (or run `local-review init`), or use an LLM CLI instead (see `local-review doctor`)", envName, envName)
-		}
-		return "", Usage{}, fmt.Errorf("no API key configured for this provider\n         set llms.<name>.api_key_env to an env var name and export the key, or run `local-review init`\n         (local/LAN endpoints need no key — see `local-review doctor`)")
+	if err := validateCompleteRequest(c); err != nil {
+		return "", Usage{}, err
 	}
 
 	req := request{
@@ -276,15 +250,51 @@ func (c *Client) Complete(ctx context.Context, msgs []Message, jsonMode bool) (s
 	}
 
 	if resp.StatusCode >= 400 {
-		// Try to extract a useful message from the JSON error envelope
-		var parsed response
-		_ = json.Unmarshal(respBody, &parsed)
-		if parsed.Error != nil {
-			return "", Usage{}, fmt.Errorf("llm %s: %s", resp.Status, parsed.Error.Message)
-		}
-		return "", Usage{}, fmt.Errorf("llm %s: %s", resp.Status, string(respBody))
+		return "", Usage{}, completeErrorFromBody(resp.Status, respBody)
 	}
+	return parseCompleteBody(respBody)
+}
 
+// validateCompleteRequest checks c is safe/ready to POST to: BaseURL must
+// be an http(s) scheme (Complete POSTs the diff, or under audit the
+// source, to BaseURL — the pre-flight probe checks this too, but
+// --no-preflight skips the probe, so validate here as well), and an API
+// key must be configured unless BaseURL is local-or-LAN (see isLocalURL —
+// loopback + RFC1918 + CGNAT/Tailscale + IPv6 unique/link-local; Ollama
+// and similar don't authenticate, so local-review init's "Ollama" preset
+// writes no api_key_env line).
+func validateCompleteRequest(c *Client) error {
+	if u, err := url.Parse(c.BaseURL); err != nil || (strings.ToLower(u.Scheme) != "http" && strings.ToLower(u.Scheme) != "https") {
+		return fmt.Errorf("invalid base_url %q: must be an http:// or https:// URL", c.BaseURL)
+	}
+	if c.APIKey != "" || isLocalURL(c.BaseURL) {
+		return nil
+	}
+	// Name the env var the user actually configured
+	// (llms.<name>.api_key_env), threaded through from the provider
+	// spec. When it's empty the key was never wired to a var name, so
+	// point at the config field rather than the removed-in-v0.15
+	// LOCAL_REVIEW_API_KEY default the old fallback named.
+	if envName := strings.TrimSpace(c.APIKeyEnv); envName != "" {
+		return fmt.Errorf("no API key: $%s is unset or empty\n         export %s=... (or run `local-review init`), or use an LLM CLI instead (see `local-review doctor`)", envName, envName)
+	}
+	return fmt.Errorf("no API key configured for this provider\n         set llms.<name>.api_key_env to an env var name and export the key, or run `local-review init`\n         (local/LAN endpoints need no key — see `local-review doctor`)")
+}
+
+// completeErrorFromBody builds the error for an HTTP >=400 response,
+// preferring the provider's JSON error envelope message when present.
+func completeErrorFromBody(status string, respBody []byte) error {
+	var parsed response
+	_ = json.Unmarshal(respBody, &parsed)
+	if parsed.Error != nil {
+		return fmt.Errorf("llm %s: %s", status, parsed.Error.Message)
+	}
+	return fmt.Errorf("llm %s: %s", status, string(respBody))
+}
+
+// parseCompleteBody parses a successful (< 400) response body into the
+// assistant's text + usage.
+func parseCompleteBody(respBody []byte) (string, Usage, error) {
 	var out response
 	if err := json.Unmarshal(respBody, &out); err != nil {
 		return "", Usage{}, fmt.Errorf("parse response: %w", err)


### PR DESCRIPTION
## Why

SonarCloud (Maintainability, High/Critical) flagged 12 functions across `internal/agentselect`, `internal/audit`, `internal/bench`, `internal/cli`, `internal/git`, and `internal/llm` — over the 15-complexity budget. Complexities ranged 16–32 (`parseUnifiedDiff` at 32 was the single worst offender in the whole sweep).

## What

Mechanical extraction only in every case — every new function was moved verbatim out of its parent, no logic changes:

| Package | Function (complexity) | Extracted |
|---|---|---|
| agentselect | `Select` (25) | `selectOnly`, `selectDefault` |
| audit | `WriteMarkdown` (16) | `writeMarkdownPackages` |
| audit | `Run` (25) | `prepareAuditRun`, `runAuditWorkerPool` |
| audit | `parseFindings` (21) | `parseFindingHeader` |
| audit | `Walk` (17) | `groupFilesByPackage`, `buildChunksFromPackages` |
| bench | `jaccard` (19) | `findingSets`, `countIntersection` |
| bench | `writeMarkdownOverhead` (18) | `writeMarkdownOverheadRow`, `writeMarkdownCoverageNotes` |
| bench | `writeUpliftBlock` (18) | `writeUpliftRow` |
| bench | `loadSWEBenchCase` (16) | `readCaseFiles`, `validateCaseFields`, `trimAndValidateKeywords` |
| cli | `ClassifyExit` (17) | `formatExitStatusFailure`, `truncateStderrTail` |
| git | `parseUnifiedDiff` (32) | `diffParseState` struct (methods replace the old closures) |
| llm | `Complete` (19) | `validateCompleteRequest`, `completeErrorFromBody`, `parseCompleteBody` |

## Added coverage where extraction exposed pre-existing gaps

Splitting an untested function into named pieces turns "untested" into "new code at 0%" in Sonar's diff view — none of these gaps were caused by the refactor, but three were real enough to fix rather than route around:

- **`Walk`** had no test exercising real file-walking (only the negative-`MaxBytesPerChunk` guard was covered) — added `TestWalk_GroupsFilesByPackageAndSortsDeterministically` against a real temp git repo (mirrors `internal/git`'s own test pattern).
- **`writeUpliftBlock`/`writeUpliftRow`** were at 0% — `report.go`'s `WriteText` (the public entry point) has no test at all in this package. Added a direct test covering both branches (measured-with-numbers, and the "(not measured)" status line) — this package's existing convention for testing unexported render helpers (see `jaccard`'s own tests).

## Verification

- [x] `go build ./...`, `go vet ./...`, `gofmt -s -l .` (clean) — all clean
- [x] `go test -race ./...` — full suite green, including every pre-existing test for every touched function (all unchanged, all still passing)
- [x] `golangci-lint run` with `gocognit` (min-complexity 15) — 0 findings across all 6 packages, down from 12
- [x] Coverage on every newly-extracted function checked individually (all ≥78%, most 90-100%)

## What's NOT in this PR

The remaining 5 SonarCloud cognitive-complexity findings from this sweep are all in `*_test.go` files — a separate PR, different risk profile (refactoring test code can fight against "reads top-to-bottom" clarity, so it gets its own review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)