### PR TITLE
ci: setup-go check-latest — stale runner toolchain turned govulncheck red

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,6 +49,11 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
+          # check-latest makes setup-go resolve the newest 1.26.x patch
+          # instead of the runner's cached toolchain — a stale cache left
+          # CI on go1.26.4 after GO-2026-5856 (crypto/tls) was fixed in
+          # go1.26.5, turning govulncheck red repo-wide.
+          check-latest: true
           cache: true
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
+          # check-latest makes setup-go resolve the newest 1.26.x patch
+          # instead of the runner's cached toolchain — a stale cache left
+          # CI on go1.26.4 after GO-2026-5856 (crypto/tls) was fixed in
+          # go1.26.5, turning govulncheck red repo-wide.
+          check-latest: true
           cache: true
       - name: Tidy + verify
         run: go mod tidy && git diff --exit-code go.mod go.sum

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
+          # check-latest makes setup-go resolve the newest 1.26.x patch
+          # instead of the runner's cached toolchain — a stale cache left
+          # CI on go1.26.4 after GO-2026-5856 (crypto/tls) was fixed in
+          # go1.26.5, turning govulncheck red repo-wide.
+          check-latest: true
           cache: true
       - name: Scan dependencies for known vulnerabilities
         # govulncheck is a `tool` directive in go.mod (pinned version,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,11 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
+          # check-latest makes setup-go resolve the newest 1.26.x patch
+          # instead of the runner's cached toolchain — a stale cache left
+          # CI on go1.26.4 after GO-2026-5856 (crypto/tls) was fixed in
+          # go1.26.5, turning govulncheck red repo-wide.
+          check-latest: true
           # No restored cache for SHIPPED binaries: a cache hit skips
           # go.sum re-verification, so a poisoned cache entry would flow
           # into release artifacts. Cold build costs seconds here; CI's

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -28,6 +28,9 @@ jobs:
           # 1.26 toolchain, which already clears gitleaks v8.30.1's
           # Go >= 1.24.11 floor.
           go-version: '1.26'
+          # check-latest: newest 1.26.x patch, not the runner's cached
+          # toolchain (see ci.yml for the GO-2026-5856 rationale).
+          check-latest: true
           cache: true
       - name: Scan git history for secrets
         # gitleaks is a `tool` directive in go.mod (pinned version,

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -69,6 +69,11 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
+          # check-latest makes setup-go resolve the newest 1.26.x patch
+          # instead of the runner's cached toolchain — a stale cache left
+          # CI on go1.26.4 after GO-2026-5856 (crypto/tls) was fixed in
+          # go1.26.5, turning govulncheck red repo-wide.
+          check-latest: true
           cache: true
 
       - name: Run tests with coverage


### PR DESCRIPTION
## Summary
GO-2026-5856 (`crypto/tls` ECH privacy leak) published today; fixed in go1.26.5. Our workflows pin `go-version: '1.26'`, which setup-go resolves to the **runner's cached** patch (1.26.4) — so `govulncheck` went red repo-wide (first seen on #181) even though the fixed toolchain was already released.

`check-latest: true` on all six setup-go steps makes the resolver query upstream for the newest 1.26.x instead of trusting the runner cache — every future stdlib security patch gets picked up on the next run with no workflow edit.

## Test plan
- [x] `actionlint` clean
- [ ] The `govulncheck` check on THIS PR is the proof: it must come back green with go1.26.5