### PR TITLE
ci+docs: add a gocognit gate so complexity debt doesn't regrow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
           fi
       - name: Vet
         run: go vet ./...
+      - name: Complexity
+        # Enforces gocognit (SonarSource's Cognitive Complexity, per-function
+        # budget 15 — see .golangci.yml) on every push/PR, not just on a
+        # PR's changed lines. SonarCloud's own S3776 rule only gates *new*
+        # code in a diff, so a function already over budget on `main` stays
+        # invisible until someone happens to touch it — this step catches a
+        # NEW function crossing the line at the PR that introduces it.
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
       - name: Test
         run: go test -race -count=1 ./...
       - name: Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+version: "2"
+
+# Deliberately minimal: only the linter this file exists for. `default:
+# standard` (or any broader preset) would turn this config into a second,
+# uncoordinated source of findings on top of `go vet` + gofmt + SonarCloud
+# — a wave of unrelated new findings on an unrelated PR is exactly the
+# kind of noise that erodes trust in the gate. Add another linter here
+# only with its own explicit rationale, not as a drive-by "while we're
+# at it."
+#
+# gocognit (SonarSource's Cognitive Complexity concept, reimplemented for
+# Go) closes the gap SonarCloud's own S3776 rule left: Sonar only enforces
+# it on *new* code in a PR's diff, so a function already over the
+# threshold on `main` is invisible to the gate until someone happens to
+# touch it — and by then the "new code" is often just one changed line
+# deep inside an already-complex function, not the whole thing. Running
+# gocognit locally / in CI enforces the SAME 15-per-function budget
+# unconditionally, on every function, so a regression is caught at the
+# PR that introduces it rather than surfacing later as a SonarCloud
+# Maintainability finding against code that already merged.
+linters:
+  default: none
+  enable:
+    - gocognit
+  settings:
+    gocognit:
+      min-complexity: 15
+  exclusions:
+    rules:
+      # Table-driven tests routinely have a t.Run closure whose body
+      # legitimately walks several assertions — that's the point of the
+      # pattern, and Sonar's own S3776 rule exempts *_test.go for the
+      # same reason (see docs/developer.md's "Lessons learned"). Keeping
+      # test files in-scope here would just push contributors toward
+      # extracting an assertXxx helper for its own sake rather than
+      # because the test got hard to follow.
+      - path: _test\.go
+        linters:
+          - gocognit

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -140,11 +140,55 @@ CI/infra change.
   exempt in `sonar-project.properties` (same rationale as the `init.go` provider
   table and the S3776 test-file exemption) — expect a new table test to need this;
   don't contort it to satisfy CPD.
