### PR TITLE
fix: bound subprocess pipe-drain with WaitDelay; pin copilot's tools-disabled argv

### DIFF
--- a/internal/cli/invoker.go
+++ b/internal/cli/invoker.go
@@ -7,10 +7,21 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/mshykov/local-review/internal/agents"
 	"github.com/mshykov/local-review/internal/agents/provider"
 )
+
+// subprocessWaitDelay bounds how long cmd.Wait may block on pipe
+// drainage after the context is canceled. Without it, a vendor CLI
+// whose child process inherits our pipes (node CLIs spawn helpers)
+// can hold Run/Wait open indefinitely AFTER the per-agent timeout or
+// Ctrl+C SIGKILLs the direct child — the exact v0.10.5 probe wedge
+// (CLAUDE.md "Pre-flight readiness probe"), which was fixed in the
+// probe's select-race but remained open on every real invocation
+// path until this landed. 5s is generous for flushing final output.
+const subprocessWaitDelay = 5 * time.Second
 
 // Invoker is the review-agent contract. Moved to internal/agents in
 // v0.14 so the HTTP provider invoker (internal/agents/provider) could
@@ -189,6 +200,7 @@ func (c *CodexInvoker) runExec(ctx context.Context, prompt, errLabel string) (st
 		args = append(args, "-m", c.model)
 	}
 	cmd := exec.CommandContext(ctx, c.path, args...)
+	cmd.WaitDelay = subprocessWaitDelay
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["codex"], c.apiKey)
 	// Switched from CombinedOutput() to separate stdout/stderr
@@ -283,6 +295,7 @@ func (g *GeminiInvoker) run(ctx context.Context, prompt string) (string, TokenUs
 		args = append(args, "-m", g.model)
 	}
 	cmd := exec.CommandContext(ctx, g.path, args...)
+	cmd.WaitDelay = subprocessWaitDelay
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["gemini"], g.apiKey)
 	var stdout, stderr bytes.Buffer
@@ -354,6 +367,7 @@ func (c *ClaudeInvoker) run(ctx context.Context, prompt string) (string, TokenUs
 		args = append(args, "--model", c.model)
 	}
 	cmd := exec.CommandContext(ctx, c.path, args...)
+	cmd.WaitDelay = subprocessWaitDelay
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["claude"], c.apiKey)
 	var stdout, stderr bytes.Buffer
@@ -476,6 +490,7 @@ func (a *AntigravityInvoker) run(ctx context.Context, prompt string) (string, To
 	}
 	args := []string{"-p", prompt, "--dangerously-skip-permissions"}
 	cmd := exec.CommandContext(ctx, a.path, args...)
+	cmd.WaitDelay = subprocessWaitDelay
 	// No stdin: agy reads the prompt from argv. Leave cmd.Stdin nil.
 	cmd.Env = os.Environ() // OAuth session lives in agy's own config dir; no key to inject
 	var stdout, stderr bytes.Buffer
@@ -573,11 +588,9 @@ func (c *CopilotInvoker) run(ctx context.Context, prompt string) (string, TokenU
 	// --allow-all-tools and there's no permission prompt to hang on.
 	// --no-ask-user additionally stops the agent from blocking on a
 	// clarifying question in non-interactive mode.
-	args := []string{"-p", prompt, "--available-tools=", "--no-ask-user", "--no-color"}
-	if c.model != "" {
-		args = append(args, "--model", c.model)
-	}
+	args := copilotArgs(prompt, c.model)
 	cmd := exec.CommandContext(ctx, c.path, args...)
+	cmd.WaitDelay = subprocessWaitDelay
 	cmd.Env = withInjectedKey(CanonicalAPIKeyEnv["copilot"], c.apiKey)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -588,4 +601,20 @@ func (c *CopilotInvoker) run(ctx context.Context, prompt string) (string, TokenU
 	}
 	// Clean review on stdout; usage summary on stderr (best-effort).
 	return strings.TrimSpace(stdout.String()), parseCopilotStderrTokens(stderr.String()), nil
+}
+
+// copilotArgs builds the copilot CLI argv. Extracted so the SECURITY
+// contract is directly testable: `--available-tools=` (whitelist-to-
+// nothing — the diff in the prompt is attacker-controllable, and any
+// available tool is a prompt-injection target) and `--no-ask-user`
+// (never block on a question in non-interactive mode) must both always
+// be present. TestCopilotArgs_ToolsDisabledContract pins them; a
+// refactor that drops either flag re-arms the injection vector the
+// 2026-07 SecOps audit flagged as the one untested runtime control.
+func copilotArgs(prompt, model string) []string {
+	args := []string{"-p", prompt, "--available-tools=", "--no-ask-user", "--no-color"}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	return args
 }

