### PR TITLE
test: cover the report renderers + scope Sonar coverage to measurable code

### DIFF
--- a/internal/audit/report_test.go
+++ b/internal/audit/report_test.go
@@ -1,0 +1,131 @@
+package audit
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// reportFixture builds a Report exercising all three package states the
+// renderers branch on: findings-bearing, clean, and errored. Shared by the
+// text and markdown renderer tests so both formats are asserted against the
+// same input shape.
+func reportFixture() Report {
+	return Report{
+		Topic:     "security",
+		Generated: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC),
+		LLM:       "claude",
+		Packages: []PackageReport{
+			{
+				Package: "internal/config",
+				Files:   []string{"internal/config/config.go", "internal/config/env.go"},
+				Findings: []Finding{
+					{Path: "internal/config/config.go", Line: 42, Severity: "critical", Body: "first line\nsecond line"},
+					{Path: "internal/config/env.go", Line: 10, LineEnd: 14, Severity: "warning", Body: "ranged finding"},
+				},
+			},
+			{
+				Package: "internal/lang",
+				Files:   []string{"internal/lang/detect.go"},
+				Clean:   true,
+			},
+			{
+				Package: "internal/llm",
+				Files:   []string{"internal/llm/client.go"},
+				Error:   "context deadline exceeded",
+			},
+		},
+		TotalFindings:        2,
+		FindingsBySeverity:   map[string]int{"critical": 1, "warning": 1},
+		PackagesWithFindings: 1,
+		PackagesClean:        1,
+		PackagesErrored:      1,
+	}
+}
+
+// TestWriteText_RendersAllPackageStates pins the terminal renderer's
+// contract: headline counts, severity breakdown, and the three per-package
+// shapes (findings inline with indented bodies, "✓ clean", "[ERR]").
+func TestWriteText_RendersAllPackageStates(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteText(&buf, reportFixture()); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"Audit: topic=security  llm=claude  packages=3  findings=2",
+		"Severity breakdown: critical=1 warning=1",
+		"Packages: 1 with findings, 1 clean, 1 errored",
+		"── internal/config ── 2 files",
+		"[critical] internal/config/config.go:42",
+		"    first line",
+		"    second line",
+		"[warning] internal/config/env.go:10-14",
+		"── internal/lang ── 1 file  ✓ clean",
+		"── internal/llm ── 1 file  [ERR] context deadline exceeded",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("WriteText output missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestWriteText_NoFindingsRendersSeverityNone covers the empty-severity
+// branch: a fully clean audit says "none" instead of an empty breakdown.
+func TestWriteText_NoFindingsRendersSeverityNone(t *testing.T) {
+	rep := Report{
+		Topic: "tech-debt",
+		LLM:   "codex",
+		Packages: []PackageReport{
+			{Package: "internal/lang", Files: []string{"internal/lang/detect.go"}, Clean: true},
+		},
+		PackagesClean: 1,
+	}
+	var buf bytes.Buffer
+	if err := WriteText(&buf, rep); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Severity breakdown: none") {
+		t.Errorf("expected severity breakdown 'none' for a clean audit, got:\n%s", buf.String())
+	}
+}
+
+// TestWriteMarkdown_OrdersFindingsThenCleanThenErrored pins the committable
+// report's section order: findings-bearing packages render as their own
+// sections first, clean packages collapse into one line, errored packages
+// land at the bottom so failures stand out.
+func TestWriteMarkdown_OrdersFindingsThenCleanThenErrored(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, reportFixture()); err != nil {
+		t.Fatalf("WriteMarkdown: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"# Audit — security",
+		"_LLM: claude_ · _Packages: 3_ · _Findings: 2_",
+		"| critical | 1 |",
+		"| major | 0 |",
+		"## internal/config",
+		"_2 files audited_",
+		"- **[critical]** `internal/config/config.go:42`",
+		"## Clean packages",
+		"_1 package with no findings:_ internal/lang",
+		"## Errored packages",
+		"- **internal/llm** — context deadline exceeded",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("WriteMarkdown output missing %q, got:\n%s", want, out)
+		}
+	}
+
+	findingsIdx := strings.Index(out, "## internal/config")
+	cleanIdx := strings.Index(out, "## Clean packages")
+	erroredIdx := strings.Index(out, "## Errored packages")
+	if !(findingsIdx < cleanIdx && cleanIdx < erroredIdx) {
+		t.Errorf("expected findings < clean < errored section order, got indices %d, %d, %d:\n%s",
+			findingsIdx, cleanIdx, erroredIdx, out)
+	}
+}

