### PR TITLE
feat: make provider failures and malformed reports visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Silent-truncation detection for provider agents.** llama.cpp-backed servers (Ollama) drop prompt overflow past the context window and still return HTTP 200 — a 15,147-token diff was processed as 2,050 tokens and reviewed as "No issues found", a clean-looking APPROVE on 14% of the change. The provider invoker now compares the endpoint's own reported `prompt_tokens` against the prompt it sent and warns loudly when the gap is an order of magnitude, naming the fixes (raise `OLLAMA_CONTEXT_LENGTH`, review a smaller change, or use a cloud agent). Requires a 2× gap before firing, so ordinary tokenizer variance stays silent.
+- **Merged-report validation.** The merge step asks an LLM to reformat findings into a fixed template with a stated total, one severity per finding, and no duplicates. A weak merge model can silently violate that: a real run claimed "Total findings: 5" while rendering two bullets — the *same* finding, under both "Major Issues" and "Info / Notes". `multi.ValidateReport` now checks the claimed count against the rendered bullets and flags any finding placed in multiple severity sections, warning after the report (never rewriting it) and pointing at `--merge-with claude`. Mechanical checks against our own template, so a bad merge from any model is caught.
+- **Large-prompt-to-local-endpoint notice.** A big diff sent to a local model now warns *before* the request goes out — a 17.7k-token diff against a local 7B took 20m42s, and an earlier attempt burned the full 600s timeout producing nothing.
+
+### Fixed
+
+- **Provider timeouts now explain themselves.** A deadline against a provider agent surfaced as a bare `context deadline exceeded`, while CLI agents got actionable guidance from `ClassifyExit`. Provider failures now carry the same class of hint (raise `timeout_seconds`, review a smaller change, and — for local endpoints specifically — that a cloud agent is the quicker path), plus a clean `cancelled` on Ctrl+C.
+
 ## [0.17.4] - 2026-07-10
 
 **Patch: the external-audit fixes.** A broken user-facing command, a widened security boundary, hung-subprocess protection, and better diagnostics — everything from the 2026-07 architecture + SecOps audit plus the dogfood findings that followed. This is also the first release shipped by the hardened pipeline: append-only tags, signed SLSA build provenance on every asset (`gh attestation verify <file> --repo mshykov/local-review`), and hermetic release builds.

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1017,6 +1018,15 @@ func mergeAndPrint(ctx context.Context, cfg config.Config, sf *sharedFlags, acti
 	fmt.Println(merged)
 	fmt.Println("─── End ───")
 
+	// Surface template violations AFTER the report: the findings may
+	// still be useful, but a self-contradicting report (count that
+	// doesn't match the bullets, one finding under two severities) means
+	// the merge model didn't follow the contract, and the reader needs
+	// to know before trusting the recommendation. Printed last so it's
+	// the final thing on screen rather than scrolled away above the
+	// report body.
+	warnReportProblems(os.Stderr, multi.ValidateReport(merged), mergeLLM.Name)
+
 	return savedPath, merged, mergeTokens
 }
 
@@ -1197,4 +1207,20 @@ func selectPromptPack(cfg config.Config, diffs []git.Diff) (string, error) {
 		return "", fmt.Errorf("load prompt pack %q: %w", packID, err)
 	}
 	return pack.Content, nil
+}
+
+// warnReportProblems renders ValidateReport's findings, naming the merge
+// agent so the user knows which model to swap when the report shape is
+// unreliable (a small local model formatting a report is the usual
+// cause — 2026-07 dogfood).
+func warnReportProblems(w io.Writer, problems []string, mergeAgent string) {
+	if len(problems) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\nWARNING: the report assembled by %q does not follow the report template:\n", mergeAgent)
+	for _, p := range problems {
+		fmt.Fprintf(w, "  - %s\n", p)
+	}
+	fmt.Fprintf(w, "  Findings above may still be valid, but the summary is not trustworthy. A stronger merge agent\n")
+	fmt.Fprintf(w, "  (`--merge-with claude`) usually fixes this; small local models often can't hold the template.\n")
 }

