### PR TITLE
feat: `config` prints which .local-review.yml files this folder resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`local-review config` now prints a `# Config sources:` block** — the cascade layers this invocation actually resolved: the home config path, the repo config found by walking up from the current directory (or "none found"), whether each file exists, and whether the repo layer merged as trusted or was sanitized. Answers "which `.local-review.yml` is this folder using?" — previously the resolved values were printed with no way to tell which file produced them (or whether a repo-level file was being read at all). Internally, `config.Load` now iterates the same `DescribeSources` description the command prints, so the diagnostic cannot drift from real load behavior.
+
 ### Fixed
 
 - **`local-review commit <rev>` was broken for every explicit ref — including `HEAD`.** `ResolveRef` ran `git rev-parse --short -- <ref>`; after `--`, rev-parse treats the argument as a *pathspec*, so resolution failed with "Needed a single revision" for all inputs and the command errored with "failed to resolve ref". Only the no-argument form (`local-review commit`) worked. Introduced by the v0.6.0 flag-injection hardening (the `--` defense broke the feature it defended) and unnoticed for ~11 releases because nothing tested the function against real git — the tool's own error hints even recommended the broken command. Now uses `--verify <ref>^{commit}` (correct semantics: annotated tags peel to their commit, tree/blob refs fail cleanly; flag injection remains guarded by `ValidateRef`, which rejects `-`-prefixed refs before git sees them), with a real-git regression test covering HEAD / branch / lightweight tag / annotated tag / hash / unknown-ref / flag-shaped-ref shapes.

--- a/cmd/local-review/config.go
+++ b/cmd/local-review/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -73,7 +74,13 @@ which settings are being used.`,
 			// a YAML round-trip alone wouldn't reveal that, since
 			// PromptsConfig only carries inputs. The block below
 			// shows what each language *actually* loaded.
-			return printPromptResolution(cmd.OutOrStdout(), cfg)
+			if err := printPromptResolution(cmd.OutOrStdout(), cfg); err != nil {
+				return err
+			}
+			// And WHICH config files produced the values above — the
+			// resolved dump alone can't answer "is my repo-level
+			// .local-review.yml even being read, and was it trusted?"
+			return printConfigSources(cmd.OutOrStdout())
 		},
 	}
 }
@@ -119,4 +126,42 @@ func printPromptResolution(w io.Writer, cfg config.Config) error {
 		}
 	}
 	return nil
+}
+
+// printConfigSources writes a comment block naming the file-backed
+// cascade layers this invocation resolves — the same description
+// config.Load merges from (config.DescribeSources), so this output
+// cannot drift from real load behavior. Comment lines keep the
+// overall output `yq`-parseable, matching printPromptResolution.
+func printConfigSources(w io.Writer) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		_, werr := fmt.Fprintf(w, "\n# (could not resolve config sources: %v)\n", err)
+		return werr
+	}
+	if _, err := fmt.Fprintln(w, "\n# Config sources (cascade order; later layers override earlier):\n#   1. built-in defaults"); err != nil {
+		return err
+	}
+	for i, src := range config.DescribeSources(config.FindRepoConfig(cwd)) {
+		var state string
+		switch {
+		case src.Path == "" && src.Role == config.SourceRoleRepo:
+			state = fmt.Sprintf("(none found walking up from %s)", cwd)
+		case src.Path == "":
+			state = "(could not resolve home directory)"
+		case src.SameAsHome:
+			state = fmt.Sprintf("%s — same file as the home config, merged once as trusted", src.Path)
+		case !src.Found:
+			state = fmt.Sprintf("%s (not found)", src.Path)
+		case src.Trusted:
+			state = fmt.Sprintf("%s loaded (trusted)", src.Path)
+		default:
+			state = fmt.Sprintf("%s loaded (untrusted: security-sensitive fields stripped; opt in with LOCAL_REVIEW_TRUST_REPO_CONFIG=1)", src.Path)
+		}
+		if _, err := fmt.Fprintf(w, "#   %d. %s  %s\n", i+2, src.Role, state); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintln(w, "#   4. CLI flags")
+	return err
 }

--- a/cmd/local-review/config.go
+++ b/cmd/local-review/config.go
@@ -37,23 +37,7 @@ which settings are being used.`,
 			// command silently dropped flag overrides on the floor.
 			applyFlagsToConfig(&cfg, sf)
 
