### PR TITLE
docs: update author-site link to shykov.dev

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -988,7 +988,7 @@
             <path d="M12 .5C5.65.5.5 5.65.5 12.02c0 5.1 3.29 9.42 7.86 10.95.57.1.78-.25.78-.55 0-.27-.01-1-.02-1.95-3.2.7-3.87-1.55-3.87-1.55-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39s1.97.13 2.89.39c2.21-1.49 3.18-1.18 3.18-1.18.62 1.59.23 2.76.11 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.69 5.41-5.25 5.69.41.36.78 1.06.78 2.14 0 1.55-.01 2.8-.01 3.18 0 .31.21.66.79.55 4.57-1.53 7.85-5.85 7.85-10.94C23.5 5.65 18.35.5 12 .5z"/>
           </svg>
         </a>
-        <a href="https://m-shykov.web.app/" class="btn-icon" aria-label="Author's site (m-shykov.web.app)" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">
+        <a href="https://shykov.dev/" class="btn-icon" aria-label="Author's site (shykov.dev)" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">
           <!-- Author-site favicon, self-hosted (the project markets
                "no telemetry, no SaaS"; hot-linking from another
                domain would log every visitor's IP at that domain


### PR DESCRIPTION
The author's personal site (linked in the website footer) moved from the legacy `m-shykov.web.app` Firebase Hosting domain to `shykov.dev`. Updates the link href and aria-label.

Pure website/docs change — no pre-push self-review needed per CLAUDE.md rule 11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the author site link in the docs page to point to the new website.
  * The link now opens in a new tab and uses safer browser settings to protect referrer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->