### PR TITLE
ci: release supply-chain hardening (append-only releases, provenance, hermetic builds)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Gate (release label or manual dispatch)
         id: gate
@@ -209,10 +210,16 @@ jobs:
           - { goos: windows, goarch: amd64 }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
-          cache: true
+          # No restored cache for SHIPPED binaries: a cache hit skips
+          # go.sum re-verification, so a poisoned cache entry would flow
+          # into release artifacts. Cold build costs seconds here; CI's
+          # non-shipping jobs keep cache: true for speed.
+          cache: false
 
       - name: Build
         env:
@@ -250,7 +257,9 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # push tag + softprops/action-gh-release attaches assets
+      contents: write     # push tag + softprops/action-gh-release attaches assets
+      id-token: write     # OIDC identity for build-provenance attestation
+      attestations: write # persist the provenance attestation
     outputs:
       tag: ${{ needs.prepare.outputs.version }}
     steps:
@@ -279,19 +288,40 @@ jobs:
           echo "--- generated checksums ---"
           cat "local-review_${VERSION}_checksums.txt"
 
+      - name: Attest build provenance
+        # Publishes a signed SLSA provenance attestation binding every
+        # release asset (binaries + checksums manifest) to THIS workflow
+        # run's identity. Verify with:
+        #   gh attestation verify <file> --repo mshykov/local-review
+        # Complements (doesn't replace) the checksums manifest: the
+        # manifest proves integrity, the attestation proves the asset
+        # came from this repo's release pipeline. Cosign remains on the
+        # roadmap for keyless signature files shipped alongside assets.
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/local-review_*_checksums.txt
+
       - name: Create and push tag
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # Idempotent: skip if the tag already exists on the remote.
+          # Fail closed if the tag already exists: proceeding would rebuild
+          # from current HEAD and OVERWRITE the published release's assets
+          # (including the checksums manifest) under the same version — the
+          # silent-replacement path the 2026-07 SecOps audit flagged. A tag
+          # ruleset also blocks v* updates/deletion server-side; releases
+          # are append-only, so a redo means bumping the version.
           if git ls-remote --tags origin "$VERSION" | grep -q "$VERSION"; then
-            echo "Tag $VERSION already exists — reusing"
-          else
-            git tag -a "$VERSION" -m "Release $VERSION"
-            git push origin "$VERSION"
+            echo "::error::Tag $VERSION already exists. Releases are append-only — bump the version instead of re-releasing onto an existing tag."
+            exit 1
           fi
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           # Full history so `gitleaks git` scans every commit on the
           # branch/PR, not just the tip — a secret added then "removed"
           # in a later commit is still in history and must be caught.

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ local-review audit --topic security --with ollama
 | **Gemini** *(sunset 2026-06-18 — v0.15+ auto-disables)* | ✅ Free API key from [Google AI Studio](https://aistudio.google.com/apikey) | `npm install -g @google/gemini-cli` |
 | **Codex** | ⚠️ ChatGPT Plus ($20/mo) **or** OpenAI API key (pay-per-token) | `npm install -g @openai/codex` |
 | **Copilot** | ⚠️ GitHub Copilot subscription (one Premium request per run) | `npm install -g @github/copilot` |
-| **Antigravity** *(detected — review integration experimental)* | Google OAuth (`agy` login) | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` (binary: `agy`) |
+| **Antigravity** *(detected — review integration experimental)* | Google OAuth (`agy` login) | `curl -fsSL --proto '=https' --proto-redir '=https' https://antigravity.google/cli/install.sh \| bash` (binary: `agy`) |
 
 > **Gemini sunset 2026-06-18.** Google's Gemini CLI stops serving Pro/Ultra/free-tier requests on this date. **v0.15+ handles this automatically**: pre-sunset `doctor` shows a live countdown banner ("N days until sunset"); on/after the cutoff, gemini is auto-disabled in the review fan-out with a clear note. Want to keep trying past the cutoff (in case Google extends, or your network sees a different rollout)? Set `llms.gemini.force_after_sunset: true` to opt back in. Antigravity (`agy`) is Google's announced successor and `local-review doctor` detects it as *experimental* — its headless `--print` mode runs an autonomous agent loop (explores the repo, rebuilds its own diff, emits step-narration) instead of returning a clean review, so it isn't yet in the fan-out. Until that lands, keep using Gemini (until the cutoff) or any of the other CLIs / providers.
 


### PR DESCRIPTION
## Summary
Closes the two MAJOR release-trust findings + three minors from today's SecOps audit. Together with the settings changes already applied live (tag ruleset blocking `v*` update/delete/force-push, tap `main` ruleset, workflow-token default → read), this converts "trust the GitHub account never has a bad day" into "tampering is either impossible or evident."

- **Append-only releases**: the publish job previously *reused* an existing tag and let `softprops/action-gh-release` overwrite the published release's assets — including the checksums manifest — so one compromised dispatch could silently replace shipped binaries with a green checkmark. Now fails closed on tag reuse (bump the version to redo), matching the new server-side tag ruleset.
- **Signed SLSA build provenance** (`actions/attest-build-provenance`, SHA-pinned v4.1.1) on every release asset. The manifest proves *integrity*; the attestation proves the asset came from *this repo's pipeline*. Verify: `gh attestation verify <file> --repo mshykov/local-review`. Cosign signature files stay on the roadmap.
- **Hermetic release builds**: `cache: false` on the release build's setup-go — a restored module cache skips go.sum re-verification. Non-shipping CI jobs keep their cache.
- **`persist-credentials: false`** on every checkout that never pushes (6 sites); the tag-pushing publish checkout and the PAT-based tap checkout keep theirs.
- **README**: Antigravity's `curl | bash` one-liner now pins `--proto '=https' --proto-redir '=https'` per docs/security.md's own rule.

## Test plan
- [x] `actionlint` clean on all six workflows
- [x] No Go code changes — `go vet` + tests unaffected (CI re-runs them anyway)
- [ ] Post-merge: next release exercises the attestation step + fail-on-reuse guard for real (noted for the v0.17.4 release)