-			// Mask API keys + strip credentials embedded in base_url
-			// values before printing (config dumps should be
-			// shareable). Same sanitizer (SanitizeBaseURLForDisplay)
-			// covers basic-auth userinfo (`https://user:pass@host`)
-			// and query-string keys (`?api_key=…`). The v0
-			// `cfg.Provider` branch was removed in v0.15 along with
-			// the top-level `provider:` block; all endpoints now
-			// flow through `cfg.LLMs[*]`.
-			for name, llmCfg := range cfg.LLMs {
-				if llmCfg.APIKey != "" {
-					llmCfg.APIKey = "***"
-				}
-				if llmCfg.BaseURL != "" {
-					llmCfg.BaseURL = config.SanitizeBaseURLForDisplay(llmCfg.BaseURL)
-				}
-				cfg.LLMs[name] = llmCfg
-			}
+			maskSensitiveForDisplay(&cfg)
 
 			enc := yaml.NewEncoder(cmd.OutOrStdout())
 			enc.SetIndent(2)
@@ -164,4 +148,22 @@ func printConfigSources(w io.Writer) error {
 	}
 	_, err = fmt.Fprintln(w, "#   4. CLI flags")
 	return err
+}
+
+// maskSensitiveForDisplay masks API keys and strips credentials embedded
+// in base_url values before printing — config dumps should be shareable.
+// SanitizeBaseURLForDisplay covers basic-auth userinfo
+// (`https://user:pass@host`) and query-string keys (`?api_key=…`). The v0
+// `cfg.Provider` branch was removed in v0.15 along with the top-level
+// `provider:` block; all endpoints now flow through `cfg.LLMs[*]`.
+func maskSensitiveForDisplay(cfg *config.Config) {
+	for name, llmCfg := range cfg.LLMs {
+		if llmCfg.APIKey != "" {
+			llmCfg.APIKey = "***"
+		}
+		if llmCfg.BaseURL != "" {
+			llmCfg.BaseURL = config.SanitizeBaseURLForDisplay(llmCfg.BaseURL)
+		}
+		cfg.LLMs[name] = llmCfg
+	}
 }

--- a/cmd/local-review/config_test.go
+++ b/cmd/local-review/config_test.go
@@ -133,3 +133,27 @@ llms:
 		t.Errorf("plain llms.ollama.base_url must roundtrip; got:\n%s", out)
 	}
 }
+
+// TestConfigCommand_PrintsConfigSources pins the "# Config sources:"
+// diagnostic block: users need `config` to answer "which
+// .local-review.yml is this folder actually using, and was it
+// trusted?" — the resolved YAML alone can't (2026-07 dogfood).
+func TestConfigCommand_PrintsConfigSources(t *testing.T) {
+	out := runConfigCmdIn(t, `
+review:
+  max_findings: 7
+`)
+	if !strings.Contains(out, "# Config sources") {
+		t.Fatalf("missing config-sources block:\n%s", out)
+	}
+	for _, want := range []string{"built-in defaults", "home", "repo", "loaded (trusted)", "CLI flags"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("config-sources block missing %q:\n%s", want, out)
+		}
+	}
+	// The harness's fake $HOME has no config file — that layer must
+	// say so rather than claiming it loaded.
+	if !strings.Contains(out, "(not found)") {
+		t.Errorf("expected home layer to report (not found) under the fake $HOME:\n%s", out)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,24 +246,14 @@ func Load(repoConfigPath string) (Config, error) {
 		}
 	}
 
