### PR TITLE
ci: fix main's Quality Gate by passing sonar.projectVersion

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -96,7 +96,13 @@ jobs:
         # between releases and only changes when a new tag lands — matching
         # how this repo actually versions.
         id: version
-        run: echo "value=$(git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)" >> "$GITHUB_OUTPUT"
+        run: |
+          version=$(git describe --tags --abbrev=0 2>/dev/null) || true
+          if [ -z "$version" ]; then
+            echo "::error::No git tag resolved via 'git describe --tags --abbrev=0' — check the checkout step still has fetch-tags: true. Refusing to fall back to a fixed placeholder version: a version string that never changes is exactly the bug this step exists to fix (it stalls Sonar's previous_version baseline forever)."
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
 
       - name: SonarQube Scan
         # The action auto-detects PR context (sonar.pullrequest.key/branch/base)

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -57,9 +57,13 @@ jobs:
     steps:
       # fetch-depth: 0 gives Sonar the full history it needs for blame data
       # ("new code" calculations against branch lifetime) and PR base detection.
+      # fetch-tags: true is required alongside it — a full-history fetch does
+      # NOT guarantee tag refs come along, and the next step needs `git
+      # describe --tags` to resolve real tags.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -78,12 +82,32 @@ jobs:
         run: |
           go test -race -covermode=atomic -coverprofile=coverage.out ./...
 
+      - name: Resolve project version
+        # The main branch's Quality Gate uses New Code = "previous version"
+        # (SonarCloud project setting), which detects a release boundary by
+        # watching sonar.projectVersion change between scans. We were never
+        # passing it, so every scan reported "not provided" — the version
+        # string never changed, so Sonar never saw a boundary and kept
+        # comparing against the oldest analysis it had (v0.7.2, 2026-05-07),
+        # silently growing "new code" to ~10 releases' worth of diff and
+        # failing the coverage condition on code most of which had already
+        # shipped. `git describe --tags --abbrev=0` resolves the nearest
+        # reachable tag with no commit-distance suffix, so it stays constant
+        # between releases and only changes when a new tag lands — matching
+        # how this repo actually versions.
+        id: version
+        run: echo "value=$(git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)" >> "$GITHUB_OUTPUT"
+
       - name: SonarQube Scan
         # The action auto-detects PR context (sonar.pullrequest.key/branch/base)
         # from the GitHub Actions environment, so PRs and main both work with no
-        # extra config.
+        # extra config. PR analysis always diffs against the PR's base branch
+        # regardless of projectVersion, so this arg only changes main's own
+        # dashboard/gate behavior (see "Resolve project version" above).
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           # SONAR_HOST_URL only needed for self-hosted SonarQube; SonarCloud
           # is the default and the action picks the right URL when omitted.
+        with:
+          args: -Dsonar.projectVersion=${{ steps.version.outputs.value }}

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -192,3 +192,17 @@ CI/infra change.
   the `go.sum` cost. `go.mod` tool directives are the right call for a single, small
   binary (govulncheck, gitleaks); a SHA-pinned Action is the right call for a large
   one. Weigh both before defaulting to "no vendor SDK, so always `go tool`."
+- **`main`'s own Quality Gate silently drifted red for months because `sonar.projectVersion`
+  was never set.** The project's New Code period is "previous version" — Sonar detects a
+  release boundary by watching the version string change between scans. Every scan reported
+  it as `"not provided"`, so the string never changed, so Sonar never saw a boundary and kept
+  comparing `main` against the oldest analysis it still had (v0.7.2, ~2 months and 10+
+  releases back) — silently growing "new code" to span most of that window and failing the
+  80% new-code-coverage condition on code that had already shipped clean, one release at a
+  time. `.github/workflows/sonar.yml` now resolves `git describe --tags --abbrev=0` (stays
+  constant between releases, only changes when a new tag lands) and passes it as
+  `sonar.projectVersion`. Caught by looking at the SonarCloud dashboard directly rather than
+  assuming "80% new-code coverage failing" meant *this* PR's diff was undertested — the
+  first move on a surprising Sonar gate is always to check what "new code" actually spans
+  (`/api/qualitygates/project_status`'s `periods[0].date`), not to start writing tests against
+  an assumption.


### PR DESCRIPTION
## Summary
The SonarCloud dashboard shows `main`'s Quality Gate failing new-code coverage (70.1% vs 80% required), attributed to "New code since about 2 months ago". That window is wrong, and it's not a real coverage regression.

**Root cause:** `sonar.yml` never set `sonar.projectVersion`, so every scan reported it as `"not provided"`. The project's New Code period is `previous_version` mode — Sonar detects a release boundary by watching that string change between scans. Since it never changed, Sonar never saw a boundary and kept comparing `main` against the oldest analysis it still had (**v0.7.2, 2026-05-07**) — silently growing "new code" to span 10+ releases and failing the coverage condition on code that had already shipped clean, one release at a time (confirmed via `/api/qualitygates/project_status`'s `periods[0].date` and `/api/project_analyses/search`'s `projectVersion: "not provided"` on every recent analysis).

**Fix:** resolve `git describe --tags --abbrev=0` (constant between releases, changes only when a new tag lands — matching how this repo actually versions) and pass it via `-Dsonar.projectVersion=...` to the scan action. Added `fetch-tags: true` to the checkout step since a full-history fetch doesn't guarantee tag refs on its own.

Once this merges, the next scan on `main` registers a version change (the string moves off `"not provided"`) and the new-code baseline resets to now — the gate should go green immediately. No test-writing needed; the 1160 "uncovered new lines" Sonar was reporting were mostly from code that individually passed its own PR's coverage gate months ago.

Also documented as a lesson in `docs/developer.md`: check what "new code" actually spans before assuming a coverage-gate failure means the current diff is undertested.

## Test plan
- [x] `actionlint .github/workflows/sonar.yml` — clean
- [x] Confirmed `git describe --tags --abbrev=0` resolves to `v0.17.3` locally on `main`
- [x] Confirmed via SonarCloud API that every recent analysis reports `projectVersion: "not provided"` and the new-code period is pinned to v0.7.2's date
- [ ] Post-merge: verify the next `main` scan shows a fresh new-code baseline and a green Quality Gate (will check after merge)