### PR TITLE
refactor: doctor delegates provider-spec construction to agentselect

### DIFF
--- a/cmd/local-review/doctor.go
+++ b/cmd/local-review/doctor.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/mshykov/local-review/internal/agentselect"
 	"github.com/mshykov/local-review/internal/cli"
 	"github.com/mshykov/local-review/internal/config"
 	"github.com/mshykov/local-review/internal/prompts"
@@ -151,35 +151,19 @@ func doctorLLMOverrides(cfg config.Config, cfgErr error) (overrides, customEnvVa
 }
 
 // doctorProviderSpecs builds the provider agents (entries with base_url in
-// cfg.LLMs) — detected via HTTP /v1/models probe and rendered alongside CLI
-// agents in the same readiness summary. Empty when no provider entries are
-// configured (or cfg failed to load). Specs sorted by name so doctor's
-// provider rows appear in a stable order across runs (Go map iteration is
-// randomised; without the sort the output flickered between invocations).
+// cfg.LLMs) for doctor's readiness summary. Nil when cfg failed to load.
+// Delegates to agentselect.ProviderSpecsFromConfig — the SAME constructor
+// the runner uses — so doctor and runtime cannot disagree about what
+// counts as a provider. Doctor previously had its own hand-rolled copy,
+// and it had already drifted (missing APIKeyEnv, no BaseURL TrimSpace):
+// a whitespace-padded base_url showed a provider row in doctor that the
+// runner skipped. Same duplicated-primitive defect class as the v0.17.1
+// pathsafe incident — don't re-inline this.
 func doctorProviderSpecs(cfg config.Config, cfgErr error) []cli.ProviderSpec {
 	if cfgErr != nil {
 		return nil
 	}
-	names := make([]string, 0, len(cfg.LLMs))
-	for name, c := range cfg.LLMs {
-		if c.BaseURL == "" {
-			continue
-		}
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	var providerSpecs []cli.ProviderSpec
-	for _, name := range names {
-		c := cfg.LLMs[name]
-		providerSpecs = append(providerSpecs, cli.ProviderSpec{
-			Name:       name,
-			BaseURL:    c.BaseURL,
-			Model:      c.Model,
-			APIKey:     c.APIKey,
-			TimeoutSec: c.TimeoutSec,
-		})
-	}
-	return providerSpecs
+	return agentselect.ProviderSpecsFromConfig(cfg)
 }
 
 // printLLMRows prints one row per detected LLM and returns the ready /

--- a/cmd/local-review/doctor_test.go
+++ b/cmd/local-review/doctor_test.go
@@ -738,11 +738,17 @@ func TestDoctorProviderSpecs_CfgErrReturnsNil(t *testing.T) {
 func TestDoctorProviderSpecs_OnlyBaseURLEntriesSortedByName(t *testing.T) {
 	cfg := config.Config{LLMs: map[string]config.LLMConfig{
 		"zeta":  {BaseURL: "http://z", Model: "m-z"},
-		"alpha": {BaseURL: "http://a", Model: "m-a", APIKey: "k", TimeoutSec: 30},
+		"alpha": {BaseURL: "http://a", Model: "m-a", APIKey: "k", APIKeyEnv: "ALPHA_KEY", TimeoutSec: 30},
 		"claude": {
 			// No BaseURL — a plain CLI agent, must be excluded.
 			CLIPath: "/usr/local/bin/claude",
 		},
+		// Whitespace-only base_url: the runner's constructor
+		// (agentselect.ProviderSpecsFromConfig) skips it after
+		// TrimSpace; doctor's old hand-rolled copy treated it as a
+		// real provider — the exact doctor-vs-runtime drift the
+		// delegation closed. Must be excluded here too.
+		"padded": {BaseURL: "   "},
 	}}
 	specs := doctorProviderSpecs(cfg, nil)
 	if len(specs) != 2 {
@@ -753,6 +759,12 @@ func TestDoctorProviderSpecs_OnlyBaseURLEntriesSortedByName(t *testing.T) {
 	}
 	if specs[0].BaseURL != "http://a" || specs[0].Model != "m-a" || specs[0].APIKey != "k" || specs[0].TimeoutSec != 30 {
 		t.Errorf("alpha spec fields not carried through: %+v", specs[0])
+	}
+	// APIKeyEnv was the drifted field: doctor's old copy dropped it, so a
+	// provider authenticated via api_key_env showed a different auth
+	// state in doctor than at runtime.
+	if specs[0].APIKeyEnv != "ALPHA_KEY" {
+		t.Errorf("alpha APIKeyEnv = %q, want ALPHA_KEY (the drift the dedup fixed)", specs[0].APIKeyEnv)
 	}
 }
 


### PR DESCRIPTION
## Summary
Audit minor: provider-spec construction was duplicated between `doctorProviderSpecs` (doctor.go) and `agentselect.ProviderSpecsFromConfig` (the runner's constructor) — and had already drifted: doctor's copy dropped `APIKeyEnv` and skipped the `TrimSpace` on BaseURL, so doctor and runtime could disagree about a provider's existence and auth state. Same duplicated-primitive defect class as the v0.17.1 pathsafe incident.

Doctor now delegates to the runner's constructor (keeping only its `cfgErr` guard). Existing tests pass unchanged; new assertions pin the two previously-drifted behaviors (APIKeyEnv carried through; whitespace-only base_url excluded).

## Test plan
- [x] `go test -race ./...` all pass; `golangci-lint` 0 issues
- [x] New assertions fail against the old hand-rolled copy

Pre-push dogfood self-review skipped (nested-agent session — documented fallback).