-	// Repo config (.local-review.yml at/above the project root) — UNtrusted
-	// by default. It is attacker-controllable whenever you review code you
-	// didn't write (a CI runner checking out a hostile commit, a freshly
-	// cloned repo). The security-sensitive LLM fields it could carry —
-	// cli_path (→ arbitrary binary exec), base_url (→ a new outbound
-	// endpoint your diff/source is POSTed to), and api_key (a secret in a
-	// repo) — are therefore stripped from this layer with a warning, the
-	// same defence resolveRelativePaths already gives prompts.pack_dir.
-	// A team that genuinely wants to check in a trusted config (e.g. a LAN
-	// Ollama base_url) opts back in with LOCAL_REVIEW_TRUST_REPO_CONFIG=1.
-	//
-	// BUT: when the project lives under $HOME and has no project-local
-	// config, FindRepoConfig walks up and returns the SAME file as the home
-	// config loaded above. Re-processing the user's own ~/.local-review.yml
-	// as the untrusted repo layer would spuriously strip its base_url /
-	// api_key_env and print an alarming "untrusted config" warning about the
-	// user's own trusted file (a v0.16.0 regression). A file that IS the
-	// home config is trusted — skip the redundant untrusted pass.
+	// Which layers merge, and under what trust, is decided by
+	// DescribeSources above: home is trusted; the repo layer is
+	// UNTRUSTED by default (attacker-controllable when reviewing code
+	// you didn't write — sanitizeUntrustedLayer strips its
+	// security-sensitive fields, LOCAL_REVIEW_TRUST_REPO_CONFIG=1 opts
+	// back in), and a repo path that IS the home config file merges
+	// once as trusted (the v0.16.0 double-processing regression). See
+	// DescribeSources + sanitizeUntrustedLayer for the full rationale.
 
 	// Warn about deprecated api_key in YAML (security risk)
 	warnDeprecatedAPIKeys(&cfg)
@@ -305,8 +295,6 @@ func detectRemovedProviderBlock(b []byte) (bool, error) {
 	return present, nil
 }
 
-// FindRepoConfig walks up from start looking for a .local-review.yml. Returns
-// "" when none is found (not an error).
 // SourceRole labels a config cascade layer in Source.
 type SourceRole string
 
@@ -361,15 +349,20 @@ func DescribeSources(repoConfigPath string) []Source {
 }
 
 // fileExists reports whether path names an existing file. Empty path
-// is "not found" (a layer that couldn't be resolved).
+// is "not found" (a layer that couldn't be resolved). Only ErrNotExist
+// counts as absent: a permission-denied or otherwise unstat-able file
+// EXISTS — reporting it "(not found)" in the sources diagnostic would
+// mislead, and mergeFrom surfaces the actual read error loudly.
 func fileExists(path string) bool {
 	if path == "" {
 		return false
 	}
 	_, err := os.Stat(path)
-	return err == nil
+	return err == nil || !errors.Is(err, os.ErrNotExist)
 }
 
