### PR TITLE
docs: add banner + CI/Go badges + star-and-discuss CTA to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/logo.svg" alt="local-review logo" width="200"/>
+  <img src="docs/social-preview.png" alt="local-review — local, BYOK code review for any language" width="800"/>
 </p>
 
 <h1 align="center">local-review</h1>
@@ -12,6 +12,8 @@
 
 <p align="center">
   <a href="https://github.com/mshykov/local-review/releases"><img src="https://img.shields.io/github/v/release/mshykov/local-review?style=flat-square" alt="Release"></a>
+  <a href="https://github.com/mshykov/local-review/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/mshykov/local-review/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go 1.26+"></a>
   <a href="https://github.com/mshykov/local-review/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License"></a>
   <a href="https://github.com/mshykov/local-review/stargazers"><img src="https://img.shields.io/github/stars/mshykov/local-review?style=flat-square" alt="Stars"></a>
   <a href="https://sonarcloud.io/summary/new_code?id=mshykov_local-review"><img src="https://sonarcloud.io/api/project_badges/measure?project=mshykov_local-review&metric=alert_status" alt="Quality Gate Status"></a>
@@ -24,6 +26,10 @@
   <a href="CHECKLIST.md">Checklist</a> •
   <a href="#customise-for-your-team">Customise</a> •
   <a href="https://local-review.shykov.dev">Website</a>
+</p>
+
+<p align="center">
+  If local-review saves you a review round, <a href="https://github.com/mshykov/local-review/stargazers">star the repo</a> and <a href="https://github.com/mshykov/local-review/discussions">join the discussion</a>.
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Swaps the small 200px logo for the existing `docs/social-preview.png` (1200×630, already shipped for OG/Twitter meta tags on the marketing site) as a proper banner image.
- Adds a CI status badge and a Go 1.26+ badge alongside the existing release/license/stars/quality-gate row.
- Adds a "star the repo and join the discussion" line — GitHub Discussions is already enabled on this repo, so it links a real channel rather than a placeholder Discord/X.

Docs-only change; no code, no build/test impact.

## Test plan
- [x] Verified both new shields.io badge URLs resolve (HTTP 200)
- [x] Confirmed `docs/social-preview.png` exists and is already a committed asset
- [x] Confirmed GitHub Discussions is enabled on the repo before linking it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed the project README branding with a new preview image.
  * Added badges for CI status and Go version support.
  * Included a short call-to-action encouraging readers to star the repository and join the discussion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->