-- **Don't chase the cognitive-complexity metric across the board.** ~20 functions
-  exceed Sonar's S3776 threshold of 15; most are legitimately-complex orchestration /
-  parsing and are existing-code issues that don't fail the new-code gate. Decompose
-  the genuine worst offender for readability; leave the rest. Refactoring purely to
-  satisfy a metric adds indirection without value.
+- **A full cognitive-complexity sweep is worth it once `.golangci.yml` exists to keep
+  it clean.** An earlier pass here decomposed only the worst offender and left ~20
+  functions over budget as "existing-code, doesn't fail the new-code gate" — true at
+  the time, but it meant the debt just sat there until each function was touched for
+  an unrelated reason, at which point the SAME extraction had to happen anyway, under
+  more time pressure. A later sweep fixed all 22 (mechanical extraction, no logic
+  changes, one PR per risk tier — danger zone / internal source / test files) and
+  added the `gocognit` CI gate below so the count stays at zero going forward instead
+  of slowly regrowing. Do the one-time sweep; don't leave a "mostly fixed" pile for
+  the next person.
+- **`golangci-lint` with only `gocognit` enabled closes the gap SonarCloud's own
+  new-code-only gate leaves.** `.github/workflows/ci.yml`'s "Complexity" step runs it
+  on every push/PR against the WHOLE repo, not just the diff — a regression is caught
+  at the PR that introduces it, not months later when SonarCloud finally flags it
+  because someone touched an adjacent line. `.golangci.yml` deliberately enables only
+  `gocognit` (not `default: standard` or any broader preset) — a wave of unrelated
+  new findings on an unrelated PR is exactly the kind of noise that erodes trust in a
+  gate. It also exempts `*_test.go`, mirroring `sonar-project.properties`'s own S3776
+  exemption for tests (see the note above) — local tooling and Sonar's gate should
+  agree, not fight each other.
+- **Extracting an untested function's internals turns "always was uncovered" into
+  "new code at 0%" in a diff-based coverage gate.** SonarCloud's new-code-coverage
+  gate (≥80%) failed twice during the complexity sweep — not because the refactor
+  broke anything, but because splitting a function that had ZERO direct test
+  coverage (e.g. `runDoctor`, `Walk`) into named helpers puts those helpers' bodies
+  into the PR's diff, and a diff-coverage tool can't see that the parent was already
+  just as untested on `main`. The fix is to add real tests for the newly-legible
+  pieces (which is a genuine improvement, not gate-satisfying theater) — write the
+  characterization tests against the CURRENT code first, confirm they pass, then
+  refactor, then confirm they still pass unchanged. Check coverage per extracted
+  function (`go test -coverprofile=... && go tool cover -func=...`) before pushing,
+  not after Sonar tells you.
 - **Branch before you edit.** Several refactors started with edits on `main` and had
   to be moved onto a feature branch (`git checkout -b` carries the working tree, so
   it's recoverable) — but starting on the branch is one less thing to get wrong.
+- **`go get -tool <module>@<version>` alone doesn't produce a `go mod tidy`-clean
+  `go.sum`.** Adding `govulncheck` / `gitleaks` as `tool` directives (closing the
+  Sonar "unpredictable dependency version" finding on `go install x@version` in CI)
+  passed `go build` / `go vet` / `go test` locally but still failed CI's `go mod tidy
+  && git diff --exit-code go.mod go.sum` step — `go mod tidy` pulls in a tool's
+  test-only transitive dependencies too, which `go get -tool` alone doesn't. Always
+  run `go mod tidy` (not just build/vet/test) after adding or bumping a `tool`
+  directive, and commit whatever it changes, before pushing.
+- **A tool with a large dependency tree can bloat `go.sum` far more than the value it
+  adds as a `tool` directive.** `golangci-lint` alone would have added ~650 lines to
+  `go.sum` (it bundles ~100 linters) for a dev-only CI tool — a real cost against
+  "no vendor SDKs... keeps the dependency surface... minimal" even though it's a
+  `tool`, not a runtime dependency. Used the SHA-pinned `golangci-lint-action`
+  instead: still fully reproducible (a real commit SHA, not a floating tag) without
+  the `go.sum` cost. `go.mod` tool directives are the right call for a single, small
+  binary (govulncheck, gitleaks); a SHA-pinned Action is the right call for a large
+  one. Weigh both before defaulting to "no vendor SDK, so always `go tool`."

--- a/docs/security.md
+++ b/docs/security.md
@@ -64,3 +64,30 @@ No vendor SDKs — raw HTTP only in `internal/llm/`, keeping the dependency surf
 thus supply-chain risk) minimal. See [developer.md](developer.md). Dependencies are
 kept current: Dependabot opens update PRs and `gitleaks` runs in CI on pull requests
 and pushes to `main`.
+
+- **CI/install tools go in `go.mod` as a `tool` directive, never `go install
+  x@version`.** `go get -tool <module>@<version>` (Go 1.24+) pins the version AND
+  checksum-verifies its full dependency graph in `go.sum` — the same integrity
+  guarantee the main build gets. A bare `go install x@version` inside a workflow step
+  has no lock file backing it; SonarCloud flags this (Security, "dependency versions
+  are not predictable"). `go tool <name>` then builds-and-runs it from the module
+  cache — no separate install step. See `.github/workflows/{govulncheck,secret-scan}.yml`
+  for the pattern. Exception: a tool with a large dependency tree (e.g.
+  `golangci-lint`, ~100 bundled linters) can cost more in `go.sum` bloat than it's
+  worth as a `tool` directive — a SHA-pinned GitHub Action is the better call there
+  (see `.github/workflows/ci.yml`'s "Complexity" step). Don't add `go mod tidy` to
+  the "later" pile either — `go get -tool` alone doesn't produce a tidy-clean
+  `go.sum` (it misses the tool's test-only transitive deps); run `go mod tidy` and
+  commit its output in the same change.
+- **Every `curl`/`wget` call that follows redirects must pin the protocol.**
+  `curl -L` (implied by `-fsSL`) follows redirects; without `--proto '=https'
+  --proto-redir '=https'`, a compromised or misconfigured server anywhere on the
+  redirect chain could downgrade the request to plain `http` mid-flight — the
+  `https://` in the *initial* URL doesn't protect against that on its own.
+  SonarCloud flags any un-pinned `curl -fsSL` as a Security finding ("not enforcing
+  HTTPS"). This applies to every occurrence of a URL, including ones a user is meant
+  to copy-paste (a documented `curl ... | sh` onboarding command is the highest-value
+  one to pin — it fetches executable code and pipes it straight into a shell). See
+  `install.sh` and `.github/workflows/release.yml`'s `update-homebrew` job for the
+  pattern; grep the repo for every `curl` when adding a new one so a fresh copy
+  doesn't miss the flags.


### PR DESCRIPTION
## Summary
- Adds `.golangci.yml` enabling only `gocognit` (per-function budget 15, matching SonarCloud's S3776 rule), with `*_test.go` exempted to mirror the existing `sonar-project.properties` exemption.
- Adds a "Complexity" step to `.github/workflows/ci.yml` (SHA-pinned `golangci-lint-action@v9.3.0`) that runs it on every push/PR against the whole repo — not just the diff, closing the blind spot where SonarCloud's new-code-only gate misses a function that was already over budget on `main`.
- Updates `docs/developer.md`'s "Lessons learned" with what the just-finished complexity sweep (22 findings, 3 PRs: #162/#163/#164) taught: do the full sweep once rather than leaving debt to regrow, the coverage-gate gotcha when extracting untested internals, the `go get -tool` + `go mod tidy` gotcha, and the go.sum-bloat-vs-Action tradeoff for large tools.
- Updates `docs/security.md`'s "Supply chain" section with the two durable rules behind PR #158's fixes: tool directives over bare `go install` in CI, and protocol-pinning every redirect-following `curl`/`wget`.

This is the last piece of the SonarCloud sweep: 10 Security findings (PR #158) + 22 Maintainability findings (PRs #162/#163/#164) fixed, and this PR is the guard against the Maintainability class regrowing silently.

## Test plan
- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` → 0 issues (verified locally with the exact config)
- [x] `go test -race -count=1 ./...` passes
- [ ] CI "Complexity" step — this is its first run against real GitHub Actions infra (only verified locally via the standalone CLI so far)