+// FindRepoConfig walks up from start looking for a .local-review.yml. Returns
+// "" when none is found (not an error).
 func FindRepoConfig(start string) string {
 	dir := start
 	for {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,13 +229,20 @@ func Defaults() Config {
 func Load(repoConfigPath string) (Config, error) {
 	cfg := Defaults()
 
-	// User config (~/.local-review.yml) — trusted: it lives in the
-	// invoking user's home, not in a repo someone else can write to.
-	var homeConfigPath string
-	if home, err := os.UserHomeDir(); err == nil {
-		homeConfigPath = filepath.Join(home, ".local-review.yml")
-		if err := mergeFrom(&cfg, homeConfigPath, true); err != nil {
-			return cfg, fmt.Errorf("load user config: %w", err)
+	// Drive the merge off the SAME source description the `config`
+	// command prints (DescribeSources) so the diagnostic output can
+	// never drift from what Load actually does — the duplicated-logic
+	// drift class behind the v0.17.1 pathsafe incident and the
+	// doctor-vs-runner provider-spec divergence.
+	for _, src := range DescribeSources(repoConfigPath) {
+		if !src.Merges {
+			continue
+		}
+		if err := mergeFrom(&cfg, src.Path, src.Trusted); err != nil {
+			if src.Role == SourceRoleHome {
+				return cfg, fmt.Errorf("load user config: %w", err)
+			}
+			return cfg, fmt.Errorf("load repo config (%s): %w", src.Path, err)
 		}
 	}
 
@@ -257,12 +264,6 @@ func Load(repoConfigPath string) (Config, error) {
 	// api_key_env and print an alarming "untrusted config" warning about the
 	// user's own trusted file (a v0.16.0 regression). A file that IS the
 	// home config is trusted — skip the redundant untrusted pass.
-	if repoConfigPath != "" && !sameFile(repoConfigPath, homeConfigPath) {
-		trusted := os.Getenv(envTrustRepoConfig) == "1"
-		if err := mergeFrom(&cfg, repoConfigPath, trusted); err != nil {
-			return cfg, fmt.Errorf("load repo config (%s): %w", repoConfigPath, err)
-		}
-	}
 
 	// Warn about deprecated api_key in YAML (security risk)
 	warnDeprecatedAPIKeys(&cfg)
@@ -306,6 +307,69 @@ func detectRemovedProviderBlock(b []byte) (bool, error) {
 
 // FindRepoConfig walks up from start looking for a .local-review.yml. Returns
 // "" when none is found (not an error).
+// SourceRole labels a config cascade layer in Source.
+type SourceRole string
+
+const (
+	SourceRoleHome SourceRole = "home"
+	SourceRoleRepo SourceRole = "repo"
+)
+
+// Source describes one file-backed layer of the config cascade —
+// which path a layer resolves to, whether the file exists, whether
+// Load will merge it, and under what trust. Load itself iterates
+// this description, and the `config` command prints it, so the two
+// cannot disagree.
+type Source struct {
+	Role    SourceRole
+	Path    string // "" when the layer can't be resolved (no home dir / no repo file found)
+	Found   bool   // the file exists on disk
+	Merges  bool   // Load will call mergeFrom on it (mergeFrom no-ops when !Found)
+	Trusted bool   // merged without sanitizeUntrustedLayer
+	// SameAsHome is set on the repo layer when the walk-up found the
+	// user's own home config (project lives under $HOME with no
+	// project-local file) — Load skips the redundant untrusted pass.
+	SameAsHome bool
+}
+
+// DescribeSources resolves the file-backed cascade layers for a given
+// repo-config path (as found by FindRepoConfig; may be empty). The
+// home layer is always trusted. The repo layer is untrusted unless
+// LOCAL_REVIEW_TRUST_REPO_CONFIG=1, and is skipped entirely when it
+// IS the home config file.
+func DescribeSources(repoConfigPath string) []Source {
+	var homeConfigPath string
+	if home, err := os.UserHomeDir(); err == nil {
+		homeConfigPath = filepath.Join(home, ".local-review.yml")
+	}
+	homeSrc := Source{
+		Role:    SourceRoleHome,
+		Path:    homeConfigPath,
+		Found:   fileExists(homeConfigPath),
+		Merges:  homeConfigPath != "",
+		Trusted: true,
+	}
+	repoSrc := Source{
+		Role:       SourceRoleRepo,
+		Path:       repoConfigPath,
+		Found:      fileExists(repoConfigPath),
+		SameAsHome: sameFile(repoConfigPath, homeConfigPath),
+		Trusted:    os.Getenv(envTrustRepoConfig) == "1",
+	}
+	repoSrc.Merges = repoConfigPath != "" && !repoSrc.SameAsHome
+	return []Source{homeSrc, repoSrc}
+}
+
+// fileExists reports whether path names an existing file. Empty path
+// is "not found" (a layer that couldn't be resolved).
+func fileExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 func FindRepoConfig(start string) string {
 	dir := start
 	for {

--- a/internal/config/untrusted_layer_test.go
+++ b/internal/config/untrusted_layer_test.go
@@ -291,3 +291,53 @@ llms:
 		}
 	}
 }
+
+// TestDescribeSources_MatchesLoadSemantics pins the contract that makes
+// the `config` command's "# Config sources:" block trustworthy: the
+// description IS what Load iterates, so every branch here corresponds
+// to a real merge decision — repo untrusted by default, trusted via
+// the env opt-in, and skipped entirely when the walk-up found the
+// user's own home config.
+func TestDescribeSources_MatchesLoadSemantics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	homeCfg := filepath.Join(home, ".local-review.yml")
+	if err := os.WriteFile(homeCfg, []byte("review:\n  max_findings: 5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repoDir := t.TempDir()
+	repoCfg := filepath.Join(repoDir, ".local-review.yml")
+	if err := os.WriteFile(repoCfg, []byte("review:\n  max_findings: 7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("LOCAL_REVIEW_TRUST_REPO_CONFIG", "")
+	srcs := DescribeSources(repoCfg)
+	if len(srcs) != 2 {
+		t.Fatalf("expected 2 sources, got %d", len(srcs))
+	}
+	h, r := srcs[0], srcs[1]
+	if h.Role != SourceRoleHome || !h.Found || !h.Merges || !h.Trusted {
+		t.Errorf("home source = %+v, want found+merges+trusted", h)
+	}
+	if r.Role != SourceRoleRepo || !r.Found || !r.Merges || r.Trusted || r.SameAsHome {
+		t.Errorf("repo source = %+v, want found+merges+untrusted", r)
+	}
+
+	t.Setenv("LOCAL_REVIEW_TRUST_REPO_CONFIG", "1")
+	if r := DescribeSources(repoCfg)[1]; !r.Trusted {
+		t.Errorf("repo source with opt-in = %+v, want trusted", r)
+	}
+
+	// Walk-up found the home config itself: merged once (as home), the
+	// repo pass is skipped — the v0.16.0 double-processing regression.
+	if r := DescribeSources(homeCfg)[1]; !r.SameAsHome || r.Merges {
+		t.Errorf("repo==home source = %+v, want SameAsHome and !Merges", r)
+	}
+
+	// Missing repo layer: nothing to merge.
+	if r := DescribeSources("")[1]; r.Merges || r.Found {
+		t.Errorf("empty repo source = %+v, want !Merges/!Found", r)
+	}
+}


### PR DESCRIPTION
## Summary
Direct dogfood request: comparing `doctor` output against `~/.local-review.yml` gives no way to tell **which config files the current folder actually loads** — `local-review config` prints merged values with no provenance.

New `# Config sources:` block at the end of `local-review config` (same yq-safe comment style as the existing prompt-sources block):

```
# Config sources (cascade order; later layers override earlier):
#   1. built-in defaults
#   2. home  /Users/you/.local-review.yml loaded (trusted)
#   3. repo  (none found walking up from /path/to/cwd)
#   4. CLI flags
```

States covered: loaded (trusted) / loaded (untrusted: sensitive fields stripped, with the opt-in hint) / (not found) / same-file-as-home merged once / no home dir.

**No-drift mechanics:** `config.Load` now iterates a new `config.DescribeSources()` and the command prints that same description — one source of truth for "what merges, under what trust," so the diagnostic can't diverge from real load behavior (the defect class behind the v0.17.1 pathsafe incident and the doctor provider-spec drift fixed in #179).

## Test plan
- [x] `TestDescribeSources_MatchesLoadSemantics` — untrusted default, trust opt-in, same-as-home skip, missing layers
- [x] `TestConfigCommand_PrintsConfigSources` — end-to-end through the cobra command
- [x] All existing config tests pass unchanged against the refactored `Load`
- [x] Live smoke test: correct output from a repo without its own config
- [x] `gofmt -s` / `go vet` / `golangci-lint` (0) / `go test -race ./...` / e2e — clean

Pre-push dogfood self-review skipped (nested-agent session — documented fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Config sources** diagnostic to `local-review config`.
  - Displays configuration layers, including built-in defaults, home, repository, and CLI flags.
  - Shows whether files were found, loaded, trusted, or skipped, including repository trust status.
  - Reports resolved prompt sources for each language pack.

- **Documentation**
  - Updated the changelog with details about the new configuration diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->