--- a/internal/cli/invoker_test.go
+++ b/internal/cli/invoker_test.go
@@ -199,3 +199,35 @@ func TestBuildReviewPrompt(t *testing.T) {
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
+
+// TestCopilotArgs_ToolsDisabledContract pins the copilot security
+// contract from docs/security.md: the diff embedded in the prompt is
+// attacker-controllable, so copilot MUST run with its tool whitelist
+// emptied (`--available-tools=`) and without blocking on questions
+// (`--no-ask-user`). Of the three documented runtime security controls,
+// this was the only one without a regression test (2026-07 SecOps
+// audit) — a refactor dropping either flag would silently re-arm
+// prompt-injection-driven tool use.
+func TestCopilotArgs_ToolsDisabledContract(t *testing.T) {
+	for _, model := range []string{"", "gpt-5"} {
+		args := copilotArgs("review this diff", model)
+		var hasToolsDisabled, hasNoAskUser bool
+		for _, a := range args {
+			if a == "--available-tools=" {
+				hasToolsDisabled = true
+			}
+			if a == "--no-ask-user" {
+				hasNoAskUser = true
+			}
+			if a == "--allow-all-tools" {
+				t.Fatalf("copilot argv must never contain --allow-all-tools, got %v", args)
+			}
+		}
+		if !hasToolsDisabled {
+			t.Errorf("copilot argv (model=%q) missing --available-tools= (empty whitelist): %v", model, args)
+		}
+		if !hasNoAskUser {
+			t.Errorf("copilot argv (model=%q) missing --no-ask-user: %v", model, args)
+		}
+	}
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -27,6 +27,7 @@ func runVersionCmd(path string, args ...string) string {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.WaitDelay = subprocessWaitDelay
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "unknown"

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -48,6 +48,13 @@ type Hunk struct {
 // signal-handler cancellation) still interrupts sooner on Ctrl+C.
 const gitDiffTimeout = 2 * time.Minute
 
+// gitWaitDelay bounds how long cmd.Wait may block on pipe drainage
+// after the context is canceled — without it, a git hook or filter
+// child that inherits our pipes can hold Wait open past the timeout
+// (same pipe-drain wedge the LLM invokers had; see internal/cli's
+// subprocessWaitDelay).
+const gitWaitDelay = 5 * time.Second
+
 // maxDiffBytes caps the diff we buffer and parse. Past this, the review is
 // almost certainly noise (vendored-blob churn, a generated-file rewrite) and
 // parsing risks a multi-hundred-MB memory peak. var (not const) so tests can
@@ -73,6 +80,7 @@ func Extract(ctx context.Context, mode Mode, ref string) ([]Diff, error) {
 
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.WaitDelay = gitWaitDelay
 	cmd.Stderr = &stderr
 	pipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -336,6 +344,7 @@ func CurrentCommit() string {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", gitRevParse, "--short", "HEAD")
+	cmd.WaitDelay = gitWaitDelay
 	out, err := cmd.Output()
 	if err != nil {
 		return "HEAD"
@@ -350,6 +359,7 @@ func CurrentBranch() string {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", gitRevParse, "--abbrev-ref", "HEAD")
+	cmd.WaitDelay = gitWaitDelay
 	out, err := cmd.Output()
 	if err != nil {
 		return "unknown"
@@ -416,6 +426,7 @@ func ResolveRef(ref string) string {
 	// still parses `-`-prefixed args as options): ValidateRef above
 	// is what rejects those before git ever sees them.
 	cmd := exec.CommandContext(ctx, "git", gitRevParse, "--short", "--verify", ref+"^{commit}")
+	cmd.WaitDelay = gitWaitDelay
 	output, err := cmd.Output()
 	if err != nil {
 		return ""


### PR DESCRIPTION
## Summary
Two audit minors with outsized blast radius:

**WaitDelay sweep.** `cmd.WaitDelay = 5s` on every `exec.CommandContext` site (5 LLM invokers, the version probe, 4 git helpers). The v0.10.5 pipe-drain wedge — a child that inherits our pipes holds `cmd.Wait` open indefinitely after SIGKILL — was fixed in the probe's select-race but remained open on every *real* invocation path: a hung vendor CLI could block the fan-out barrier past the per-agent timeout and past Ctrl+C. `WaitDelay` (Go 1.20+) is the stdlib fix: after ctx cancellation, Wait force-closes the pipes after 5s instead of draining forever.

**Copilot tools-disabled regression test.** Argv construction extracted into `copilotArgs()` and `TestCopilotArgs_ToolsDisabledContract` pins `--available-tools=` + `--no-ask-user` present / `--allow-all-tools` absent. This was the only one of the three documented runtime security controls without a test (config-sanitizer and pathsafe both have them) — the same silent-drift defect class as the v0.17.1 pathsafe incident.

## Test plan
- [x] New copilot argv contract test passes (and fails if either flag is dropped)
- [x] `gofmt -s` / `go vet` / `golangci-lint` (0 issues) / `go test -race ./...` / e2e — all clean

Pre-push dogfood self-review skipped (nested-agent session — documented fallback); full suites + CI + CodeRabbit as the net.