--- a/internal/bench/report_test.go
+++ b/internal/bench/report_test.go
@@ -59,3 +59,165 @@ func TestWriteUpliftBlock_MeasuredAndUnmeasuredRows(t *testing.T) {
 		t.Errorf("expected gemini's row to say (not measured), got:\n%s", out)
 	}
 }
+
+// fullReportFixture builds a Report that walks every optional section of
+// the text renderer at once: a consistency-measured LLM (Cons. column),
+// per-language splits, an uplift baseline with partial token-measured
+// overhead (inline coverage note), a second LLM with none of those
+// (dash/dash branches), and an errored case (":ERR" per-case cell).
+func fullReportFixture() Report {
+	cons := 0.92
+	return Report{
+		Dataset:   "bench/dataset",
+		CaseCount: 2,
+		Mode:      "replay",
+		LLMReports: []LLMReport{
+			{
+				LLM:         "claude",
+				Precision:   0.83,
+				Recall:      0.71,
+				F1:          0.77,
+				NoiseRate:   0.50,
+				MedianMs:    4500,
+				P95Ms:       6100,
+				Consistency: &cons,
+				Languages: []LanguageScore{
+					{Language: "go", F1: 0.89},
+					{Language: "python", F1: 0.60},
+				},
+				Cases: []CaseScore{
+					{CaseID: "go-nil-deref", TruePositives: 2, Produced: 2},
+					{CaseID: "py-sql-injection", Error: "timeout"},
+				},
+				Baseline: &LLMBaselineAggregate{
+					F1: 0.45, Precision: 0.50, Recall: 0.40, NoiseRate: 0.80,
+					MeasuredNonCleanCases: 1, MeasuredCleanCases: 1,
+				},
+				Overhead: &OverheadAggregate{
+					PairedCases:           2,
+					TreatmentDurationMs:   9000,
+					BaselineDurationMs:    5000,
+					TokenMeasuredCases:    1,
+					TreatmentInputTokens:  11000,
+					TreatmentOutputTokens: 1500,
+					BaselineInputTokens:   8000,
+					BaselineOutputTokens:  500,
+				},
+			},
+			{
+				// No consistency, no languages, no baseline numbers, no
+				// overhead: exercises the dash and "(not measured)" branches
+				// alongside claude's populated row.
+				LLM:       "gemini",
+				Precision: 0.60,
+				Recall:    0.55,
+				F1:        0.57,
+				NoiseRate: 1.00,
+				MedianMs:  800,
+				P95Ms:     950,
+				Cases: []CaseScore{
+					{CaseID: "go-nil-deref", TruePositives: 1, Produced: 3},
+				},
+				Baseline: &LLMBaselineAggregate{},
+			},
+		},
+	}
+}
+
+// TestWriteText_FullReport drives the public text entry point end to end
+// with every optional section active, pinning the overall table (with the
+// Cons. column), the per-language grid, the uplift and overhead blocks
+// (numeric, dashed, and partial-token-coverage variants), and the per-case
+// detail including the ":ERR" cell.
+func TestWriteText_FullReport(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteText(&buf, fullReportFixture()); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"Bench: dataset=bench/dataset  cases=2  mode=replay",
+		"Cons.", // consistency column present
+		"0.92",  // claude's measured consistency
+		"4.5s",  // fmtMs seconds branch (median)
+		"800ms", // fmtMs millisecond branch
+		"Per-language F1:",
+		"claude=0.89  gemini=-", // measured next to sentinel dash
+		"Uplift over baseline",
+		"0.77 (+0.32)",   // claude's F1 uplift cell
+		"(not measured)", // gemini's zero-data baseline row
+		"Overhead vs raw model",
+		"4.5s (+2.00s)", // paired duration mean + signed delta
+		"12k (+4.0k)",   // token mean in k-notation (12500 → "12k": ≥10k uses %.0f) + signed delta
+		"tokens measured on 1 of 2 paired cases",
+		"Per-case detail:",
+		"claude:F1=1.00",
+		"py-sql-injection",
+		"claude:ERR",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("WriteText output missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestWriteText_TerseReport pins the minimal shape: no consistency
+// measured anywhere → no Cons. column; single language → no per-language
+// block; no baseline → no uplift or overhead sections. Single-run benches
+// must stay one screen tall.
+func TestWriteText_TerseReport(t *testing.T) {
+	rep := Report{
+		Dataset:   "bench/dataset",
+		CaseCount: 1,
+		Mode:      "cli",
+		LLMReports: []LLMReport{
+			{
+				LLM:       "codex",
+				Precision: 1.0,
+				Recall:    0.5,
+				F1:        0.67,
+				MedianMs:  1200,
+				P95Ms:     1200,
+				Cases:     []CaseScore{{CaseID: "go-nil-deref", TruePositives: 1, FalseNegatives: 1, Produced: 1}},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteText(&buf, rep); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	out := buf.String()
+
+	for _, absent := range []string{"Cons.", "Per-language F1:", "Uplift over baseline", "Overhead vs raw model"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("terse report unexpectedly contains %q:\n%s", absent, out)
+		}
+	}
+	for _, want := range []string{"codex", "Per-case detail:", "go-nil-deref"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("terse report missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestFmtTokens_UnitBoundaries pins the k-notation cutovers: plain count
+// below 1000, one decimal to 10k, whole k above — matching the per-LLM
+// completion-line shape users compare against.
+func TestFmtTokens_UnitBoundaries(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{999, "999"},
+		{1000, "1.0k"},
+		{9999, "10.0k"},
+		{10000, "10k"},
+		{250000, "250k"},
+	}
+	for _, c := range cases {
+		if got := fmtTokens(c.in); got != c.want {
+			t.Errorf("fmtTokens(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/git/list_test.go
+++ b/internal/git/list_test.go
@@ -1,6 +1,12 @@
 package git
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 // TestSplitNullBytes_EmptyInput covers the early-return path —
 // an empty `git ls-files -z` stdout (no tracked files) should
@@ -78,5 +84,137 @@ func TestSplitNullBytes_MultipleConsecutiveNullsSkippedAsEmpty(t *testing.T) {
 	}
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Errorf("expected empty tokens dropped; got %v", got)
+	}
+}
+
+// initTestRepo creates a temp git repo with two committed files (one in a
+// subdirectory) and one uncommitted file, mirroring diff_test.go's inline
+// setup. Returns the repo root (symlink-resolved, since macOS TempDir lives
+// under /var → /private/var and RepoRoot returns git's resolved path).
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "t@example.com")
+	runGit("config", "user.name", "T")
+	runGit("config", "commit.gpgsign", "false")
+	if err := os.MkdirAll(filepath.Join(repo, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"top.go", "pkg/nested.go"} {
+		if err := os.WriteFile(filepath.Join(repo, f), []byte("package x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGit("add", ".")
+	runGit("commit", "-q", "-m", "init")
+	// Untracked file: must NOT appear in TrackedFiles output.
+	if err := os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+// TestTrackedFiles_ListsCommittedFilesRepoRootRelative pins the audit
+// enumeration contract: repo-root-relative paths, tracked files only
+// (untracked and gitignored files are exactly what audit must not scan),
+// and repo-wide results even when invoked with an explicit root while the
+// process CWD is elsewhere — the PR #73 CWD bug this function exists to
+// prevent.
+func TestTrackedFiles_ListsCommittedFilesRepoRootRelative(t *testing.T) {
+	repo := initTestRepo(t)
+
+	files, err := TrackedFiles(repo)
+	if err != nil {
+		t.Fatalf("TrackedFiles: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range files {
+		got[f] = true
+	}
+	if !got["top.go"] || !got["pkg/nested.go"] {
+		t.Errorf("expected top.go and pkg/nested.go in tracked files, got %v", files)
+	}
+	if got["untracked.txt"] {
+		t.Errorf("untracked.txt must not be listed, got %v", files)
+	}
+}
+
+// TestTrackedFiles_EmptyRootResolvesViaRepoRoot covers the root==""
+// fallback (resolve CWD's repo root once) and RepoRoot itself against a
+// real repo. Chdir is process-global — same no-t.Parallel() caveat as
+// TestExtract_StagedDiffAndSizeCap.
+func TestTrackedFiles_EmptyRootResolvesViaRepoRoot(t *testing.T) {
+	repo := initTestRepo(t)
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Run from a SUBDIRECTORY: proves both RepoRoot's walk-up and
+	// TrackedFiles' repo-wide `:/` pathspec behave from a non-root CWD.
+	if err := os.Chdir(filepath.Join(repo, "pkg")); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+
+	root, err := RepoRoot()
+	if err != nil {
+		t.Fatalf("RepoRoot: %v", err)
+	}
+	if root != repo {
+		t.Errorf("RepoRoot = %q, want %q", root, repo)
+	}
+
+	files, err := TrackedFiles("")
+	if err != nil {
+		t.Fatalf("TrackedFiles(\"\"): %v", err)
+	}
+	found := false
+	for _, f := range files {
+		if f == "top.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected repo-wide listing (top.go) from subdir CWD, got %v", files)
+	}
+}
+
+// TestRepoRoot_ErrorsOutsideWorkTree pins the fail-loud contract: outside
+// any git repo, RepoRoot must surface git's non-zero exit as an error.
+func TestRepoRoot_ErrorsOutsideWorkTree(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+	// GIT_CEILING_DIRECTORIES can't help here since exec.Command inherits
+	// our env; a plain TempDir is outside any repo on CI runners, but a
+	// developer machine could nest tmp under a repo — guard against that.
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	cmd.Dir = dir
+	if out, _ := cmd.CombinedOutput(); strings.TrimSpace(string(out)) == "true" {
+		t.Skip("temp dir is inside a git work tree on this machine; cannot test the outside-repo path")
+	}
+
+	if _, err := RepoRoot(); err == nil {
+		t.Error("expected an error outside a git work tree, got nil")
 	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -39,6 +39,21 @@ sonar.test.inclusions=**/*_test.go
 # Coverage report path matches the -coverprofile output in sonar.yml.
 sonar.go.coverage.reportPaths=coverage.out
 
+# Coverage-measurement exclusions (issues/analysis still apply to these
+# files — only the coverage metric skips them). Scoped to cobra wiring:
+#   - main.go: command registration + flag plumbing; exercised end-to-end
+#     by the e2e suite, but as a SUBPROCESS of the test binary, which
+#     `go test -coverprofile` cannot observe — so its real coverage is
+#     structurally invisible to this report.
+#   - iohelpers.go: stdout/stderr plumbing for the same wiring.
+#   - bench.go / audit.go: flag parsing + terminal presentation for their
+#     subcommands; the logic they orchestrate lives in internal/bench and
+#     internal/audit, which STAY measured (and tested).
+# runner.go and doctor.go are deliberately NOT excluded: they're the
+# danger zone (CLAUDE.md rule 12) — coverage pressure on them is a
+# feature, not noise.
+sonar.coverage.exclusions=cmd/local-review/main.go,cmd/local-review/iohelpers.go,cmd/local-review/bench.go,cmd/local-review/audit.go
+
 # Don't apply the Cognitive Complexity rule (S3776) to test files. Table-driven
 # Go tests are intentionally long and linear (one t.Run per case); their
 # "complexity" is the case count, not branching that's hard to maintain.


### PR DESCRIPTION
## Summary
Fixes the failing SonarCloud new-code coverage condition (70.1% vs 80% required) from both ends, per the "increase coverage OR exclude it" decision:

**Increase (real tests, ~170 newly covered lines in the new-code window):**
- `internal/bench/report.go` — `WriteText` end-to-end with every optional section active (consistency column, per-language grid, uplift + overhead blocks, partial-token-coverage note, `:ERR` cells), the terse single-run shape, and `fmtTokens` unit boundaries. Package 76.0% → **84.5%**; every previously-0% renderer function now covered.
- `internal/audit/report.go` — `WriteText` across all three package states (findings / clean / errored) and `WriteMarkdown`'s section-ordering contract. Package 76.9% → **84.2%**.
- `internal/git/list.go` — `RepoRoot` + `TrackedFiles` against a real temp repo (repo-root-relative paths, untracked exclusion, subdirectory CWD, outside-a-repo error). This also starts closing the "git exec surface has zero real-git tests" gap from the architecture audit. Package 71.5% → **81.0%**.

**Exclude (coverage metric only — issues/analysis still apply):**
- `sonar.coverage.exclusions` for cobra wiring: `main.go` (exercised by the e2e suite, but as a subprocess — structurally invisible to `-coverprofile`), `iohelpers.go`, and `bench.go`/`audit.go` (flag plumbing + presentation; their logic lives in `internal/bench`/`internal/audit`, which stay measured and are exactly the files tested above).
- `runner.go` and `doctor.go` deliberately stay measured — coverage pressure on the danger zone is a feature.

Estimated effect on the (still baseline-stuck) new-code window: 70.1% → **~83%**, comfortably over the 80% bar. When the baseline eventually resets (next release, per PR #171), the margin only improves.

## Test plan
- [x] `gofmt -s`, `go vet`, `golangci-lint run` (0 issues) clean
- [x] `go test -race -count=1 ./...` passes
- [x] `go test -tags e2e ./e2e/...` passes
- [x] Per-function coverage verified via `go tool cover -func` (all previously-0% renderer functions now exercised)
- [ ] Post-merge: confirm the main-branch Sonar scan's coverage condition goes green

Pre-push dogfood self-review skipped: the `claude` CLI can't run inside this nested-agent session (docs/developer.md's documented fallback) — full `-race` + e2e suites, CI, and CodeRabbit are the safety net for this test-only + scanner-config change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for audit report output, benchmark report rendering, Git file discovery, and repository-root detection.
  * Added checks for text and markdown formatting, section ordering, and edge-case number formatting.
* **Chores**
  * Updated analysis settings to exclude selected local-review wiring files from coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->