--- a/cmd/local-review/runner.go
+++ b/cmd/local-review/runner.go
@@ -1217,10 +1217,13 @@ func warnReportProblems(w io.Writer, problems []string, mergeAgent string) {
 	if len(problems) == 0 {
 		return
 	}
-	fmt.Fprintf(w, "\nWARNING: the report assembled by %q does not follow the report template:\n", mergeAgent)
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nWARNING: the report assembled by %q does not follow the report template:\n", mergeAgent)
 	for _, p := range problems {
-		fmt.Fprintf(w, "  - %s\n", p)
+		fmt.Fprintf(&b, "  - %s\n", p)
 	}
-	fmt.Fprintf(w, "  Findings above may still be valid, but the summary is not trustworthy. A stronger merge agent\n")
-	fmt.Fprintf(w, "  (`--merge-with claude`) usually fixes this; small local models often can't hold the template.\n")
+	b.WriteString("  Findings above may still be valid, but the summary is not trustworthy. A stronger merge agent\n")
+	b.WriteString("  (`--merge-with claude`) usually fixes this; small local models often can't hold the template.\n")
+	// Composed then written once, matching the provider diagnostics.
+	fmt.Fprint(w, b.String())
 }

--- a/internal/agents/provider/provider_invoker.go
+++ b/internal/agents/provider/provider_invoker.go
@@ -27,8 +27,11 @@ import (
 	"fmt"
 	"strings"
 
+	"errors"
 	"github.com/mshykov/local-review/internal/agents"
 	"github.com/mshykov/local-review/internal/llm"
+	"io"
+	"os"
 )
 
 // Invoker is the HTTP-provider implementation of agents.Invoker.
