### PR TITLE
test: extract table-driven assertion helpers to cut complexity to ≤15

### DIFF
--- a/cmd/local-review/runner_test.go
+++ b/cmd/local-review/runner_test.go
@@ -491,15 +491,17 @@ func TestSingleLine_CollapsesAndTrims(t *testing.T) {
 // (b) the rendered timeout uses the CONFIGURED value, not the
 // hard-coded cli.DefaultProbeTimeout (so --preflight-timeout's
 // effect is visible in the rendered line).
+type formatProbeLineCase struct {
+	name            string
+	result          cli.ProbeResult
+	timeout         time.Duration
+	wantContains    []string
+	wantNotContains []string
+	wantStartsWith  string // exact prefix check for column-padding
+}
+
 func TestFormatProbeLine(t *testing.T) {
-	cases := []struct {
-		name            string
-		result          cli.ProbeResult
-		timeout         time.Duration
-		wantContains    []string
-		wantNotContains []string
-		wantStartsWith  string // exact prefix check for column-padding
-	}{
+	cases := []formatProbeLineCase{
 		{
 			name:           "ready_shows_glyph_and_duration",
 			result:         cli.ProbeResult{LLM: "claude", Status: cli.ProbeReady, Duration: 1234 * time.Millisecond},
@@ -563,20 +565,25 @@ func TestFormatProbeLine(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := formatProbeLine(tc.result, tc.timeout)
-			for _, sub := range tc.wantContains {
-				if !strings.Contains(got, sub) {
-					t.Errorf("formatProbeLine = %q, want it to contain %q", got, sub)
-				}
-			}
-			for _, sub := range tc.wantNotContains {
-				if strings.Contains(got, sub) {
-					t.Errorf("formatProbeLine = %q, want it NOT to contain %q", got, sub)
-				}
-			}
-			if tc.wantStartsWith != "" && !strings.HasPrefix(got, tc.wantStartsWith) {
-				t.Errorf("formatProbeLine = %q, want prefix %q (column padding)", got, tc.wantStartsWith)
-			}
+			assertFormatProbeLine(t, tc)
 		})
+	}
+}
+
+func assertFormatProbeLine(t *testing.T, tc formatProbeLineCase) {
+	t.Helper()
+	got := formatProbeLine(tc.result, tc.timeout)
+	for _, sub := range tc.wantContains {
+		if !strings.Contains(got, sub) {
+			t.Errorf("formatProbeLine = %q, want it to contain %q", got, sub)
+		}
+	}
+	for _, sub := range tc.wantNotContains {
+		if strings.Contains(got, sub) {
+			t.Errorf("formatProbeLine = %q, want it NOT to contain %q", got, sub)
+		}
+	}
+	if tc.wantStartsWith != "" && !strings.HasPrefix(got, tc.wantStartsWith) {
+		t.Errorf("formatProbeLine = %q, want prefix %q (column padding)", got, tc.wantStartsWith)
 	}
 }

--- a/internal/cli/probe_test.go
+++ b/internal/cli/probe_test.go
@@ -533,19 +533,21 @@ func (h *hungInvokerWithPartial) PartialStderr() string {
 // Err-must-NOT-contain, errors.Is-unwrap) is meaningful for the
 // scenario; empty fields are skipped. Test names follow CLAUDE.md
 // rule 9 — each case encodes an invariant, not a call shape.
+type probeTimeoutCase struct {
+	name            string
+	invoker         Invoker
+	wantContains    []string // every substring must appear in Err.Error()
+	wantNotContains []string // none of these may appear in Err.Error()
+	wantUnwraps     error    // errors.Is(Err, this) must hold; nil = skip
+}
+
 func TestProbe_TimeoutClassification(t *testing.T) {
 	release := make(chan struct{})
 	defer close(release)
 
 	vendorMsg := "Error: You have exhausted your capacity on this model."
 
-	cases := []struct {
-		name            string
-		invoker         Invoker
-		wantContains    []string // every substring must appear in Err.Error()
-		wantNotContains []string // none of these may appear in Err.Error()
-		wantUnwraps     error    // errors.Is(Err, this) must hold; nil = skip
-	}{
+	cases := []probeTimeoutCase{
 		{
 			name: "partial_stderr_surfaces_as_reason",
 			invoker: &hungInvokerWithPartial{
@@ -590,31 +592,36 @@ func TestProbe_TimeoutClassification(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-			defer cancel()
-
-			r := Probe(ctx, tc.invoker, "test-llm")
-			if r.Status != ProbeTimeout {
-				t.Fatalf("Status = %s, want ProbeTimeout", r.Status)
-			}
-			if r.Err == nil {
-				t.Fatal("Err is nil; expected ctx-Err or partial-stderr error")
-			}
-			errStr := r.Err.Error()
-			for _, sub := range tc.wantContains {
-				if !strings.Contains(errStr, sub) {
-					t.Errorf("Err = %q, want it to contain %q", errStr, sub)
-				}
-			}
-			for _, sub := range tc.wantNotContains {
-				if strings.Contains(errStr, sub) {
-					t.Errorf("Err = %q, want it NOT to contain %q (display should stay clean)", errStr, sub)
-				}
-			}
-			if tc.wantUnwraps != nil && !errors.Is(r.Err, tc.wantUnwraps) {
-				t.Errorf("errors.Is(Err, %v) = false, want true", tc.wantUnwraps)
-			}
+			assertProbeTimeoutClassification(t, tc)
 		})
+	}
+}
+
+func assertProbeTimeoutClassification(t *testing.T, tc probeTimeoutCase) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	r := Probe(ctx, tc.invoker, "test-llm")
+	if r.Status != ProbeTimeout {
+		t.Fatalf("Status = %s, want ProbeTimeout", r.Status)
+	}
+	if r.Err == nil {
+		t.Fatal("Err is nil; expected ctx-Err or partial-stderr error")
+	}
+	errStr := r.Err.Error()
+	for _, sub := range tc.wantContains {
+		if !strings.Contains(errStr, sub) {
+			t.Errorf("Err = %q, want it to contain %q", errStr, sub)
+		}
+	}
+	for _, sub := range tc.wantNotContains {
+		if strings.Contains(errStr, sub) {
+			t.Errorf("Err = %q, want it NOT to contain %q (display should stay clean)", errStr, sub)
+		}
+	}
+	if tc.wantUnwraps != nil && !errors.Is(r.Err, tc.wantUnwraps) {
+		t.Errorf("errors.Is(Err, %v) = false, want true", tc.wantUnwraps)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -860,40 +860,48 @@ func nonZeroConfig() Config {
 // findZeroFields walks v's exported fields and returns dotted paths of
 // any that are still their zero value. Used to detect merge() drift.
 func findZeroFields(v reflect.Value, prefix string) []string {
-	var out []string
 	switch v.Kind() {
 	case reflect.Struct:
-		t := v.Type()
-		for i := 0; i < v.NumField(); i++ {
-			fv := v.Field(i)
-			ft := t.Field(i)
-			if !ft.IsExported() {
-				continue
-			}
-			path := prefix + ft.Name
-			out = append(out, findZeroFields(fv, path+".")...)
-		}
+		return findZeroFieldsInStruct(v, prefix)
 	case reflect.Map:
-		if v.Len() == 0 {
-			out = append(out, strings.TrimSuffix(prefix, "."))
-			return out
-		}
-		// Recurse into one entry — sufficient to catch "the inner struct
-		// type isn't fully merged"; we don't need to walk every key.
-		for _, k := range v.MapKeys() {
-			out = append(out, findZeroFields(v.MapIndex(k), prefix+k.String()+".")...)
-			break
-		}
+		return findZeroFieldsInMap(v, prefix)
 	case reflect.Pointer:
 		if v.IsNil() {
-			out = append(out, strings.TrimSuffix(prefix, "."))
+			return []string{strings.TrimSuffix(prefix, ".")}
 		}
 	default:
 		if v.IsZero() {
-			out = append(out, strings.TrimSuffix(prefix, "."))
+			return []string{strings.TrimSuffix(prefix, ".")}
 		}
 	}
+	return nil
+}
+
+func findZeroFieldsInStruct(v reflect.Value, prefix string) []string {
+	var out []string
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		fv := v.Field(i)
+		ft := t.Field(i)
+		if !ft.IsExported() {
+			continue
+		}
+		path := prefix + ft.Name
+		out = append(out, findZeroFields(fv, path+".")...)
+	}
 	return out
+}
+
+func findZeroFieldsInMap(v reflect.Value, prefix string) []string {
+	if v.Len() == 0 {
+		return []string{strings.TrimSuffix(prefix, ".")}
+	}
+	// Recurse into one entry — sufficient to catch "the inner struct
+	// type isn't fully merged"; we don't need to walk every key.
+	for _, k := range v.MapKeys() {
+		return findZeroFields(v.MapIndex(k), prefix+k.String()+".")
+	}
+	return nil
 }
 
 // --- v0.14 provider: deprecation -----------------------------------------

--- a/internal/multi/merger_test.go
+++ b/internal/multi/merger_test.go
@@ -381,17 +381,24 @@ func TestMergePromptRendersByReviewCount(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := render(tc.n, tc.threshold)
-			for _, want := range tc.mustHave {
-				if !strings.Contains(out, want) {
-					t.Errorf("rendered prompt missing %q", want)
-				}
-			}
-			for _, no := range tc.mustNot {
-				if strings.Contains(out, no) {
-					t.Errorf("rendered prompt unexpectedly contains %q", no)
-				}
-			}
+			assertPromptContainsAndExcludes(t, out, tc.mustHave, tc.mustNot)
 		})
+	}
+}
+
+// assertPromptContainsAndExcludes checks that out contains every string in
+// mustHave and none of the strings in mustNot.
+func assertPromptContainsAndExcludes(t *testing.T, out string, mustHave, mustNot []string) {
+	t.Helper()
+	for _, want := range mustHave {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered prompt missing %q", want)
+		}
+	}
+	for _, no := range mustNot {
+		if strings.Contains(out, no) {
+			t.Errorf("rendered prompt unexpectedly contains %q", no)
+		}
 	}
 }
 

--- a/internal/multi/orchestrator_test.go
+++ b/internal/multi/orchestrator_test.go
@@ -76,6 +76,17 @@ func TestRunParallel_StreamsCompletionOrder(t *testing.T) {
 	// can't race ahead and let two agents finish "simultaneously"
 	// from the channel's perspective.
 	want := []string{"codex", "claude", "gemini"}
+	assertReleaseOrder(t, ch, gates, want)
+	assertChannelClosesAfterRelease(t, ch)
+}
+
+// assertReleaseOrder releases each gate in `want` order and asserts the
+// channel emits results in that same order — we read each result
+// immediately after releasing its gate so the next gate-close can't race
+// ahead and let two agents finish "simultaneously" from the channel's
+// perspective.
+func assertReleaseOrder(t *testing.T, ch <-chan ReviewResult, gates map[string]chan struct{}, want []string) {
+	t.Helper()
 	for i, name := range want {
 		close(gates[name])
 		select {
@@ -93,13 +104,17 @@ func TestRunParallel_StreamsCompletionOrder(t *testing.T) {
 			t.Fatalf("timed out waiting for %s emission", name)
 		}
 	}
-	// Channel should now be closed. Use a timeout-bounded select
-	// instead of a bare `<-ch`: the orchestrator's outer goroutine
-	// closes the channel only after wg.Wait() returns, which races
-	// in microseconds with the last worker's wg.Done(). Normally
-	// imperceptible, but under heavy CI load a bare receive could
-	// hang briefly and turn this assertion into a flaky timeout.
-	// 2s matches the rest of this file's "test never hangs" budget.
+}
+
+// assertChannelClosesAfterRelease asserts ch closes within 2s. Uses a
+// timeout-bounded select instead of a bare `<-ch`: the orchestrator's
+// outer goroutine closes the channel only after wg.Wait() returns, which
+// races in microseconds with the last worker's wg.Done(). Normally
+// imperceptible, but under heavy CI load a bare receive could hang
+// briefly and turn this assertion into a flaky timeout. 2s matches the
+// rest of this file's "test never hangs" budget.
+func assertChannelClosesAfterRelease(t *testing.T, ch <-chan ReviewResult) {
+	t.Helper()
 	select {
 	case _, ok := <-ch:
 		if ok {


### PR DESCRIPTION
## Why

SonarCloud (Maintainability) flagged the last 5 cognitive-complexity findings from this sweep, all in `*_test.go` files: `TestFormatProbeLine` (19), `TestProbe_TimeoutClassification` (25), `findZeroFields` (16), `TestMergePromptRendersByReviewCount` (18), `TestRunParallel_StreamsCompletionOrder` (16).

## What

Mechanical extraction only — no assertion changes:

- **4 table-driven tests**: each had its per-case assertion logic inline inside the `t.Run` closure. Pulled each closure body into a named `assertFoo(t, tc)` helper (`t.Helper()`-annotated) — same assertions, same failure messages, just a separate function with its own gocognit score. `TestFormatProbeLine` / `TestProbe_TimeoutClassification` needed their anonymous case-struct types promoted to named types so the helper could take one as a parameter.
- **`findZeroFields`**: not a `*testing.T` function — a recursive `reflect.Value` walker that happens to live in `config_test.go`. Split by `reflect.Kind` into `findZeroFieldsInStruct` / `findZeroFieldsInMap`, same pattern as the `internal/*` production-code extractions in #163.

## Verification

- [x] `go build ./...`, `gofmt -s -l .` — clean
- [x] `go test -race ./...` — full suite green, every case/subtest for every touched function unchanged and still passing
- [x] `golangci-lint run` with `gocognit` (min-complexity 15) — **0 findings across the entire repository**

This was the last of all 22 SonarCloud cognitive-complexity findings from this sweep — 17 already fixed in #162 (danger zone) and #163 (internal/* source files), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test readability and consistency across several areas by extracting repeated assertion logic into shared helpers.
  * Simplified table-driven tests for probe formatting, timeout classification, merge prompt rendering, and parallel result ordering.
  * Refined internal config test traversal logic while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->