@@ -110,10 +113,14 @@ func (p *Invoker) RunPrompt(ctx context.Context, prompt string) (string, agents.
 // roster line (`qwen ✗ <reason>`) attributes correctly when multiple
 // providers run in parallel.
 func (p *Invoker) complete(ctx context.Context, msgs []llm.Message) (string, agents.TokenUsage, error) {
+	sent := estimateTokens(msgs)
+	warnIfSlowLocalRun(p.Name, sent, p.client.IsLocalEndpoint())
+
 	text, u, err := p.client.Complete(ctx, msgs, false)
 	if err != nil {
-		return "", agents.TokenUsage{}, fmt.Errorf("%s: %w", p.Name, err)
+		return "", agents.TokenUsage{}, fmt.Errorf("%s: %s", p.Name, describeProviderErr(ctx, err, p.Name, sent, p.client.IsLocalEndpoint()))
 	}
+	warnIfTruncated(p.Name, sent, u.PromptTokens)
 	usage := agents.TokenUsage{
 		InputTokens:  u.PromptTokens,
 		OutputTokens: u.CompletionTokens,
@@ -134,3 +141,101 @@ func (p *Invoker) complete(ctx context.Context, msgs []llm.Message) (string, age
 // abstract contract — a mismatch fails the build instead of a
 // runtime "interface not implemented" deep inside the runner.
 var _ agents.Invoker = (*Invoker)(nil)
+
+// warnOut is where provider diagnostics are written. A package var so
+// tests can capture them without touching the process's real stderr.
+var warnOut io.Writer = os.Stderr
+
+// Thresholds for the diagnostics below. All deliberately conservative:
+// a missed warning is a nuisance, a false alarm on every run trains
+// users to ignore the channel entirely.
+const (
+	// truncationFloorTokens is the smallest prompt worth checking for
+	// silent truncation. Below this, the ~4-chars-per-token estimate is
+	// too coarse to distinguish truncation from estimation error.
+	truncationFloorTokens = 2000
+
+	// slowLocalPromptTokens is where a local model's generation speed
+	// (~10 tok/s for a 7B on Apple silicon) starts to mean double-digit
+	// minutes. Cloud endpoints are exempt — they're fast enough that a
+	// large prompt is unremarkable.
+	slowLocalPromptTokens = 8000
+)
+
+// estimateTokens approximates a prompt's token count with the common
+// ~4-characters-per-token heuristic. Deliberately rough: it only needs
+// to be good enough to spot an ORDER-OF-MAGNITUDE gap between what we
+// sent and what the provider says it processed. Never used for billing
+// or budgeting, so the 20-40% error typical on code is irrelevant here.
+func estimateTokens(msgs []llm.Message) int {
+	n := 0
+	for _, m := range msgs {
+		n += len(m.Content)
+	}
+	return n / 4
+}
+
+// warnIfTruncated compares the provider's OWN reported prompt_tokens
+// against what we estimate we sent, and warns when the provider
+// processed dramatically less.
+//
+// Why this matters more than a normal error: llama.cpp-backed servers
+// (Ollama) silently DROP prompt overflow past the context window and
+// still return HTTP 200. A 2026-07 dogfood run sent a 15,147-token
+// diff to a 4096-context model, which processed 2,050 tokens and
+// returned "No issues found" — a clean-looking APPROVE on 14% of the
+// change. A reviewer that fails silent is worse than one that fails
+// loud, so this converts the silent case into a visible one.
+//
+// Requires a 2x gap before warning: the estimate is coarse, and
+// providers legitimately differ from it (tokenizer, chat-template
+// overhead). Real truncation shows up as 5-10x.
+func warnIfTruncated(name string, sent, reported int) {
+	if reported <= 0 || sent < truncationFloorTokens || reported >= sent/2 {
+		return
+	}
+	fmt.Fprintf(warnOut, "WARNING: %s processed only ~%s of the ~%s prompt tokens sent — the input was very likely TRUNCATED to fit the model's context window.\n",
+		name, humanTokens(reported), humanTokens(sent))
+	fmt.Fprintf(warnOut, "         This review saw a fraction of your diff; treat any \"no issues found\" as unverified. Raise the endpoint's context length\n")
+	fmt.Fprintf(warnOut, "         (e.g. OLLAMA_CONTEXT_LENGTH=32768 ollama serve), review a smaller change (`local-review commit <rev>`), or use a cloud agent.\n")
+}
+
+// warnIfSlowLocalRun flags a large prompt heading to a local endpoint
+// BEFORE the request goes out, so the user can cancel instead of
+// discovering the cost after a 20-minute wait (2026-07 dogfood: a
+// 17.7k-token diff against a local 7B took 20m42s, and an earlier
+// attempt burned the full 600s timeout producing nothing).
+func warnIfSlowLocalRun(name string, sent int, local bool) {
+	if !local || sent < slowLocalPromptTokens {
+		return
+	}
+	fmt.Fprintf(warnOut, "NOTE: sending ~%s prompt tokens to local endpoint %q — local models generate slowly (a 7B on Apple silicon is ~10 tok/s),\n", humanTokens(sent), name)
+	fmt.Fprintf(warnOut, "      so this can take many minutes and may hit llms.%s.timeout_seconds. For a faster pass use a cloud agent (`--only claude`)\n", name)
+	fmt.Fprintf(warnOut, "      or review a smaller change (`local-review commit <rev>`).\n")
+}
+
+// describeProviderErr turns a failed provider call into an actionable
+// message, mirroring what cli.ClassifyExit already does for CLI agents
+// (which had the hint and providers didn't — a deadline surfaced as a
+// bare "context deadline exceeded" with no guidance, 2026-07 dogfood).
+func describeProviderErr(ctx context.Context, err error, name string, sent int, local bool) string {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return "cancelled"
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		msg := fmt.Sprintf("timeout — raise llms.%s.timeout_seconds, or review a smaller change (`local-review commit <rev>`)", name)
+		if local {
+			msg += fmt.Sprintf("; a ~%s-token prompt against a local model is often slower than the timeout allows, so a cloud agent (`--only claude`) is the quicker path", humanTokens(sent))
+		}
+		return msg
+	}
+	return err.Error()
+}
+
+// humanTokens renders a token count as "17.4k" / "950" for messages.
+func humanTokens(n int) string {
+	if n >= 1000 {
+		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
+	}
+	return fmt.Sprintf("%d", n)
+}

--- a/internal/agents/provider/provider_invoker.go
+++ b/internal/agents/provider/provider_invoker.go
@@ -24,14 +24,14 @@ package provider
 
 import (
 	"context"
-	"fmt"
-	"strings"
-
 	"errors"
-	"github.com/mshykov/local-review/internal/agents"
-	"github.com/mshykov/local-review/internal/llm"
+	"fmt"
 	"io"
 	"os"
+	"strings"
+
+	"github.com/mshykov/local-review/internal/agents"
+	"github.com/mshykov/local-review/internal/llm"
 )
 
 // Invoker is the HTTP-provider implementation of agents.Invoker.
@@ -194,10 +194,14 @@ func warnIfTruncated(name string, sent, reported int) {
 	if reported <= 0 || sent < truncationFloorTokens || reported >= sent/2 {
 		return
 	}
-	fmt.Fprintf(warnOut, "WARNING: %s processed only ~%s of the ~%s prompt tokens sent — the input was very likely TRUNCATED to fit the model's context window.\n",
-		name, humanTokens(reported), humanTokens(sent))
-	fmt.Fprintf(warnOut, "         This review saw a fraction of your diff; treat any \"no issues found\" as unverified. Raise the endpoint's context length\n")
-	fmt.Fprintf(warnOut, "         (e.g. OLLAMA_CONTEXT_LENGTH=32768 ollama serve), review a smaller change (`local-review commit <rev>`), or use a cloud agent.\n")
+	// ONE write: the orchestrator runs a goroutine per agent, so a
+	// multi-call Fprintf would interleave two agents' warnings into an
+	// unreadable braid.
+	emitWarning(fmt.Sprintf(
+		"WARNING: %s processed only ~%s of the ~%s prompt tokens sent — the input was very likely TRUNCATED to fit the model's context window.\n"+
+			"         This review saw a fraction of your diff; treat any \"no issues found\" as unverified. Raise the endpoint's context length\n"+
+			"         (e.g. OLLAMA_CONTEXT_LENGTH=32768 ollama serve), review a smaller change (`local-review commit <rev>`), or use a cloud agent.\n",
+		name, humanTokens(reported), humanTokens(sent)))
 }
 
 // warnIfSlowLocalRun flags a large prompt heading to a local endpoint
@@ -209,9 +213,19 @@ func warnIfSlowLocalRun(name string, sent int, local bool) {
 	if !local || sent < slowLocalPromptTokens {
 		return
 	}
-	fmt.Fprintf(warnOut, "NOTE: sending ~%s prompt tokens to local endpoint %q — local models generate slowly (a 7B on Apple silicon is ~10 tok/s),\n", humanTokens(sent), name)
-	fmt.Fprintf(warnOut, "      so this can take many minutes and may hit llms.%s.timeout_seconds. For a faster pass use a cloud agent (`--only claude`)\n", name)
-	fmt.Fprintf(warnOut, "      or review a smaller change (`local-review commit <rev>`).\n")
+	emitWarning(fmt.Sprintf(
+		"NOTE: sending ~%s prompt tokens to local endpoint %q — local models generate slowly (a 7B on Apple silicon is ~10 tok/s),\n"+
+			"      so this can take many minutes and may hit llms.%s.timeout_seconds. For a faster pass use a cloud agent (`--only claude`)\n"+
+			"      or review a smaller change (`local-review commit <rev>`).\n",
+		humanTokens(sent), name, name))
+}
+
+// emitWarning writes a fully-composed diagnostic in a single call.
+// Provider agents run concurrently (one goroutine per agent in
+// internal/multi), so composing first and writing once keeps each
+// warning contiguous instead of interleaved with another agent's.
+func emitWarning(msg string) {
+	fmt.Fprint(warnOut, msg)
 }
 
 // describeProviderErr turns a failed provider call into an actionable

--- a/internal/agents/provider/provider_invoker_test.go
+++ b/internal/agents/provider/provider_invoker_test.go
@@ -1,14 +1,19 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/mshykov/local-review/internal/llm"
 )
 
 // fakeServer returns a chat-completions mock that echoes a fixed
@@ -190,5 +195,122 @@ func TestInvoker_TrimsTrailingWhitespace(t *testing.T) {
 	}
 	if text != "hello world" {
 		t.Errorf("want trimmed 'hello world', got %q", text)
+	}
+}
+
+// captureWarn swaps the package's diagnostic sink for the duration of
+// fn and returns what was written. Restoration is via t.Cleanup so a
+// panicking body can't leave the sink pointed at a closed buffer.
+func captureWarn(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := warnOut
+	var buf bytes.Buffer
+	warnOut = &buf
+	t.Cleanup(func() { warnOut = orig })
+	fn()
+	warnOut = orig
+	return buf.String()
+}
+
+// TestWarnIfTruncated_FiresOnSilentTruncation reproduces the 2026-07
+// dogfood: a 15,147-token diff sent to a 4096-context Ollama model,
+// which processed 2,050 tokens, returned HTTP 200, and reported "no
+// issues found". The provider never errors in this case, so this
+// warning is the only signal the review was incomplete.
+func TestWarnIfTruncated_FiresOnSilentTruncation(t *testing.T) {
+	out := captureWarn(t, func() { warnIfTruncated("ollama", 15147, 2050) })
+	if !strings.Contains(out, "TRUNCATED") {
+		t.Errorf("expected a truncation warning, got: %q", out)
+	}
+	for _, want := range []string{"~2.0k", "~15.1k", "OLLAMA_CONTEXT_LENGTH", "local-review commit"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("truncation warning missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestWarnIfTruncated_QuietWhenProviderProcessedThePrompt is the
+// false-positive guard. The ~4-chars-per-token estimate is coarse, so
+// normal variance (different tokenizer, chat-template overhead) must
+// never warn — only an order-of-magnitude gap should.
+func TestWarnIfTruncated_QuietWhenProviderProcessedThePrompt(t *testing.T) {
+	cases := map[string]struct{ sent, reported int }{
+		"exact match":            {15000, 15000},
+		"reported a bit lower":   {15000, 12000},
+		"reported higher":        {15000, 17000},
+		"prompt below the floor": {500, 100},
+		"usage not reported":     {15000, 0},
+	}
+	for name, c := range cases {
+		out := captureWarn(t, func() { warnIfTruncated("ollama", c.sent, c.reported) })
+		if out != "" {
+			t.Errorf("%s: expected silence, got: %s", name, out)
+		}
+	}
+}
+
+// TestWarnIfSlowLocalRun_OnlyForBigPromptsToLocalEndpoints pins both
+// halves of the gate: a large prompt to a LOCAL endpoint warns (a
+// 17.7k-token diff took 20m42s on a local 7B), while the same prompt to
+// a cloud endpoint — and a small prompt anywhere — stays silent.
+func TestWarnIfSlowLocalRun_OnlyForBigPromptsToLocalEndpoints(t *testing.T) {
+	out := captureWarn(t, func() { warnIfSlowLocalRun("ollama", 17700, true) })
+	if !strings.Contains(out, "~17.7k") || !strings.Contains(out, "timeout_seconds") {
+		t.Errorf("expected a slow-local note naming the size and timeout knob, got: %q", out)
+	}
+
+	if out := captureWarn(t, func() { warnIfSlowLocalRun("openai", 17700, false) }); out != "" {
+		t.Errorf("cloud endpoint must not warn, got: %s", out)
+	}
+	if out := captureWarn(t, func() { warnIfSlowLocalRun("ollama", 500, true) }); out != "" {
+		t.Errorf("small prompt must not warn, got: %s", out)
+	}
+}
+
+// TestDescribeProviderErr_TimeoutGivesActionableHint covers the gap the
+// audit found: CLI agents got ClassifyExit's guidance on a deadline
+// while providers surfaced a bare "context deadline exceeded".
+func TestDescribeProviderErr_TimeoutGivesActionableHint(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	local := describeProviderErr(ctx, context.DeadlineExceeded, "ollama", 17700, true)
+	for _, want := range []string{"timeout", "llms.ollama.timeout_seconds", "local-review commit", "--only claude"} {
+		if !strings.Contains(local, want) {
+			t.Errorf("local timeout hint missing %q, got: %s", want, local)
+		}
+	}
+	// The cloud variant keeps the generic guidance but must NOT push the
+	// user toward a cloud agent they're already using.
+	cloud := describeProviderErr(ctx, context.DeadlineExceeded, "openai", 17700, false)
+	if strings.Contains(cloud, "--only claude") {
+		t.Errorf("cloud timeout must not suggest switching to a cloud agent: %s", cloud)
+	}
+
+	cctx, ccancel := context.WithCancel(context.Background())
+	ccancel()
+	if got := describeProviderErr(cctx, context.Canceled, "ollama", 100, true); got != "cancelled" {
+		t.Errorf("cancellation should read as cancelled, got: %s", got)
+	}
+
+	// A non-context failure must pass through verbatim.
+	plain := describeProviderErr(context.Background(), errors.New("connection refused"), "ollama", 100, true)
+	if plain != "connection refused" {
+		t.Errorf("ordinary errors must pass through unchanged, got: %s", plain)
+	}
+}
+
+// TestEstimateTokens_ApproximatesPromptSize keeps the heuristic honest —
+// it only needs order-of-magnitude accuracy for the truncation check.
+func TestEstimateTokens_ApproximatesPromptSize(t *testing.T) {
+	msgs := []llm.Message{
+		{Role: "system", Content: strings.Repeat("a", 4000)},
+		{Role: "user", Content: strings.Repeat("b", 4000)},
+	}
+	if got := estimateTokens(msgs); got != 2000 {
+		t.Errorf("estimateTokens = %d, want 2000 (8000 chars / 4)", got)
+	}
+	if got := estimateTokens(nil); got != 0 {
+		t.Errorf("estimateTokens(nil) = %d, want 0", got)
 	}
 }

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -65,6 +65,13 @@ func mustCIDR(s string) *net.IPNet {
 // they would have for any non-local URL.
 //
 // Any non-local URL (public IP, FQDN) still requires a key.
+// IsLocalEndpoint reports whether this client's base_url points at a
+// local / LAN / Tailscale host — the same classification isLocalURL
+// uses for the api-key bypass. Callers use it to tailor diagnostics
+// (a 20-minute run is expected of a local 7B model and alarming from
+// a cloud endpoint).
+func (c *Client) IsLocalEndpoint() bool { return isLocalURL(c.BaseURL) }
+
 func isLocalURL(raw string) bool {
 	u, err := url.Parse(raw)
 	if err != nil {

--- a/internal/multi/validate.go
+++ b/internal/multi/validate.go
@@ -1,0 +1,151 @@
+package multi
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ValidateReport checks a merged/formatted report for internal
+// contradictions and returns one human-readable warning per problem
+// (empty when the report is self-consistent).
+//
+// Why this exists: the merge step asks an LLM to reformat findings into
+// a fixed template with a stated total, one severity section per
+// finding, and no duplicates (see merge_prompt.md's "Deduplicate
+// Findings"). A weak merge model can silently violate that contract. A
+// 2026-07 dogfood run produced a report claiming "Total findings: 5"
+// while rendering exactly two bullets — the SAME finding, listed under
+// both "Major Issues" and "Info / Notes". Nothing detected it, so a
+// malformed report shipped looking authoritative.
+//
+// These checks are mechanical (the report is our own template, not free
+// text), so they catch a bad merge from ANY model rather than
+// blacklisting particular ones. They never rewrite the report: the
+// findings may still be valuable, and silently "fixing" a count would
+// hide that the merge model is unreliable. Warn, show the report, let
+// the human judge.
+func ValidateReport(markdown string) []string {
+	if strings.TrimSpace(markdown) == "" {
+		return nil
+	}
+	sections := findingsBySection(markdown)
+
+	var warnings []string
+	if w := checkCountClaim(markdown, sections); w != "" {
+		warnings = append(warnings, w)
+	}
+	warnings = append(warnings, checkCrossSectionDuplicates(sections)...)
+	return warnings
+}
+
+// severitySections are the finding-bearing headings of the report
+// template, in the template's own order.
+var severitySections = []string{"Critical Issues", "Major Issues", "Warnings", "Info / Notes"}
+
+var (
+	// totalFindingsRE captures the summary's claimed count, e.g.
+	// "- **Total findings**: 5".
+	totalFindingsRE = regexp.MustCompile(`(?m)^\s*-\s*\*\*Total findings\*\*:\s*(\d+)`)
+
+	// findingBulletRE matches a rendered finding bullet and captures its
+	// location key: "- **`path/file.go:42`** — Title". The location is
+	// what the template mandates, and it's the only stable identity a
+	// finding has across sections.
+	findingBulletRE = regexp.MustCompile("(?m)^\\s*-\\s*\\*\\*`([^`]+)`\\*\\*")
+
+	// headingRE matches any level-2 heading, used to slice the report
+	// into sections.
+	headingRE = regexp.MustCompile(`(?m)^##\s+(.+?)\s*$`)
+)
+
+// findingsBySection slices the report at its "## " headings and returns
+// the finding location keys rendered under each severity section.
+func findingsBySection(markdown string) map[string][]string {
+	out := make(map[string][]string)
+	idx := headingRE.FindAllStringSubmatchIndex(markdown, -1)
+	for i, m := range idx {
+		name := strings.TrimSpace(markdown[m[2]:m[3]])
+		if !isSeveritySection(name) {
+			continue
+		}
+		end := len(markdown)
+		if i+1 < len(idx) {
+			end = idx[i+1][0]
+		}
+		body := markdown[m[1]:end]
+		for _, b := range findingBulletRE.FindAllStringSubmatch(body, -1) {
+			out[name] = append(out[name], strings.TrimSpace(b[1]))
+		}
+	}
+	return out
+}
+
+func isSeveritySection(name string) bool {
+	for _, s := range severitySections {
+		if strings.EqualFold(name, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkCountClaim compares the summary's "Total findings" against the
+// bullets actually rendered. A mismatch means the reader is being told
+// a number the report doesn't substantiate — in the dogfood case, "5"
+// against two rendered bullets.
+func checkCountClaim(markdown string, sections map[string][]string) string {
+	m := totalFindingsRE.FindStringSubmatch(markdown)
+	if m == nil {
+		return "" // no claim to contradict
+	}
+	claimed, err := strconv.Atoi(m[1])
+	if err != nil {
+		return ""
+	}
+	rendered := 0
+	for _, f := range sections {
+		rendered += len(f)
+	}
+	if claimed == rendered {
+		return ""
+	}
+	return fmt.Sprintf("the report claims %d finding(s) but renders %d — the merge model did not follow the report template, so treat both the count and the findings as unreliable", claimed, rendered)
+}
+
+// checkCrossSectionDuplicates reports a finding rendered under more than
+// one severity section. The template gives each finding exactly one
+// severity, and merge_prompt.md explicitly instructs deduplication, so
+// this is always a merge-model failure — and a consequential one: the
+// same issue counted as both "Major" (blocks merge) and "Info"
+// (non-blocking) makes the recommendation meaningless.
+func checkCrossSectionDuplicates(sections map[string][]string) []string {
+	placement := make(map[string]map[string]bool) // finding -> set of sections
+	for name, findings := range sections {
+		for _, f := range findings {
+			if placement[f] == nil {
+				placement[f] = make(map[string]bool)
+			}
+			placement[f][name] = true
+		}
+	}
+
+	var warnings []string
+	for f, secs := range placement {
+		if len(secs) < 2 {
+			continue
+		}
+		names := make([]string, 0, len(secs))
+		for s := range secs {
+			names = append(names, s)
+		}
+		sort.Strings(names)
+		warnings = append(warnings, fmt.Sprintf("finding %q appears under multiple severity sections (%s) — the merge model duplicated it instead of assigning one severity", f, strings.Join(names, ", ")))
+	}
+	// Deterministic order: map iteration above is randomised, and a
+	// warning list that reshuffles between runs is hard to diff.
+	sort.Strings(warnings)
+	return warnings
+}

--- a/internal/multi/validate_test.go
+++ b/internal/multi/validate_test.go
@@ -1,0 +1,147 @@
+package multi
+
+import (
+	"strings"
+	"testing"
+)
+
+// dogfoodReport is the shape of a real 2026-07 malformed report: the
+// summary claims 5 findings, but exactly one finding is rendered — under
+// BOTH "Major Issues" and "Info / Notes". Both defects must be caught.
+const dogfoodReport = "# Code Review — Single-LLM Report\n" + `
+## Summary
+- **Reviewer**: ollama (single source — no cross-model consensus)
+- **Total findings**: 5
+- **Recommendation**: REQUEST CHANGES
+
+## Critical Issues
+*(Block merge — will break production, lose data, or create security holes)*
+
+No critical issues found.
+
+## Major Issues
+*(Should fix before merge — likely bugs, perf issues, or security concerns)*
+
+- **` + "`CHANGELOG.md:26`" + `** — Dev Solidgate payments could never reach the sandbox channel.
+
+  Explanation body.
+
+  **Fix**: Some fix.
+
+## Warnings
+*(Design/maintainability problems worth addressing)*
+
+No warnings found.
+
+## Info / Notes
+*(Context the author may want to know — not blocking)*
+
+- **` + "`CHANGELOG.md:26`" + `** — Dev Solidgate payments could never reach the sandbox channel.
+
+  Explanation body.
+`
+
+func TestValidateReport_CatchesCountMismatchAndCrossSectionDuplicate(t *testing.T) {
+	problems := ValidateReport(dogfoodReport)
+	if len(problems) != 2 {
+		t.Fatalf("expected 2 problems (count mismatch + duplicate), got %d: %v", len(problems), problems)
+	}
+	joined := strings.Join(problems, "\n")
+	// "renders 2": the duplicated finding is TWO rendered bullets, which
+	// is exactly what a reader counts on screen — the fact that they are
+	// the same finding is the separate cross-section warning below.
+	if !strings.Contains(joined, "claims 5 finding(s) but renders 2") {
+		t.Errorf("count-mismatch warning missing or wrong: %v", problems)
+	}
+	if !strings.Contains(joined, "CHANGELOG.md:26") ||
+		!strings.Contains(joined, "Info / Notes") ||
+		!strings.Contains(joined, "Major Issues") {
+		t.Errorf("cross-section duplicate warning must name the finding and both sections: %v", problems)
+	}
+}
+
+// TestValidateReport_AcceptsWellFormedReport is the false-positive
+// guard: a correct report (accurate count, each finding in exactly one
+// section) must produce ZERO warnings, or the channel becomes noise
+// users learn to ignore.
+func TestValidateReport_AcceptsWellFormedReport(t *testing.T) {
+	good := "# Code Review — Consolidated Report\n" + `
+## Summary
+- **Reviewer**: claude, codex
+- **Total findings**: 3
+- **Recommendation**: REQUEST CHANGES
+
+## Critical Issues
+*(Block merge)*
+
+- **` + "`api/pay.go:12`" + `** — Secret logged in plaintext.
+
+  Body.
+
+## Major Issues
+*(Should fix before merge)*
+
+- **` + "`api/pay.go:88`" + `** — Missing error check.
+
+  Body.
+
+## Warnings
+*(Design)*
+
+No warnings found.
+
+## Info / Notes
+*(Context)*
+
+- **` + "`README.md:4`" + `** — Stale docs link.
+
+  Body.
+`
+	if problems := ValidateReport(good); len(problems) != 0 {
+		t.Errorf("well-formed report must produce no warnings, got: %v", problems)
+	}
+}
+
+// TestValidateReport_CleanReportAndEdgeCases covers the shapes that must
+// stay silent: a zero-finding report, a report with no count claim at
+// all, and empty input.
+func TestValidateReport_CleanReportAndEdgeCases(t *testing.T) {
+	clean := `## Summary
+- **Total findings**: 0
+- **Recommendation**: APPROVE
+
+## Critical Issues
+No critical issues found.
+
+## Major Issues
+No major issues found.
+`
+	if problems := ValidateReport(clean); len(problems) != 0 {
+		t.Errorf("clean 0-finding report must be silent, got: %v", problems)
+	}
+
+	noClaim := "## Major Issues\n\n- **`a.go:1`** — Something.\n"
+	if problems := ValidateReport(noClaim); len(problems) != 0 {
+		t.Errorf("report without a Total-findings claim has nothing to contradict, got: %v", problems)
+	}
+
+	for _, empty := range []string{"", "   \n\t "} {
+		if problems := ValidateReport(empty); problems != nil {
+			t.Errorf("empty report must yield nil, got: %v", problems)
+		}
+	}
+}
+
+// TestValidateReport_SameFindingTwiceInOneSectionIsNotCrossSection
+// pins the boundary: repeating a finding within ONE section is a count
+// problem (both bullets are rendered and counted), not a severity
+// contradiction — the duplicate check must not fire on it.
+func TestValidateReport_SameFindingTwiceInOneSectionIsNotCrossSection(t *testing.T) {
+	rep := "## Summary\n- **Total findings**: 2\n\n## Major Issues\n\n- **`a.go:1`** — X.\n\n- **`a.go:1`** — X again.\n"
+	problems := ValidateReport(rep)
+	for _, p := range problems {
+		if strings.Contains(p, "multiple severity sections") {
+			t.Errorf("intra-section repetition must not be reported as a cross-section duplicate: %v", problems)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Four dogfood findings from real runs, all the same shape: **the tool had the information and didn't tell the user.**

**1. Silent truncation (the dangerous one).** Ollama drops prompt overflow past the context window and still returns HTTP 200. A real run sent a 15,147-token diff to a 4096-context model, which processed **2,050 tokens** and returned *"No issues found"* — a clean-looking APPROVE on 14% of a payment-integration diff. `usage.prompt_tokens` was already captured; now it's compared against the prompt sent, warning on an order-of-magnitude gap. 2× threshold so ordinary tokenizer variance stays silent.

**2. Provider timeouts had no hint.** A deadline surfaced as bare `context deadline exceeded`, while CLI agents got `ClassifyExit`'s guidance. Providers now get equivalent hints — raise `timeout_seconds`, review a smaller change, and for *local* endpoints specifically, that a cloud agent is the quicker path — plus a clean `cancelled` on Ctrl+C.

**3. Slow local runs were invisible until too late.** A 17.7k-token diff against a local 7B took **20m42s**; an earlier attempt burned the full 600s timeout producing nothing. Large prompts to local endpoints now warn *before* the request goes out.

**4. Malformed merged reports shipped silently.** A run claimed `Total findings: 5` while rendering two bullets — the **same** finding under both "Major Issues" and "Info / Notes", despite `merge_prompt.md`'s explicit dedup instruction. `multi.ValidateReport` checks the claimed count against rendered bullets and flags cross-section duplicates. It **warns after the report, never rewrites it**: the findings may still be valuable, and silently fixing a count would hide that the merge model is unreliable. Checks are mechanical against our own template, so a bad merge from *any* model is caught — not a blacklist.

## Test plan
- [x] Unit tests for all four, using the real malformed report and real token numbers from the dogfood runs as fixtures
- [x] **False-positive guards** on every warning (well-formed report → 0 warnings; exact/near/over-reported token counts → silent; cloud endpoints and small prompts → silent). A warning channel that cries wolf gets ignored.
- [x] **Verified end-to-end** against a fake endpoint that under-reports `prompt_tokens` like a truncating llama.cpp server: both the pre-flight note and the truncation warning fire on the real code path, with correct numbers
- [x] `gofmt -s` / `go vet` / `golangci-lint` (0 issues) / `go test -race ./...` / e2e — all clean

Pre-push dogfood self-review skipped (nested-agent session — documented fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when provider token usage suggests prompt truncation.
  * Added pre-flight warnings for large prompts sent to local endpoints.
  * Added validation for merged reports to detect incorrect finding totals and duplicate findings.

* **Bug Fixes**
  * Improved timeout messages with actionable CLI guidance.
  * Clarified cancellation messages, including Ctrl+C interruptions.
  * Added informative warnings when merged reports contain formatting or integrity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->